### PR TITLE
Require and validate auth code for delete request

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/exception/InvalidAuthCodeException.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/exception/InvalidAuthCodeException.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.api.testdata.exception;
+
+public class InvalidAuthCodeException extends Exception {
+
+    private static final long serialVersionUID = -1089294951310096902L;
+
+    private final String companyNumber;
+
+    public InvalidAuthCodeException(String companyNumber) {
+        this.companyNumber = companyNumber;
+    }
+
+    public String getCompanyNumber() {
+        return companyNumber;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/DeleteCompanyRequest.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/DeleteCompanyRequest.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.api.testdata.model.rest;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Body for a delete company request
+ *
+ */
+public class DeleteCompanyRequest {
+
+    @JsonProperty("auth_code")
+    @NotNull(message="company auth_code required")
+    private String authCode;
+
+    public String getAuthCode() {
+        return authCode;
+    }
+
+    public void setAuthCode(String authCode) {
+        this.authCode = authCode;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
@@ -15,5 +15,12 @@ public interface TestDataService {
      */
     CompanyData createCompanyData(CompanySpec companySpec) throws DataException;
 
-    void deleteCompanyData(String companyId) throws NoDataFoundException, DataException;
+    /**
+     * Delete all data for company {@code companyNumber}
+     * 
+     * @param companyNumber The company number to be deleted
+     * @throws NoDataFoundException
+     * @throws DataException
+     */
+    void deleteCompanyData(String companyNumber) throws NoDataFoundException, DataException;
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscStatement;
 import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanyData;
+import uk.gov.companieshouse.api.testdata.service.CompanyAuthCodeService;
 import uk.gov.companieshouse.api.testdata.service.DataService;
 import uk.gov.companieshouse.api.testdata.service.OfficerAppointmentService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
@@ -31,7 +32,7 @@ public class TestDataServiceImpl implements TestDataService {
     @Autowired
     private OfficerAppointmentService officerAppointmentService;
     @Autowired
-    private DataService<CompanyAuthCode> companyAuthCodeService;
+    private CompanyAuthCodeService companyAuthCodeService;
     @Autowired
     private DataService<Appointment> appointmentService;
     @Autowired

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
@@ -25,6 +25,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanyData;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.model.rest.Jurisdiction;
+import uk.gov.companieshouse.api.testdata.service.CompanyAuthCodeService;
 import uk.gov.companieshouse.api.testdata.service.DataService;
 import uk.gov.companieshouse.api.testdata.service.OfficerAppointmentService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
@@ -45,7 +46,7 @@ class TestDataServiceImplTest {
     @Mock
     private OfficerAppointmentService officerListService;
     @Mock
-    private DataService<CompanyAuthCode> companyAuthCodeService;
+    private CompanyAuthCodeService companyAuthCodeService;
     @Mock
     private DataService<Appointment> appointmentService;
     @Mock


### PR DESCRIPTION
Require and validate auth code for delete request:
- 400 and `invalid request` message when missing or invalid JSON body request
- 400 and `company auth_code required` message when JSON body request does not contain auth code
- 401 and `incorrect company auth_code` when supplied auth code does not match the company one

Resolves FA-219, FA-221 & FA-268