### PR TITLE
Run application with empty args

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/Application.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/Application.java
@@ -14,8 +14,7 @@ public class Application {
     }
 
     public static void main(String[] args) {
-        String[] emptyArgs = new String[0];
-        SpringApplication.run(Application.class, emptyArgs);
+        SpringApplication.run(Application.class);
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/Application.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/Application.java
@@ -9,12 +9,13 @@ import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 @EnableAutoConfiguration(exclude=MongoAutoConfiguration.class)
 public class Application {
     
-    private Application() {
-        // private empty constructor
+    Application() {
+        // default empty constructor
     }
 
     public static void main(String[] args) {
-        SpringApplication.run(Application.class, (String[]) null);
+        String[] emptyArgs = new String[0];
+        SpringApplication.run(Application.class, emptyArgs);
     }
 
 }


### PR DESCRIPTION
Spring refuses to start if args == null, so start with an empty array instead.
Allow Spring to instantiate Application.class with a default access constructor.