### PR TITLE
Encrypt auth code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <version>5.2.1.RELEASE</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyAuthCode.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyAuthCode.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.api.testdata.model.entity;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -10,8 +11,10 @@ public class CompanyAuthCode {
     @Id
     @Field("id")
     private String id;
-    @Field("auth_code")
+    @Transient
     private String authCode;
+    @Field("auth_code")
+    private String encryptedAuthCode;
     @Field("is_active")
     private Boolean isActive;
 
@@ -29,6 +32,14 @@ public class CompanyAuthCode {
 
     public void setAuthCode(String authCode) {
         this.authCode = authCode;
+    }
+
+    public String getEncryptedAuthCode() {
+        return encryptedAuthCode;
+    }
+
+    public void setEncryptedAuthCode(String encryptedAuthCode) {
+        this.encryptedAuthCode = encryptedAuthCode;
     }
 
     public Boolean getIsActive() {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImpl.java
@@ -44,7 +44,8 @@ public class CompanyAuthCodeServiceImpl implements DataService<CompanyAuthCode> 
         CompanyAuthCode companyAuthCode = new CompanyAuthCode();
 
         companyAuthCode.setId(companyNumber);
-        companyAuthCode.setAuthCode(encrypt(authCode));
+        companyAuthCode.setAuthCode(authCode);
+        companyAuthCode.setEncryptedAuthCode(encrypt(authCode));
         companyAuthCode.setIsActive(true);
 
         try {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImpl.java
@@ -1,6 +1,12 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.apache.commons.codec.digest.MessageDigestAlgorithms;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.stereotype.Service;
 
 import com.mongodb.DuplicateKeyException;
@@ -24,14 +30,21 @@ public class CompanyAuthCodeServiceImpl implements DataService<CompanyAuthCode> 
     private RandomService randomService;
     @Autowired
     private CompanyAuthCodeRepository repository;
+    
+    private final MessageDigest sha256Digest;
+    
+    public CompanyAuthCodeServiceImpl() throws NoSuchAlgorithmException {
+        sha256Digest = MessageDigest.getInstance(MessageDigestAlgorithms.SHA_256);
+    }
 
     @Override
     public CompanyAuthCode create(String companyNumber) throws DataException {
+        final String authCode = String.valueOf(randomService.getNumber(AUTH_CODE_LENGTH));
 
         CompanyAuthCode companyAuthCode = new CompanyAuthCode();
 
         companyAuthCode.setId(companyNumber);
-        companyAuthCode.setAuthCode(String.valueOf(randomService.getNumber(AUTH_CODE_LENGTH)));
+        companyAuthCode.setAuthCode(encrypt(authCode));
         companyAuthCode.setIsActive(true);
 
         try {
@@ -43,6 +56,11 @@ public class CompanyAuthCodeServiceImpl implements DataService<CompanyAuthCode> 
 
             throw new DataException(ErrorMessageConstants.FAILED_TO_INSERT);
         }
+    }
+
+    private String encrypt(final String authCode) {
+        byte[] password = sha256Digest.digest(authCode.getBytes(StandardCharsets.UTF_8));
+        return BCrypt.hashpw(password, BCrypt.gensalt());
     }
 
     @Override

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImplTest.java
@@ -63,12 +63,13 @@ class CompanyAuthCodeServiceImplTest {
         CompanyAuthCode authCode = authCodeCaptor.getValue();
 
         assertNotNull(authCode);
+        assertEquals(String.valueOf(COMPANY_AUTH_CODE), authCode.getAuthCode());
         assertTrue(authCode.getIsActive());
         assertEquals(COMPANY_NUMBER, authCode.getId());
 
         // Ideally we would use the following line to verify the encryption:
         //
-        // assertTrue(BCrypt.checkpw(password, authCode.getAuthCode()));
+        // assertTrue(BCrypt.checkpw(password, authCode.getEncryptedAuthCode()));
         //
         // However, the latest version of Spring Security at the time of developing this
         // (5.2.1.RELEASE) does not provide a checkpw method accepting a byte[] as a
@@ -76,7 +77,7 @@ class CompanyAuthCodeServiceImplTest {
         // That is why we need to verify it ourselves by just hashing the authcode using
         // the same salt (present in the auth code) and then comparing the hashed
         // values.
-        assertEquals(authCode.getAuthCode(), BCrypt.hashpw(password, authCode.getAuthCode()));
+        assertEquals(authCode.getEncryptedAuthCode(), BCrypt.hashpw(password, authCode.getEncryptedAuthCode()));
     }
 
     @Test


### PR DESCRIPTION
Store auth code encrypted using BCrypt. 
The endpoint will still return the auth code number.

We need the latest version (5.2.1) of Spring Security Crypto since it is the one which allows encryption of a `byte[]` not containing UTF-8 characters (it's a sha-256 of the auth code). This is why we need to override the managed version from the parent pom (currently CH parent pom uses 5.1.4)

Resolves FA-173