### PR TITLE
Use Optional for non-required request body

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -36,7 +36,7 @@ public class TestDataController {
     private TestDataService testDataService;
 
     @PostMapping("/company")
-    public ResponseEntity<CompanyData> create(@Valid @RequestBody Optional<CompanySpec> request) throws Exception {
+    public ResponseEntity<CompanyData> create(@Valid @RequestBody Optional<CompanySpec> request) throws DataException {
 
         CompanySpec spec = request.orElse(new CompanySpec());
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.api.testdata.controller;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.validation.Valid;
 
@@ -19,8 +20,8 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.testdata.Application;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
-import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanyData;
+import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.service.TestDataService;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -35,16 +36,12 @@ public class TestDataController {
     private TestDataService testDataService;
 
     @PostMapping("/company")
-    public ResponseEntity<CompanyData> create(@Valid @RequestBody(required = false) CompanySpec request)
-            throws DataException {
+    public ResponseEntity<CompanyData> create(@Valid @RequestBody Optional<CompanySpec> request) throws Exception {
 
-        CompanySpec spec = request;
-        if (spec == null) {
-            spec = new CompanySpec();
-        }
-        
+        CompanySpec spec = request.orElse(new CompanySpec());
+
         CompanyData createdCompany = testDataService.createCompanyData(spec);
-        
+
         Map<String, Object> data = new HashMap<>();
         data.put("company number", createdCompany.getCompanyNumber());
         data.put("jurisdiction", spec.getJurisdiction());

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -44,7 +46,7 @@ class TestDataControllerTest {
         CompanyData company = new CompanyData("12345678", "123456");
 
         when(this.testDataService.createCompanyData(request)).thenReturn(company);
-        ResponseEntity<CompanyData> response = this.testDataController.create(request);
+        ResponseEntity<CompanyData> response = this.testDataController.create(Optional.ofNullable(request));
 
         assertEquals(company, response.getBody());
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
@@ -56,7 +58,7 @@ class TestDataControllerTest {
         CompanyData company = new CompanyData("12345678", "123456");
 
         when(this.testDataService.createCompanyData(any())).thenReturn(company);
-        ResponseEntity<CompanyData> response = this.testDataController.create(request);
+        ResponseEntity<CompanyData> response = this.testDataController.create(Optional.ofNullable(request));
 
         assertEquals(company, response.getBody());
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
@@ -73,7 +75,7 @@ class TestDataControllerTest {
         CompanyData company = new CompanyData("12345678", "123456");
 
         when(this.testDataService.createCompanyData(request)).thenReturn(company);
-        ResponseEntity<CompanyData> response = this.testDataController.create(request);
+        ResponseEntity<CompanyData> response = this.testDataController.create(Optional.ofNullable(request));
 
         assertEquals(company, response.getBody());
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
@@ -90,7 +92,7 @@ class TestDataControllerTest {
         when(this.testDataService.createCompanyData(request)).thenThrow(exception);
 
         assertThrows(DataException.class, () -> {
-            this.testDataController.create(request);
+            this.testDataController.create(Optional.ofNullable(request));
         }, exception.getMessage());
     }
 


### PR DESCRIPTION
Use an `Optional` object for non-required `CompanySpec` request body to make the code less verbose