### PR TITLE
Roll back creation of data on exception

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/repository/AppointmentsRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/repository/AppointmentsRepository.java
@@ -1,10 +1,13 @@
 package uk.gov.companieshouse.api.testdata.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.repository.NoRepositoryBean;
+
 import uk.gov.companieshouse.api.testdata.model.entity.Appointment;
 
 @NoRepositoryBean
 public interface AppointmentsRepository extends MongoRepository<Appointment, String> {
-    Appointment findByCompanyNumber(String companyNumber);
+    Optional<Appointment> findByCompanyNumber(String companyNumber);
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/repository/CompanyProfileRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/repository/CompanyProfileRepository.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.api.testdata.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 
@@ -8,5 +10,5 @@ import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
 @NoRepositoryBean
 public interface CompanyProfileRepository extends MongoRepository<CompanyProfile, String> {
 
-    CompanyProfile findByCompanyNumber(String companyNumber);
+    Optional<CompanyProfile> findByCompanyNumber(String companyNumber);
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/repository/CompanyPscStatementRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/repository/CompanyPscStatementRepository.java
@@ -1,10 +1,13 @@
 package uk.gov.companieshouse.api.testdata.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.repository.NoRepositoryBean;
+
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscStatement;
 
 @NoRepositoryBean
 public interface CompanyPscStatementRepository extends MongoRepository<CompanyPscStatement, String> {
-    CompanyPscStatement findByCompanyNumber(String companyNumber);
+    Optional<CompanyPscStatement> findByCompanyNumber(String companyNumber);
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/repository/FilingHistoryRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/repository/FilingHistoryRepository.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.api.testdata.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 
@@ -8,5 +10,5 @@ import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
 @NoRepositoryBean
 public interface FilingHistoryRepository extends MongoRepository<FilingHistory, String> {
 
-    FilingHistory findByCompanyNumber(String companyId);
+    Optional<FilingHistory> findByCompanyNumber(String companyId);
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/DataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/DataService.java
@@ -1,11 +1,17 @@
 package uk.gov.companieshouse.api.testdata.service;
 
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 
 public interface DataService<T> {
     T create(CompanySpec companySpec) throws DataException;
 
-    void delete(String companyNumber) throws NoDataFoundException, DataException;
+    /**
+     * Delete information for the given {@code companyNymber}
+     * 
+     * @param companyNumber
+     * @return True if the data could be found and deleted. False if no data found
+     * @throws DataException When any error occurs
+     */
+    boolean delete(String companyNumber) throws DataException;
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.api.testdata.service;
 
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanyData;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 
@@ -19,8 +18,7 @@ public interface TestDataService {
      * Delete all data for company {@code companyNumber}
      * 
      * @param companyNumber The company number to be deleted
-     * @throws NoDataFoundException
      * @throws DataException
      */
-    void deleteCompanyData(String companyNumber) throws NoDataFoundException, DataException;
+    void deleteCompanyData(String companyNumber) throws DataException;
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -12,7 +13,6 @@ import org.springframework.stereotype.Service;
 import com.mongodb.MongoException;
 
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.Appointment;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
 import uk.gov.companieshouse.api.testdata.model.entity.OfficerAppointment;
@@ -32,8 +32,6 @@ public class AppointmentsServiceImpl implements DataService<Appointment> {
     private static final int ID_LENGTH = 10;
     private static final int INTERNAL_ID_LENGTH = 9;
     private static final String INTERNAL_ID_PREFIX = "8";
-    private static final String APPOINTMENT_DATA_NOT_FOUND = "appointment data not found";
-    private static final String OFFICER_APPOINTMENT_DATA_NOT_FOUND = "officer appointment data not found";
     private static final String COMPANY_LINK = "/company/";
     private static final String OFFICERS_LINK = "/officers/";
     private static final String OCCUPATION = "Director";
@@ -109,24 +107,24 @@ public class AppointmentsServiceImpl implements DataService<Appointment> {
     }
 
     @Override
-    public void delete(String companyNumber) throws NoDataFoundException, DataException {
+    public boolean delete(String companyNumber) throws DataException {
         Appointment existingAppointment = appointmentsRepository.findByCompanyNumber(companyNumber);
 
         if (existingAppointment == null) {
-            throw new NoDataFoundException(APPOINTMENT_DATA_NOT_FOUND);
+            return false;
         }
         String officerId = existingAppointment.getOfficerId();
 
-        this.deleteOfficerAppointment(officerId);
+        Optional<OfficerAppointment> officerApt = officerRepository.findById(officerId);
 
         try {
+            officerApt.ifPresent(officerRepository::delete);
             appointmentsRepository.delete(existingAppointment);
+            return true;
         } catch (MongoException e) {
             throw new DataException("Failed to delete appointment", e);
         }
     }
-
-
 
     private void createOfficerAppointment(CompanySpec spec, String officerId, String appointmentId)
             throws DataException {
@@ -163,17 +161,6 @@ public class AppointmentsServiceImpl implements DataService<Appointment> {
             throw new DataException("Failed to save officer appointment", e);
         }
 
-    }
-
-    private void deleteOfficerAppointment(String officerId) throws NoDataFoundException, DataException {
-        OfficerAppointment existingAppointment = officerRepository.findById(officerId)
-                .orElseThrow(() -> new NoDataFoundException(OFFICER_APPOINTMENT_DATA_NOT_FOUND));
-
-        try {
-            officerRepository.delete(existingAppointment);
-        } catch (MongoException e) {
-            throw new DataException("Failed to delete officer appointment", e);
-        }
     }
 
     private List<OfficerAppointmentItem> createOfficerAppointmentItems(CompanySpec companySpec, String appointmentId,

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
@@ -108,19 +108,16 @@ public class AppointmentsServiceImpl implements DataService<Appointment> {
 
     @Override
     public boolean delete(String companyNumber) throws DataException {
-        Appointment existingAppointment = appointmentsRepository.findByCompanyNumber(companyNumber);
-
-        if (existingAppointment == null) {
-            return false;
-        }
-        String officerId = existingAppointment.getOfficerId();
-
-        Optional<OfficerAppointment> officerApt = officerRepository.findById(officerId);
-
         try {
-            officerApt.ifPresent(officerRepository::delete);
-            appointmentsRepository.delete(existingAppointment);
-            return true;
+            Optional<Appointment> existingAppointment = appointmentsRepository.findByCompanyNumber(companyNumber);
+
+            if (existingAppointment.isPresent()) {
+                String officerId = existingAppointment.get().getOfficerId();
+                officerRepository.findById(officerId).ifPresent(officerRepository::delete);
+                appointmentsRepository.delete(existingAppointment.get());
+                return true;
+            }
+            return false;
         } catch (MongoException e) {
             throw new DataException("Failed to delete appointment", e);
         }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImpl.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.api.testdata.service.impl;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
 
 import org.apache.commons.codec.digest.MessageDigestAlgorithms;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,13 +64,13 @@ public class CompanyAuthCodeServiceImpl implements CompanyAuthCodeService {
     }
 
     @Override
-    public void delete(String companyId) throws NoDataFoundException, DataException {
+    public boolean delete(String companyId) throws DataException {
 
-        CompanyAuthCode existingCompanyAuthCode = repository.findById(companyId)
-                .orElseThrow(() -> new NoDataFoundException(COMPANY_AUTH_DATA_NOT_FOUND));
+        Optional<CompanyAuthCode> existingCompanyAuthCode = repository.findById(companyId);
 
         try {
-            repository.delete(existingCompanyAuthCode);
+            existingCompanyAuthCode.ifPresent(repository::delete);
+            return existingCompanyAuthCode.isPresent();
         } catch (MongoException e) {
             throw new DataException("Failed to delete company auth code", e);
         }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyMetricsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyMetricsServiceImpl.java
@@ -1,12 +1,13 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
+import java.util.Optional;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.mongodb.MongoException;
 
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyMetrics;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.repository.CompanyMetricsRepository;
@@ -15,8 +16,6 @@ import uk.gov.companieshouse.api.testdata.service.RandomService;
 
 @Service
 public class CompanyMetricsServiceImpl implements DataService<CompanyMetrics> {
-
-    private static final String METRIC_DATA_NOT_FOUND = "company metrics data not found";
 
     @Autowired
     private CompanyMetricsRepository repository;
@@ -39,12 +38,12 @@ public class CompanyMetricsServiceImpl implements DataService<CompanyMetrics> {
     }
 
     @Override
-    public void delete(String companyNumber) throws NoDataFoundException, DataException {
-        CompanyMetrics existingMetric = repository.findById(companyNumber)
-                .orElseThrow(() -> new NoDataFoundException(METRIC_DATA_NOT_FOUND));
+    public boolean delete(String companyNumber) throws DataException {
+        Optional<CompanyMetrics> existingMetric = repository.findById(companyNumber);
 
         try {
-            repository.delete(existingMetric);
+            existingMetric.ifPresent(repository::delete);
+            return existingMetric.isPresent();
         } catch (MongoException e) {
             throw new DataException("Failed to delete company metrics", e);
         }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Collections;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -90,20 +91,13 @@ public class CompanyProfileServiceImpl implements DataService<CompanyProfile> {
 
     @Override
     public boolean delete(String companyId) throws DataException {
-
-        CompanyProfile existingCompany = repository.findByCompanyNumber(companyId);
-
-        if (existingCompany == null) {
-            return false;
-        }
-
         try {
-            repository.delete(existingCompany);
-            return true;
+            Optional<CompanyProfile> profile = repository.findByCompanyNumber(companyId);
+            profile.ifPresent(repository::delete);
+            return profile.isPresent();
         } catch (MongoException e) {
             throw new DataException("Failed to delete company profile", e);
         }
-
     }
 
     private Links createLinks(String companyNumber) {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Service;
 import com.mongodb.MongoException;
 
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
@@ -21,11 +20,9 @@ import uk.gov.companieshouse.api.testdata.service.AddressService;
 import uk.gov.companieshouse.api.testdata.service.DataService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 
-
 @Service
 public class CompanyProfileServiceImpl implements DataService<CompanyProfile> {
 
-    private static final String COMPANY_PROFILE_DATA_NOT_FOUND = "company profile data not found";
     private static final String LINK_STEM = "/company/";
 
     @Autowired
@@ -92,16 +89,17 @@ public class CompanyProfileServiceImpl implements DataService<CompanyProfile> {
     }
 
     @Override
-    public void delete(String companyId) throws NoDataFoundException, DataException {
+    public boolean delete(String companyId) throws DataException {
 
         CompanyProfile existingCompany = repository.findByCompanyNumber(companyId);
 
         if (existingCompany == null) {
-            throw new NoDataFoundException(COMPANY_PROFILE_DATA_NOT_FOUND);
+            return false;
         }
 
         try {
             repository.delete(existingCompany);
+            return true;
         } catch (MongoException e) {
             throw new DataException("Failed to delete company profile", e);
         }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.api.testdata.service.impl;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -66,15 +67,10 @@ public class CompanyPscStatementServiceImpl implements DataService<CompanyPscSta
 
     @Override
     public boolean delete(String companyNumber) throws DataException {
-        CompanyPscStatement existingStatement = repository.findByCompanyNumber(companyNumber);
-
-        if (existingStatement == null) {
-            return false;
-        }
-
         try {
-            repository.delete(existingStatement);
-            return true;
+            Optional<CompanyPscStatement> existingStatement = repository.findByCompanyNumber(companyNumber);
+            existingStatement.ifPresent(repository::delete);
+            return existingStatement.isPresent();
         } catch (MongoException e) {
             throw new DataException("Failed to delete PSC statement", e);
         }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 import com.mongodb.MongoException;
 
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscStatement;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
@@ -21,7 +20,6 @@ import uk.gov.companieshouse.api.testdata.service.RandomService;
 @Service
 public class CompanyPscStatementServiceImpl implements DataService<CompanyPscStatement> {
 
-    private static final String STATEMENT_DATA_NOT_FOUND = "statement data not found";
     private static final int ID_LENGTH = 10;
     private static final int SALT_LENGTH = 8;
 
@@ -67,15 +65,16 @@ public class CompanyPscStatementServiceImpl implements DataService<CompanyPscSta
     }
 
     @Override
-    public void delete(String companyNumber) throws NoDataFoundException, DataException {
+    public boolean delete(String companyNumber) throws DataException {
         CompanyPscStatement existingStatement = repository.findByCompanyNumber(companyNumber);
 
         if (existingStatement == null) {
-            throw new NoDataFoundException(STATEMENT_DATA_NOT_FOUND);
+            return false;
         }
 
         try {
             repository.delete(existingStatement);
+            return true;
         } catch (MongoException e) {
             throw new DataException("Failed to delete PSC statement", e);
         }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImpl.java
@@ -6,6 +6,7 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -78,16 +79,11 @@ public class FilingHistoryServiceImpl implements DataService<FilingHistory> {
 
     @Override
     public boolean delete(String companyId) throws DataException {
-
-        FilingHistory filingHistoryToDelete = filingHistoryRepository.findByCompanyNumber(companyId);
-
-        if (filingHistoryToDelete == null) {
-            return false;
-        }
-
         try {
-            filingHistoryRepository.delete(filingHistoryToDelete);
-            return true;
+            Optional<FilingHistory> filingHistory = filingHistoryRepository.findByCompanyNumber(companyId);
+
+            filingHistory.ifPresent(filingHistoryRepository::delete);
+            return filingHistory.isPresent();
         } catch (MongoException e) {
             throw new DataException("Failed to delete filing history", e);
         }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImpl.java
@@ -14,7 +14,6 @@ import com.mongodb.MongoException;
 
 import uk.gov.companieshouse.api.testdata.exception.BarcodeServiceException;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.AssociatedFiling;
 import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
@@ -30,8 +29,7 @@ public class FilingHistoryServiceImpl implements DataService<FilingHistory> {
     private static final int SALT_LENGTH = 8;
     private static final int ENTITY_ID_LENGTH = 9;
     private static final String ENTITY_ID_PREFIX = "8";
-    private static final String FILING_HISTORY_DATA_NOT_FOUND = "filing history data not found";
-
+ 
     @Autowired
     private FilingHistoryRepository filingHistoryRepository;
     @Autowired
@@ -79,16 +77,17 @@ public class FilingHistoryServiceImpl implements DataService<FilingHistory> {
     }
 
     @Override
-    public void delete(String companyId) throws NoDataFoundException, DataException {
+    public boolean delete(String companyId) throws DataException {
 
         FilingHistory filingHistoryToDelete = filingHistoryRepository.findByCompanyNumber(companyId);
 
         if (filingHistoryToDelete == null) {
-            throw new NoDataFoundException(FILING_HISTORY_DATA_NOT_FOUND);
+            return false;
         }
 
         try {
             filingHistoryRepository.delete(filingHistoryToDelete);
+            return true;
         } catch (MongoException e) {
             throw new DataException("Failed to delete filing history", e);
         }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -1,25 +1,32 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import uk.gov.companieshouse.api.testdata.Application;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.Appointment;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyAuthCode;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyMetrics;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscStatement;
 import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
-import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanyData;
+import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.service.CompanyAuthCodeService;
 import uk.gov.companieshouse.api.testdata.service.DataService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 import uk.gov.companieshouse.api.testdata.service.TestDataService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Service
 public class TestDataServiceImpl implements TestDataService {
+    private static final Logger LOG = LoggerFactory.getLogger(Application.APPLICATION_NAME);
 
     private static final int COMPANY_NUMBER_LENGTH = 8;
 
@@ -48,25 +55,70 @@ public class TestDataServiceImpl implements TestDataService {
                 randomService.getNumber(COMPANY_NUMBER_LENGTH - companyNumberPrefix.length());
 
         spec.setCompanyNumber(companyNumber);
-        
-        this.companyProfileService.create(spec);
-        this.filingHistoryService.create(spec);
-        this.appointmentService.create(spec);
-        CompanyAuthCode authCode = this.companyAuthCodeService.create(spec);
-        this.companyMetricsService.create(spec);
-        this.companyPscStatementService.create(spec);
 
-        return new CompanyData(companyNumber, authCode.getAuthCode());
+        try {
+            this.companyProfileService.create(spec);
+            this.filingHistoryService.create(spec);
+            this.appointmentService.create(spec);
+            CompanyAuthCode authCode = this.companyAuthCodeService.create(spec);
+            this.companyMetricsService.create(spec);
+            this.companyPscStatementService.create(spec);
+
+            return new CompanyData(companyNumber, authCode.getAuthCode());
+        } catch (DataException ex) {
+            Map<String, Object> data = new HashMap<>();
+            data.put("company number", companyNumber);
+            LOG.error("Rolling back creation of company", data);
+            // Rollback all successful insertions
+            deleteCompanyData(spec.getCompanyNumber());
+            throw ex;
+        }
     }
 
     @Override
-    public void deleteCompanyData(String companyId) throws NoDataFoundException, DataException {
+    public void deleteCompanyData(String companyId) throws DataException {
+        Optional<DataException> throwEx = Optional.empty();
+        try {
+            this.companyProfileService.delete(companyId);
+        } catch (DataException de) {
+            throwEx = addOrSuppressException(throwEx, de);
+        }
+        try {
+            this.filingHistoryService.delete(companyId);
+        } catch (DataException de) {
+            throwEx = addOrSuppressException(throwEx, de);
+        }
+        try {
+            this.companyAuthCodeService.delete(companyId);
+        } catch (DataException de) {
+            throwEx = addOrSuppressException(throwEx, de);
+        }
+        try {
+            this.appointmentService.delete(companyId);
+        } catch (DataException de) {
+            throwEx = addOrSuppressException(throwEx, de);
+        }
+        try {
+            this.companyPscStatementService.delete(companyId);
+        } catch (DataException de) {
+            throwEx = addOrSuppressException(throwEx, de);
+        }
+        try {
+            this.companyMetricsService.delete(companyId);
+        } catch (DataException de) {
+            throwEx = addOrSuppressException(throwEx, de);
+        }
 
-        this.companyProfileService.delete(companyId);
-        this.filingHistoryService.delete(companyId);
-        this.companyAuthCodeService.delete(companyId);
-        this.appointmentService.delete(companyId);
-        this.companyPscStatementService.delete(companyId);
-        this.companyMetricsService.delete(companyId);
+        if (throwEx.isPresent()) {
+            throw throwEx.get();
+        }
+
+    }
+    
+    private Optional<DataException> addOrSuppressException(Optional<DataException> throwEx, DataException suppressed) {
+        if (throwEx.isPresent()) {
+            throwEx.get().addSuppressed(suppressed);
+        }
+        return Optional.of(throwEx.orElse(suppressed));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
@@ -121,7 +121,7 @@ class TestDataControllerTest {
     }
 
     @Test
-    void deleteNoDataFound() throws Exception {
+    void deleteDataException() throws Exception {
         final String companyNumber = "123456";
         final DeleteCompanyRequest request = new DeleteCompanyRequest();
         request.setAuthCode("222222");
@@ -129,10 +129,10 @@ class TestDataControllerTest {
 
         when(companyAuthCodeService.verifyAuthCode(companyNumber, request.getAuthCode())).thenReturn(validAuthCode);
 
-        NoDataFoundException ex = new NoDataFoundException("Error message");
+        DataException ex = new DataException("Error message");
         doThrow(ex).when(this.testDataService).deleteCompanyData(companyNumber);
 
-        NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () -> {
+        DataException thrown = assertThrows(DataException.class, () -> {
             this.testDataController.delete(companyNumber, request);
         });
         assertEquals(ex, thrown);

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImplTest.java
@@ -211,7 +211,7 @@ class AppointmentsServiceImplTest {
         OfficerAppointment officerAppointment = new OfficerAppointment();
         final String officerId = "TEST";
         apt.setOfficerId(officerId);
-        when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(apt);
+        when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(apt));
         when(officerRepository.findById(officerId)).thenReturn(Optional.of(officerAppointment));
 
         assertTrue(this.appointmentsService.delete(COMPANY_NUMBER));
@@ -221,8 +221,7 @@ class AppointmentsServiceImplTest {
 
     @Test
     void deleteNoAppointmentDataException() throws DataException {
-        Appointment apt = null;
-        when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(apt);
+        when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.empty());
         
         assertFalse(this.appointmentsService.delete(COMPANY_NUMBER));
         verify(officerRepository, never()).delete(any());
@@ -234,7 +233,7 @@ class AppointmentsServiceImplTest {
         Appointment apt = new Appointment();
         final String officerId = "TEST";
         apt.setOfficerId(officerId);
-        when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(apt);
+        when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(apt));
         when(officerRepository.findById(officerId)).thenReturn(Optional.empty());
 
         assertTrue(this.appointmentsService.delete(COMPANY_NUMBER));
@@ -248,7 +247,7 @@ class AppointmentsServiceImplTest {
         OfficerAppointment officerAppointment = new OfficerAppointment();
         final String officerId = "TEST";
         apt.setOfficerId(officerId);
-        when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(apt);
+        when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(apt));
         when(officerRepository.findById(officerId)).thenReturn(Optional.of(officerAppointment));
         doThrow(MongoException.class).when(appointmentsRepository).delete(apt);
         
@@ -264,7 +263,7 @@ class AppointmentsServiceImplTest {
         OfficerAppointment officerAppointment = new OfficerAppointment();
         final String officerId = "TEST";
         apt.setOfficerId(officerId);
-        when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(apt);
+        when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(apt));
         when(officerRepository.findById(officerId)).thenReturn(Optional.of(officerAppointment));
         doThrow(MongoException.class).when(officerRepository).delete(officerAppointment);
 

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImplTest.java
@@ -1,14 +1,18 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,7 +24,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.mongodb.MongoException;
 
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.Address;
 import uk.gov.companieshouse.api.testdata.model.entity.Appointment;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
@@ -31,8 +34,6 @@ import uk.gov.companieshouse.api.testdata.repository.AppointmentsRepository;
 import uk.gov.companieshouse.api.testdata.repository.OfficerRepository;
 import uk.gov.companieshouse.api.testdata.service.AddressService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
-
-import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 class AppointmentsServiceImplTest {
@@ -205,7 +206,7 @@ class AppointmentsServiceImplTest {
     }
     
     @Test
-    void delete() throws Exception {
+    void delete() throws DataException {
         Appointment apt = new Appointment();
         OfficerAppointment officerAppointment = new OfficerAppointment();
         final String officerId = "TEST";
@@ -213,33 +214,32 @@ class AppointmentsServiceImplTest {
         when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(apt);
         when(officerRepository.findById(officerId)).thenReturn(Optional.of(officerAppointment));
 
-        this.appointmentsService.delete(COMPANY_NUMBER);
+        assertTrue(this.appointmentsService.delete(COMPANY_NUMBER));
+        verify(officerRepository).delete(officerAppointment);
         verify(appointmentsRepository).delete(apt);
     }
 
     @Test
-    void deleteNoAppointmentDataException() {
+    void deleteNoAppointmentDataException() throws DataException {
         Appointment apt = null;
         when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(apt);
         
-        NoDataFoundException exception = assertThrows(NoDataFoundException.class, () ->
-                this.appointmentsService.delete(COMPANY_NUMBER)
-        );
-        assertEquals("appointment data not found", exception.getMessage());
+        assertFalse(this.appointmentsService.delete(COMPANY_NUMBER));
+        verify(officerRepository, never()).delete(any());
+        verify(appointmentsRepository, never()).delete(any());
     }
 
     @Test
-    void deleteNoOfficerDataException() {
+    void deleteNoOfficerDataException() throws DataException {
         Appointment apt = new Appointment();
         final String officerId = "TEST";
         apt.setOfficerId(officerId);
         when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(apt);
         when(officerRepository.findById(officerId)).thenReturn(Optional.empty());
 
-        NoDataFoundException exception = assertThrows(NoDataFoundException.class, () ->
-                this.appointmentsService.delete(COMPANY_NUMBER)
-        );
-        assertEquals("officer appointment data not found", exception.getMessage());
+        assertTrue(this.appointmentsService.delete(COMPANY_NUMBER));
+        verify(officerRepository, never()).delete(any());
+        verify(appointmentsRepository).delete(apt);
     }
 
     @Test
@@ -271,7 +271,7 @@ class AppointmentsServiceImplTest {
         DataException exception = assertThrows(DataException.class, () ->
                 this.appointmentsService.delete(COMPANY_NUMBER)
         );
-        assertEquals("Failed to delete officer appointment", exception.getMessage());
+        assertEquals("Failed to delete appointment", exception.getMessage());
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -142,23 +143,20 @@ class CompanyAuthCodeServiceImplTest {
     }
     
     @Test
-    void delete() throws Exception {
+    void delete() throws DataException {
         CompanyAuthCode authCode = new CompanyAuthCode();
         when(repository.findById(COMPANY_NUMBER))
                 .thenReturn(Optional.of(authCode));
         
-        this.companyAuthCodeServiceImpl.delete(COMPANY_NUMBER);
-
+        assertTrue(this.companyAuthCodeServiceImpl.delete(COMPANY_NUMBER));
         verify(repository).delete(authCode);
     }
 
     @Test
-    void deleteNoDataException() {
+    void deleteNoDataException() throws DataException {
         when(repository.findById(COMPANY_NUMBER)).thenReturn(Optional.empty());
-        NoDataFoundException exception = assertThrows(NoDataFoundException.class, () ->
-            this.companyAuthCodeServiceImpl.delete(COMPANY_NUMBER)
-        );
-        assertEquals("company auth data not found", exception.getMessage());
+        assertFalse(this.companyAuthCodeServiceImpl.delete(COMPANY_NUMBER));
+        verify(repository, never()).delete(any());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyMetricsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyMetricsServiceImplTest.java
@@ -1,12 +1,17 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,13 +23,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.mongodb.MongoException;
 
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyMetrics;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.repository.CompanyMetricsRepository;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
-
-import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 class CompanyMetricsServiceImplTest {
@@ -96,23 +98,22 @@ class CompanyMetricsServiceImplTest {
     }
 
     @Test
-    void delete() throws NoDataFoundException, DataException {
+    void delete() throws DataException {
         CompanyMetrics metrics = new CompanyMetrics();
         Optional<CompanyMetrics> optionalMetric = Optional.of(metrics);
         when(repository.findById(COMPANY_NUMBER)).thenReturn(optionalMetric);
 
-        this.metricsService.delete(COMPANY_NUMBER);
+        assertTrue(this.metricsService.delete(COMPANY_NUMBER));
         verify(repository).delete(metrics);
     }
 
     @Test
-    void deleteNoDataException() {
+    void deleteNoDataException() throws DataException {
         Optional<CompanyMetrics> optionalMetric = Optional.empty();
         when(repository.findById(COMPANY_NUMBER)).thenReturn(optionalMetric);
-        NoDataFoundException exception = assertThrows(NoDataFoundException.class, () ->
-                this.metricsService.delete(COMPANY_NUMBER)
-        );
-        assertEquals("company metrics data not found", exception.getMessage());
+        
+        assertFalse(this.metricsService.delete(COMPANY_NUMBER));
+        verify(repository, never()).delete(any());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -1,11 +1,13 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -19,7 +21,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.mongodb.MongoException;
 
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.Address;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
@@ -184,26 +185,23 @@ class CompanyProfileServiceImplTest {
     }
 
     @Test
-    void delete() throws Exception {
+    void delete() throws DataException {
         CompanyProfile companyProfile = new CompanyProfile();
         when(repository.findByCompanyNumber(COMPANY_NUMBER))
                 .thenReturn(companyProfile);
 
-        this.companyProfileService.delete(COMPANY_NUMBER);
-
+        assertTrue(this.companyProfileService.delete(COMPANY_NUMBER));
         verify(repository).delete(companyProfile);
     }
     
     @Test
-    void deleteNoCompanyProfile() {
+    void deleteNoCompanyProfile() throws DataException {
         CompanyProfile companyProfile = null;
         when(repository.findByCompanyNumber(COMPANY_NUMBER))
                 .thenReturn(companyProfile);
         
-        NoDataFoundException exception = assertThrows(NoDataFoundException.class, () ->
-            this.companyProfileService.delete(COMPANY_NUMBER)
-        );
-        assertEquals("company profile data not found", exception.getMessage());
+        assertFalse(this.companyProfileService.delete(COMPANY_NUMBER));
+        verify(repository, never()).delete(any());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -188,7 +190,7 @@ class CompanyProfileServiceImplTest {
     void delete() throws DataException {
         CompanyProfile companyProfile = new CompanyProfile();
         when(repository.findByCompanyNumber(COMPANY_NUMBER))
-                .thenReturn(companyProfile);
+                .thenReturn(Optional.of(companyProfile));
 
         assertTrue(this.companyProfileService.delete(COMPANY_NUMBER));
         verify(repository).delete(companyProfile);
@@ -196,9 +198,8 @@ class CompanyProfileServiceImplTest {
     
     @Test
     void deleteNoCompanyProfile() throws DataException {
-        CompanyProfile companyProfile = null;
         when(repository.findByCompanyNumber(COMPANY_NUMBER))
-                .thenReturn(companyProfile);
+                .thenReturn(Optional.empty());
         
         assertFalse(this.companyProfileService.delete(COMPANY_NUMBER));
         verify(repository, never()).delete(any());
@@ -208,7 +209,7 @@ class CompanyProfileServiceImplTest {
     void deleteMongoException() {
         CompanyProfile companyProfile = new CompanyProfile();
         when(repository.findByCompanyNumber(COMPANY_NUMBER))
-                .thenReturn(companyProfile);
+                .thenReturn(Optional.of(companyProfile));
         doThrow(MongoException.class).when(repository).delete(companyProfile);
         DataException exception = assertThrows(DataException.class, () ->
             this.companyProfileService.delete(COMPANY_NUMBER)

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -96,7 +98,7 @@ class CompanyPscStatementServiceImplTest {
     @Test
     void delete() throws DataException {
         CompanyPscStatement companyPscStatement = new CompanyPscStatement();
-        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(companyPscStatement);
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(companyPscStatement));
 
         assertTrue(this.companyPscStatementService.delete(COMPANY_NUMBER));
         verify(repository).delete(companyPscStatement);
@@ -105,7 +107,7 @@ class CompanyPscStatementServiceImplTest {
     @Test
     void deleteNoDataException() throws DataException {
         CompanyPscStatement companyPscStatement = null;
-        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(companyPscStatement);
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.ofNullable(companyPscStatement));
 
         assertFalse(this.companyPscStatementService.delete(COMPANY_NUMBER));
         verify(repository, never()).delete(companyPscStatement);
@@ -114,7 +116,7 @@ class CompanyPscStatementServiceImplTest {
     @Test
     void deleteMongoException() {
         CompanyPscStatement companyPscStatement = new CompanyPscStatement();
-        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(companyPscStatement);
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(companyPscStatement));
         doThrow(MongoException.class).when(repository).delete(companyPscStatement);
         
         DataException exception = assertThrows(DataException.class, () ->

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java
@@ -1,10 +1,13 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -18,7 +21,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.mongodb.MongoException;
 
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscStatement;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
@@ -92,23 +94,21 @@ class CompanyPscStatementServiceImplTest {
     }
     
     @Test
-    void delete() throws Exception {
+    void delete() throws DataException {
         CompanyPscStatement companyPscStatement = new CompanyPscStatement();
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(companyPscStatement);
 
-        this.companyPscStatementService.delete(COMPANY_NUMBER);
+        assertTrue(this.companyPscStatementService.delete(COMPANY_NUMBER));
         verify(repository).delete(companyPscStatement);
     }
 
     @Test
-    void deleteNoDataException() {
+    void deleteNoDataException() throws DataException {
         CompanyPscStatement companyPscStatement = null;
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(companyPscStatement);
-        
-        NoDataFoundException exception = assertThrows(NoDataFoundException.class, () ->
-                this.companyPscStatementService.delete(COMPANY_NUMBER)
-        );
-        assertEquals("statement data not found", exception.getMessage());
+
+        assertFalse(this.companyPscStatementService.delete(COMPANY_NUMBER));
+        verify(repository, never()).delete(companyPscStatement);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImplTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -137,7 +138,7 @@ class FilingHistoryServiceImplTest {
     void delete() throws DataException {
         FilingHistory filingHistory = new FilingHistory();
 
-        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(filingHistory);
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(filingHistory));
 
         assertTrue(filingHistoryService.delete(COMPANY_NUMBER));
 
@@ -146,8 +147,7 @@ class FilingHistoryServiceImplTest {
 
     @Test
     void deleteNoCompany() throws DataException {
-        FilingHistory filingHistory = null;
-        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(filingHistory);
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.empty());
 
         assertFalse(this.filingHistoryService.delete(COMPANY_NUMBER));
         verify(repository, never()).delete(any());
@@ -157,7 +157,7 @@ class FilingHistoryServiceImplTest {
     void deleteMongoException() {
         FilingHistory filingHistory = new FilingHistory();
         when(repository.findByCompanyNumber(COMPANY_NUMBER))
-                .thenReturn(filingHistory);
+                .thenReturn(Optional.of(filingHistory));
         doThrow(MongoException.class).when(repository).delete(filingHistory);
         DataException exception = assertThrows(DataException.class, () ->
             this.filingHistoryService.delete(COMPANY_NUMBER)

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImplTest.java
@@ -1,10 +1,13 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,7 +25,6 @@ import com.mongodb.MongoException;
 
 import uk.gov.companieshouse.api.testdata.exception.BarcodeServiceException;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.AssociatedFiling;
 import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
@@ -132,25 +134,23 @@ class FilingHistoryServiceImplTest {
     }
 
     @Test
-    void delete() throws Exception {
+    void delete() throws DataException {
         FilingHistory filingHistory = new FilingHistory();
 
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(filingHistory);
 
-        filingHistoryService.delete(COMPANY_NUMBER);
+        assertTrue(filingHistoryService.delete(COMPANY_NUMBER));
 
         verify(repository).delete(filingHistory);
     }
 
     @Test
-    void deleteNoCompany() {
+    void deleteNoCompany() throws DataException {
         FilingHistory filingHistory = null;
-        when(repository.findByCompanyNumber(COMPANY_NUMBER))
-                .thenReturn(filingHistory);
-        NoDataFoundException exception = assertThrows(NoDataFoundException.class, () ->
-            this.filingHistoryService.delete(COMPANY_NUMBER)
-        );
-        assertEquals("filing history data not found", exception.getMessage());
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(filingHistory);
+
+        assertFalse(this.filingHistoryService.delete(COMPANY_NUMBER));
+        verify(repository, never()).delete(any());
     }
 
     @Test


### PR DESCRIPTION
Roll back creation of data on exception
Delete methods will no longer throw an exception if nothing to delete, but return false
Repositories now return `Optional`

Resolves FA-264