### PR TITLE
Remove MongoException catching

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -18,7 +18,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import uk.gov.companieshouse.api.testdata.Application;
+import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.InvalidAuthCodeException;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanyData;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.model.rest.DeleteCompanyRequest;
@@ -40,7 +42,7 @@ public class TestDataController {
     private CompanyAuthCodeService companyAuthCodeService;
 
     @PostMapping("/company")
-    public ResponseEntity<CompanyData> create(@Valid @RequestBody Optional<CompanySpec> request) throws Exception {
+    public ResponseEntity<CompanyData> create(@Valid @RequestBody Optional<CompanySpec> request) throws DataException {
 
         CompanySpec spec = request.orElse(new CompanySpec());
 
@@ -55,8 +57,9 @@ public class TestDataController {
 
     @DeleteMapping("/company/{companyNumber}")
     public ResponseEntity<Void> delete(@PathVariable("companyNumber") String companyNumber,
-            @Valid @RequestBody DeleteCompanyRequest request) throws Exception {
-        
+            @Valid @RequestBody DeleteCompanyRequest request)
+            throws DataException, InvalidAuthCodeException, NoDataFoundException {
+
         if (!companyAuthCodeService.verifyAuthCode(companyNumber, request.getAuthCode())) {
             throw new InvalidAuthCodeException(companyNumber);
         }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import uk.gov.companieshouse.api.testdata.Application;
-import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.InvalidAuthCodeException;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanyData;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
@@ -41,7 +40,7 @@ public class TestDataController {
     private CompanyAuthCodeService companyAuthCodeService;
 
     @PostMapping("/company")
-    public ResponseEntity<CompanyData> create(@Valid @RequestBody Optional<CompanySpec> request) throws DataException {
+    public ResponseEntity<CompanyData> create(@Valid @RequestBody Optional<CompanySpec> request) throws Exception {
 
         CompanySpec spec = request.orElse(new CompanySpec());
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/DataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/DataService.java
@@ -11,7 +11,6 @@ public interface DataService<T> {
      * 
      * @param companyNumber
      * @return True if the data could be found and deleted. False if no data found
-     * @throws DataException When any error occurs
      */
-    boolean delete(String companyNumber) throws DataException;
+    boolean delete(String companyNumber);
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
@@ -10,7 +10,7 @@ public interface TestDataService {
      * 
      * @param companySpec The specification the new company must adhere to
      * @return A {@link CompanyData}
-     * @throws DataException If any exception occurs
+     * @throws DataException If any error occurs
      */
     CompanyData createCompanyData(CompanySpec companySpec) throws DataException;
 
@@ -18,7 +18,7 @@ public interface TestDataService {
      * Delete all data for company {@code companyNumber}
      * 
      * @param companyNumber The company number to be deleted
-     * @throws DataException
+     * @throws DataException If any error occurs
      */
     void deleteCompanyData(String companyNumber) throws DataException;
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImpl.java
@@ -10,9 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.stereotype.Service;
 
-import com.mongodb.MongoException;
-
-import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyAuthCode;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
@@ -38,7 +35,7 @@ public class CompanyAuthCodeServiceImpl implements CompanyAuthCodeService {
     }
 
     @Override
-    public CompanyAuthCode create(CompanySpec spec) throws DataException {
+    public CompanyAuthCode create(CompanySpec spec) {
         final String authCode = String.valueOf(randomService.getNumber(AUTH_CODE_LENGTH));
 
         CompanyAuthCode companyAuthCode = new CompanyAuthCode();
@@ -48,11 +45,7 @@ public class CompanyAuthCodeServiceImpl implements CompanyAuthCodeService {
         companyAuthCode.setEncryptedAuthCode(encrypt(authCode));
         companyAuthCode.setIsActive(true);
 
-        try {
-            return repository.save(companyAuthCode);
-        } catch (MongoException e) {
-            throw new DataException("Failed to save company auth code", e);
-        }
+        return repository.save(companyAuthCode);
     }
 
     private String encrypt(final String authCode) {
@@ -64,16 +57,12 @@ public class CompanyAuthCodeServiceImpl implements CompanyAuthCodeService {
     }
 
     @Override
-    public boolean delete(String companyId) throws DataException {
+    public boolean delete(String companyId) {
 
         Optional<CompanyAuthCode> existingCompanyAuthCode = repository.findById(companyId);
 
-        try {
-            existingCompanyAuthCode.ifPresent(repository::delete);
-            return existingCompanyAuthCode.isPresent();
-        } catch (MongoException e) {
-            throw new DataException("Failed to delete company auth code", e);
-        }
+        existingCompanyAuthCode.ifPresent(repository::delete);
+        return existingCompanyAuthCode.isPresent();
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyMetricsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyMetricsServiceImpl.java
@@ -5,9 +5,6 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.mongodb.MongoException;
-
-import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyMetrics;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.repository.CompanyMetricsRepository;
@@ -23,30 +20,22 @@ public class CompanyMetricsServiceImpl implements DataService<CompanyMetrics> {
     private RandomService randomService;
     
     @Override
-    public CompanyMetrics create(CompanySpec spec) throws DataException {
+    public CompanyMetrics create(CompanySpec spec) {
         CompanyMetrics metrics = new CompanyMetrics();
         metrics.setId(spec.getCompanyNumber());
         metrics.setEtag(randomService.getEtag());
         metrics.setActivePscStatementsCount(1);
         metrics.setActiveDirectorsCount(1);
 
-        try {
-            return repository.save(metrics);
-        } catch (MongoException e) {
-            throw new DataException("Failed to save company metrics", e);
-        }
+        return repository.save(metrics);
     }
 
     @Override
-    public boolean delete(String companyNumber) throws DataException {
+    public boolean delete(String companyNumber) {
         Optional<CompanyMetrics> existingMetric = repository.findById(companyNumber);
 
-        try {
-            existingMetric.ifPresent(repository::delete);
-            return existingMetric.isPresent();
-        } catch (MongoException e) {
-            throw new DataException("Failed to delete company metrics", e);
-        }
+        existingMetric.ifPresent(repository::delete);
+        return existingMetric.isPresent();
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -9,9 +9,6 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.mongodb.MongoException;
-
-import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
@@ -36,7 +33,7 @@ public class CompanyProfileServiceImpl implements DataService<CompanyProfile> {
     private CompanyProfileRepository repository;
 
     @Override
-    public CompanyProfile create(CompanySpec spec) throws DataException {
+    public CompanyProfile create(CompanySpec spec) {
         final String companyNumber = spec.getCompanyNumber();
         final Jurisdiction jurisdiction = spec.getJurisdiction();
 
@@ -82,22 +79,14 @@ public class CompanyProfileServiceImpl implements DataService<CompanyProfile> {
         profile.setHasCharges(false);
         profile.setCanFile(true);
 
-        try {
-            return repository.save(profile);
-        } catch (MongoException e) {
-            throw new DataException("Failed to save company profile", e);
-        }
+        return repository.save(profile);
     }
 
     @Override
-    public boolean delete(String companyId) throws DataException {
-        try {
-            Optional<CompanyProfile> profile = repository.findByCompanyNumber(companyId);
-            profile.ifPresent(repository::delete);
-            return profile.isPresent();
-        } catch (MongoException e) {
-            throw new DataException("Failed to delete company profile", e);
-        }
+    public boolean delete(String companyId) {
+        Optional<CompanyProfile> profile = repository.findByCompanyNumber(companyId);
+        profile.ifPresent(repository::delete);
+        return profile.isPresent();
     }
 
     private Links createLinks(String companyNumber) {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.java
@@ -8,9 +8,6 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.mongodb.MongoException;
-
-import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscStatement;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
@@ -31,7 +28,7 @@ public class CompanyPscStatementServiceImpl implements DataService<CompanyPscSta
     private CompanyPscStatementRepository repository;
 
     @Override
-    public CompanyPscStatement create(CompanySpec spec) throws DataException {
+    public CompanyPscStatement create(CompanySpec spec) {
         final String companyNumber = spec.getCompanyNumber();
         CompanyPscStatement companyPscStatement = new CompanyPscStatement();
 
@@ -58,21 +55,13 @@ public class CompanyPscStatementServiceImpl implements DataService<CompanyPscSta
 
         companyPscStatement.setCreatedAt(dateTimeNow);
 
-        try {
-            return repository.save(companyPscStatement);
-        } catch (MongoException e) {
-            throw new DataException("Failed to save PSC statement", e);
-        }
+        return repository.save(companyPscStatement);
     }
 
     @Override
-    public boolean delete(String companyNumber) throws DataException {
-        try {
-            Optional<CompanyPscStatement> existingStatement = repository.findByCompanyNumber(companyNumber);
-            existingStatement.ifPresent(repository::delete);
-            return existingStatement.isPresent();
-        } catch (MongoException e) {
-            throw new DataException("Failed to delete PSC statement", e);
-        }
+    public boolean delete(String companyNumber) {
+        Optional<CompanyPscStatement> existingStatement = repository.findByCompanyNumber(companyNumber);
+        existingStatement.ifPresent(repository::delete);
+        return existingStatement.isPresent();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImpl.java
@@ -11,8 +11,6 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.mongodb.MongoException;
-
 import uk.gov.companieshouse.api.testdata.exception.BarcodeServiceException;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.model.entity.AssociatedFiling;
@@ -70,23 +68,15 @@ public class FilingHistoryServiceImpl implements DataService<FilingHistory> {
 
         filingHistory.setBarcode(barcode);
 
-        try {
-            return filingHistoryRepository.save(filingHistory);
-        } catch (MongoException e) {
-            throw new DataException("Failed to save filing history", e);
-        }
+        return filingHistoryRepository.save(filingHistory);
     }
 
     @Override
-    public boolean delete(String companyId) throws DataException {
-        try {
-            Optional<FilingHistory> filingHistory = filingHistoryRepository.findByCompanyNumber(companyId);
+    public boolean delete(String companyId) {
+        Optional<FilingHistory> filingHistory = filingHistoryRepository.findByCompanyNumber(companyId);
 
-            filingHistory.ifPresent(filingHistoryRepository::delete);
-            return filingHistory.isPresent();
-        } catch (MongoException e) {
-            throw new DataException("Failed to delete filing history", e);
-        }
+        filingHistory.ifPresent(filingHistoryRepository::delete);
+        return filingHistory.isPresent();
     }
 
     private List<AssociatedFiling> createAssociatedFilings(Instant dayTimeNow, Instant dayNow){

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImplTest.java
@@ -3,12 +3,9 @@ package uk.gov.companieshouse.api.testdata.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -21,9 +18,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.mongodb.MongoException;
-
-import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.model.entity.Address;
 import uk.gov.companieshouse.api.testdata.model.entity.Appointment;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
@@ -59,7 +53,7 @@ class AppointmentsServiceImplTest {
     private AppointmentsServiceImpl appointmentsService;
 
     @Test
-    void create() throws DataException {
+    void create() {
         final Address mockServiceAddress = new Address(
                 "","","","",""
         );
@@ -118,7 +112,7 @@ class AppointmentsServiceImplTest {
     }
 
     @Test
-    void createScottish() throws DataException {
+    void createScottish() {
         final Address mockServiceAddress = new Address(
                 "","","","",""
         );
@@ -177,36 +171,7 @@ class AppointmentsServiceImplTest {
     }
 
     @Test
-    void createAppointmentMongoException() {
-        CompanySpec spec = new CompanySpec();
-        spec.setCompanyNumber(COMPANY_NUMBER);
-
-        when(this.randomService.getEncodedIdWithSalt(10, 8)).thenReturn(ENCODED_VALUE);
-        when(appointmentsRepository.save(any())).thenThrow(MongoException.class);
-
-        DataException exception = assertThrows(DataException.class, () ->
-                this.appointmentsService.create(spec)
-        );
-        assertEquals("Failed to save appointment", exception.getMessage());
-    }
-
-    @Test
-    void createOfficerMongoException() {
-        CompanySpec spec = new CompanySpec();
-        spec.setCompanyNumber(COMPANY_NUMBER);
-
-        when(this.randomService.getEncodedIdWithSalt(10, 8)).thenReturn(ENCODED_VALUE);
-        when(officerRepository.save(any())).thenThrow(MongoException.class);
-
-        DataException exception = assertThrows(DataException.class, () ->
-                this.appointmentsService.create(spec)
-        );
-        verify(appointmentsRepository, times(0)).save(any());
-        assertEquals("Failed to save officer appointment", exception.getMessage());
-    }
-    
-    @Test
-    void delete() throws DataException {
+    void delete() {
         Appointment apt = new Appointment();
         OfficerAppointment officerAppointment = new OfficerAppointment();
         final String officerId = "TEST";
@@ -220,7 +185,7 @@ class AppointmentsServiceImplTest {
     }
 
     @Test
-    void deleteNoAppointmentDataException() throws DataException {
+    void deleteNoAppointmentDataException() {
         when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.empty());
         
         assertFalse(this.appointmentsService.delete(COMPANY_NUMBER));
@@ -229,7 +194,7 @@ class AppointmentsServiceImplTest {
     }
 
     @Test
-    void deleteNoOfficerDataException() throws DataException {
+    void deleteNoOfficerDataException() {
         Appointment apt = new Appointment();
         final String officerId = "TEST";
         apt.setOfficerId(officerId);
@@ -239,38 +204,6 @@ class AppointmentsServiceImplTest {
         assertTrue(this.appointmentsService.delete(COMPANY_NUMBER));
         verify(officerRepository, never()).delete(any());
         verify(appointmentsRepository).delete(apt);
-    }
-
-    @Test
-    void deleteAppointmentMongoException() {
-        Appointment apt = new Appointment();
-        OfficerAppointment officerAppointment = new OfficerAppointment();
-        final String officerId = "TEST";
-        apt.setOfficerId(officerId);
-        when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(apt));
-        when(officerRepository.findById(officerId)).thenReturn(Optional.of(officerAppointment));
-        doThrow(MongoException.class).when(appointmentsRepository).delete(apt);
-        
-        DataException exception = assertThrows(DataException.class, () ->
-                this.appointmentsService.delete(COMPANY_NUMBER)
-        );
-        assertEquals("Failed to delete appointment", exception.getMessage());
-    }
-
-    @Test
-    void deleteOfficerMongoException() {
-        Appointment apt = new Appointment();
-        OfficerAppointment officerAppointment = new OfficerAppointment();
-        final String officerId = "TEST";
-        apt.setOfficerId(officerId);
-        when(appointmentsRepository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(apt));
-        when(officerRepository.findById(officerId)).thenReturn(Optional.of(officerAppointment));
-        doThrow(MongoException.class).when(officerRepository).delete(officerAppointment);
-
-        DataException exception = assertThrows(DataException.class, () ->
-                this.appointmentsService.delete(COMPANY_NUMBER)
-        );
-        assertEquals("Failed to delete appointment", exception.getMessage());
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImplTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,9 +24,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 
-import com.mongodb.MongoException;
-
-import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyAuthCode;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
@@ -87,20 +83,6 @@ class CompanyAuthCodeServiceImplTest {
     }
 
     @Test
-    void createMongoException() {
-        CompanySpec spec = new CompanySpec();
-        spec.setCompanyNumber(COMPANY_NUMBER);
-
-        when(this.randomService.getNumber(6)).thenReturn(COMPANY_AUTH_CODE);
-        when(repository.save(any())).thenThrow(MongoException.class);
-
-        DataException exception = assertThrows(DataException.class, () ->
-            this.companyAuthCodeServiceImpl.create(spec)
-        );
-        assertEquals("Failed to save company auth code", exception.getMessage());
-    }
-    
-    @Test
     void verifyAuthCodeCorrect() throws NoSuchAlgorithmException, NoDataFoundException {
         final String plainCode = "222";
         
@@ -143,7 +125,7 @@ class CompanyAuthCodeServiceImplTest {
     }
     
     @Test
-    void delete() throws DataException {
+    void delete() {
         CompanyAuthCode authCode = new CompanyAuthCode();
         when(repository.findById(COMPANY_NUMBER))
                 .thenReturn(Optional.of(authCode));
@@ -153,23 +135,10 @@ class CompanyAuthCodeServiceImplTest {
     }
 
     @Test
-    void deleteNoDataException() throws DataException {
+    void deleteNoDataException() {
         when(repository.findById(COMPANY_NUMBER)).thenReturn(Optional.empty());
         assertFalse(this.companyAuthCodeServiceImpl.delete(COMPANY_NUMBER));
         verify(repository, never()).delete(any());
-    }
-
-    @Test
-    void deleteMongoException() {
-        CompanyAuthCode authCode = new CompanyAuthCode();
-        when(repository.findById(COMPANY_NUMBER))
-                .thenReturn(Optional.of(authCode));
-        doThrow(MongoException.class).when(repository).delete(authCode);
-        
-        DataException exception = assertThrows(DataException.class, () ->
-            this.companyAuthCodeServiceImpl.delete(COMPANY_NUMBER)
-        );
-        assertEquals("Failed to delete company auth code", exception.getMessage());
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyMetricsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyMetricsServiceImplTest.java
@@ -3,10 +3,8 @@ package uk.gov.companieshouse.api.testdata.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,9 +18,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.mongodb.MongoException;
-
-import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyMetrics;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.repository.CompanyMetricsRepository;
@@ -43,7 +38,7 @@ class CompanyMetricsServiceImplTest {
     private CompanyMetricsServiceImpl metricsService;
 
     @Test
-    void create() throws DataException {
+    void create() {
         CompanySpec spec = new CompanySpec();
         spec.setCompanyNumber(COMPANY_NUMBER);
 
@@ -85,20 +80,7 @@ class CompanyMetricsServiceImplTest {
     }
 
     @Test
-    void createMongoException() {
-        CompanySpec spec = new CompanySpec();
-        spec.setCompanyNumber(COMPANY_NUMBER);
-
-        when(repository.save(any())).thenThrow(MongoException.class);
-
-        DataException exception = assertThrows(DataException.class, () ->
-            this.metricsService.create(spec)
-        );
-        assertEquals("Failed to save company metrics", exception.getMessage());
-    }
-
-    @Test
-    void delete() throws DataException {
+    void delete() {
         CompanyMetrics metrics = new CompanyMetrics();
         Optional<CompanyMetrics> optionalMetric = Optional.of(metrics);
         when(repository.findById(COMPANY_NUMBER)).thenReturn(optionalMetric);
@@ -108,25 +90,11 @@ class CompanyMetricsServiceImplTest {
     }
 
     @Test
-    void deleteNoDataException() throws DataException {
+    void deleteNoDataException() {
         Optional<CompanyMetrics> optionalMetric = Optional.empty();
         when(repository.findById(COMPANY_NUMBER)).thenReturn(optionalMetric);
         
         assertFalse(this.metricsService.delete(COMPANY_NUMBER));
         verify(repository, never()).delete(any());
     }
-
-    @Test
-    void deleteMongoException() {
-        CompanyMetrics metrics = new CompanyMetrics();
-        Optional<CompanyMetrics> optionalMetric = Optional.of(metrics);
-        when(repository.findById(COMPANY_NUMBER)).thenReturn(optionalMetric);
-        doThrow(MongoException.class).when(repository).delete(metrics);
-
-        DataException exception = assertThrows(DataException.class, () ->
-                this.metricsService.delete(COMPANY_NUMBER)
-        );
-        assertEquals("Failed to delete company metrics", exception.getMessage());
-    }
-
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -3,10 +3,8 @@ package uk.gov.companieshouse.api.testdata.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,9 +18,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.mongodb.MongoException;
-
-import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.model.entity.Address;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
@@ -48,7 +43,7 @@ class CompanyProfileServiceImplTest {
     private CompanyProfileServiceImpl companyProfileService;
 
     @Test
-    void createEnglandWales() throws DataException {
+    void createEnglandWales() {
         final Address mockServiceAddress = new Address(
                 "","","","",""
         );
@@ -111,7 +106,7 @@ class CompanyProfileServiceImplTest {
     }
 
     @Test
-    void createScotland() throws DataException {
+    void createScotland() {
         final Address mockServiceAddress = new Address(
                 "","","","",""
         );
@@ -173,21 +168,9 @@ class CompanyProfileServiceImplTest {
         assertEquals(ETAG, profile.getEtag());
     }
 
-    @Test
-    void createMongoException() {
-        CompanySpec spec = new CompanySpec();
-        spec.setCompanyNumber(COMPANY_NUMBER);
-
-        when(repository.save(any())).thenThrow(MongoException.class);
-
-        DataException exception = assertThrows(DataException.class, () ->
-            this.companyProfileService.create(spec)
-        );
-        assertEquals("Failed to save company profile", exception.getMessage());
-    }
 
     @Test
-    void delete() throws DataException {
+    void delete() {
         CompanyProfile companyProfile = new CompanyProfile();
         when(repository.findByCompanyNumber(COMPANY_NUMBER))
                 .thenReturn(Optional.of(companyProfile));
@@ -197,24 +180,12 @@ class CompanyProfileServiceImplTest {
     }
     
     @Test
-    void deleteNoCompanyProfile() throws DataException {
+    void deleteNoCompanyProfile() {
         when(repository.findByCompanyNumber(COMPANY_NUMBER))
                 .thenReturn(Optional.empty());
         
         assertFalse(this.companyProfileService.delete(COMPANY_NUMBER));
         verify(repository, never()).delete(any());
-    }
-
-    @Test
-    void deleteMongoException() {
-        CompanyProfile companyProfile = new CompanyProfile();
-        when(repository.findByCompanyNumber(COMPANY_NUMBER))
-                .thenReturn(Optional.of(companyProfile));
-        doThrow(MongoException.class).when(repository).delete(companyProfile);
-        DataException exception = assertThrows(DataException.class, () ->
-            this.companyProfileService.delete(COMPANY_NUMBER)
-        );
-        assertEquals("Failed to delete company profile", exception.getMessage());
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java
@@ -3,10 +3,8 @@ package uk.gov.companieshouse.api.testdata.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,9 +18,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.mongodb.MongoException;
-
-import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscStatement;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
@@ -45,7 +40,7 @@ class CompanyPscStatementServiceImplTest {
     private CompanyPscStatementServiceImpl companyPscStatementService;
 
     @Test
-    void create() throws DataException {
+    void create() {
         CompanySpec spec = new CompanySpec();
         spec.setCompanyNumber(COMPANY_NUMBER);
 
@@ -82,21 +77,7 @@ class CompanyPscStatementServiceImplTest {
     }
 
     @Test
-    void createMongoException() {
-        CompanySpec spec = new CompanySpec();
-        spec.setCompanyNumber(COMPANY_NUMBER);
-
-        when(this.randomService.getEncodedIdWithSalt(10, 8)).thenReturn(ENCODED_VALUE);
-        when(repository.save(any())).thenThrow(MongoException.class);
-
-        DataException exception = assertThrows(DataException.class, () ->
-                this.companyPscStatementService.create(spec)
-        );
-        assertEquals("Failed to save PSC statement", exception.getMessage());
-    }
-    
-    @Test
-    void delete() throws DataException {
+    void delete() {
         CompanyPscStatement companyPscStatement = new CompanyPscStatement();
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(companyPscStatement));
 
@@ -105,24 +86,11 @@ class CompanyPscStatementServiceImplTest {
     }
 
     @Test
-    void deleteNoDataException() throws DataException {
+    void deleteNoDataException() {
         CompanyPscStatement companyPscStatement = null;
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.ofNullable(companyPscStatement));
 
         assertFalse(this.companyPscStatementService.delete(COMPANY_NUMBER));
         verify(repository, never()).delete(companyPscStatement);
     }
-
-    @Test
-    void deleteMongoException() {
-        CompanyPscStatement companyPscStatement = new CompanyPscStatement();
-        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(companyPscStatement));
-        doThrow(MongoException.class).when(repository).delete(companyPscStatement);
-        
-        DataException exception = assertThrows(DataException.class, () ->
-                this.companyPscStatementService.delete(COMPANY_NUMBER)
-        );
-        assertEquals("Failed to delete PSC statement", exception.getMessage());
-    }
-
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImplTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -21,8 +20,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import com.mongodb.MongoException;
 
 import uk.gov.companieshouse.api.testdata.exception.BarcodeServiceException;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
@@ -119,23 +116,7 @@ class FilingHistoryServiceImplTest {
     }
 
     @Test
-    void createMongoException() throws BarcodeServiceException{
-        CompanySpec spec = new CompanySpec();
-        spec.setCompanyNumber(COMPANY_NUMBER);
-
-        when(randomService.getNumber(ENTITY_ID_LENGTH)).thenReturn(UNENCODED_ID);
-        when(randomService.addSaltAndEncode(ENTITY_ID_PREFIX + UNENCODED_ID, 8)).thenReturn(TEST_ID);
-        when(barcodeService.getBarcode()).thenReturn(BARCODE);
-        when(repository.save(any())).thenThrow(MongoException.class);
-
-        DataException exception = assertThrows(DataException.class, () ->
-            this.filingHistoryService.create(spec)
-        );
-        assertEquals("Failed to save filing history", exception.getMessage());
-    }
-
-    @Test
-    void delete() throws DataException {
+    void delete() {
         FilingHistory filingHistory = new FilingHistory();
 
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(filingHistory));
@@ -146,22 +127,11 @@ class FilingHistoryServiceImplTest {
     }
 
     @Test
-    void deleteNoCompany() throws DataException {
+    void deleteNoCompany() {
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.empty());
 
         assertFalse(this.filingHistoryService.delete(COMPANY_NUMBER));
         verify(repository, never()).delete(any());
     }
 
-    @Test
-    void deleteMongoException() {
-        FilingHistory filingHistory = new FilingHistory();
-        when(repository.findByCompanyNumber(COMPANY_NUMBER))
-                .thenReturn(Optional.of(filingHistory));
-        doThrow(MongoException.class).when(repository).delete(filingHistory);
-        DataException exception = assertThrows(DataException.class, () ->
-            this.filingHistoryService.delete(COMPANY_NUMBER)
-        );
-        assertEquals("Failed to delete filing history", exception.getMessage());
-    }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
@@ -62,7 +62,7 @@ class TestDataServiceImplTest {
     private ArgumentCaptor<CompanySpec> specCaptor;
 
     @Test
-    void createCompanyDataDefaultSpec() throws DataException {
+    void createCompanyDataDefaultSpec() throws Exception {
         CompanySpec spec = new CompanySpec();
         CompanyProfile mockCompany = new CompanyProfile();
         mockCompany.setCompanyNumber(COMPANY_NUMBER);
@@ -96,7 +96,7 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void createCompanyDataScottishSpec() throws DataException {
+    void createCompanyDataScottishSpec() throws Exception {
         CompanySpec spec = new CompanySpec();
         spec.setJurisdiction(Jurisdiction.SCOTLAND);
         CompanyProfile mockCompany = new CompanyProfile();
@@ -131,7 +131,7 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void createCompanyDataNISpec() throws DataException {
+    void createCompanyDataNISpec() throws Exception {
         CompanySpec spec = new CompanySpec();
         spec.setJurisdiction(Jurisdiction.NI);
         CompanyProfile mockCompany = new CompanyProfile();
@@ -179,7 +179,7 @@ class TestDataServiceImplTest {
 
         DataException thrown = assertThrows(DataException.class, () -> this.testDataService.createCompanyData(spec));
 
-        assertEquals(pscStatementException, thrown);
+        assertEquals(pscStatementException, thrown.getCause());
         
         verify(companyProfileService).create(specCaptor.capture());
         CompanySpec expectedSpec = specCaptor.getValue();
@@ -201,7 +201,7 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void deleteCompanyData() throws DataException {
+    void deleteCompanyData() throws Exception {
         this.testDataService.deleteCompanyData(COMPANY_NUMBER);
 
         verify(companyProfileService, times(1)).delete(COMPANY_NUMBER);
@@ -226,15 +226,15 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void deleteCompanyDataProfileException() throws DataException {
-        DataException ex = new DataException("exception");
+    void deleteCompanyDataProfileException() {
+        RuntimeException ex = new RuntimeException("exception");
         when(companyProfileService.delete(COMPANY_NUMBER)).thenThrow(ex);
 
         DataException thrown = assertThrows(DataException.class,
                 () -> this.testDataService.deleteCompanyData(COMPANY_NUMBER));
 
-        assertEquals(ex, thrown);
-        assertEquals(0, thrown.getSuppressed().length);
+        assertEquals(1, thrown.getSuppressed().length);
+        assertEquals(ex, thrown.getSuppressed()[0]);
 
         verify(companyProfileService, times(1)).delete(COMPANY_NUMBER);
         verify(filingHistoryService, times(1)).delete(COMPANY_NUMBER);
@@ -245,15 +245,15 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void deleteCompanyDataFilingHistoryException() throws DataException {
-        DataException ex = new DataException("exception");
+    void deleteCompanyDataFilingHistoryException() {
+        RuntimeException ex = new RuntimeException("exception");
         when(filingHistoryService.delete(COMPANY_NUMBER)).thenThrow(ex);
 
         DataException thrown = assertThrows(DataException.class,
                 () -> this.testDataService.deleteCompanyData(COMPANY_NUMBER));
 
-        assertEquals(ex, thrown);
-        assertEquals(0, thrown.getSuppressed().length);
+        assertEquals(1, thrown.getSuppressed().length);
+        assertEquals(ex, thrown.getSuppressed()[0]);
 
         verify(companyProfileService, times(1)).delete(COMPANY_NUMBER);
         verify(filingHistoryService, times(1)).delete(COMPANY_NUMBER);
@@ -264,15 +264,15 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void deleteCompanyDataAuthCodeException() throws DataException {
-        DataException ex = new DataException("exception");
+    void deleteCompanyDataAuthCodeException() {
+        RuntimeException ex = new RuntimeException("exception");
         when(companyAuthCodeService.delete(COMPANY_NUMBER)).thenThrow(ex);
 
         DataException thrown = assertThrows(DataException.class,
                 () -> this.testDataService.deleteCompanyData(COMPANY_NUMBER));
 
-        assertEquals(ex, thrown);
-        assertEquals(0, thrown.getSuppressed().length);
+        assertEquals(1, thrown.getSuppressed().length);
+        assertEquals(ex, thrown.getSuppressed()[0]);
 
         verify(companyProfileService, times(1)).delete(COMPANY_NUMBER);
         verify(filingHistoryService, times(1)).delete(COMPANY_NUMBER);
@@ -283,15 +283,15 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void deleteCompanyDataAppointmentException() throws DataException {
-        DataException ex = new DataException("exception");
+    void deleteCompanyDataAppointmentException() {
+        RuntimeException ex = new RuntimeException("exception");
         when(appointmentService.delete(COMPANY_NUMBER)).thenThrow(ex);
 
         DataException thrown = assertThrows(DataException.class,
                 () -> this.testDataService.deleteCompanyData(COMPANY_NUMBER));
 
-        assertEquals(ex, thrown);
-        assertEquals(0, thrown.getSuppressed().length);
+        assertEquals(1, thrown.getSuppressed().length);
+        assertEquals(ex, thrown.getSuppressed()[0]);
 
         verify(companyProfileService, times(1)).delete(COMPANY_NUMBER);
         verify(filingHistoryService, times(1)).delete(COMPANY_NUMBER);
@@ -302,15 +302,15 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void deleteCompanyDataPscStatementException() throws DataException {
-        DataException ex = new DataException("exception");
+    void deleteCompanyDataPscStatementException() {
+        RuntimeException ex = new RuntimeException("exception");
         when(companyPscStatementService.delete(COMPANY_NUMBER)).thenThrow(ex);
 
         DataException thrown = assertThrows(DataException.class,
                 () -> this.testDataService.deleteCompanyData(COMPANY_NUMBER));
 
-        assertEquals(ex, thrown);
-        assertEquals(0, thrown.getSuppressed().length);
+        assertEquals(1, thrown.getSuppressed().length);
+        assertEquals(ex, thrown.getSuppressed()[0]);
 
         verify(companyProfileService, times(1)).delete(COMPANY_NUMBER);
         verify(filingHistoryService, times(1)).delete(COMPANY_NUMBER);
@@ -321,15 +321,15 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void deleteCompanyDataMetricsException() throws DataException {
-        DataException ex = new DataException("exception");
+    void deleteCompanyDataMetricsException() {
+        RuntimeException ex = new RuntimeException("exception");
         when(metricsService.delete(COMPANY_NUMBER)).thenThrow(ex);
 
         DataException thrown = assertThrows(DataException.class,
                 () -> this.testDataService.deleteCompanyData(COMPANY_NUMBER));
 
-        assertEquals(ex, thrown);
-        assertEquals(0, thrown.getSuppressed().length);
+        assertEquals(1, thrown.getSuppressed().length);
+        assertEquals(ex, thrown.getSuppressed()[0]);
 
         verify(companyProfileService, times(1)).delete(COMPANY_NUMBER);
         verify(filingHistoryService, times(1)).delete(COMPANY_NUMBER);
@@ -340,23 +340,23 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void deleteCompanyDataMultipleExceptions() throws DataException {
-        DataException profileException = new DataException("exception");
+    void deleteCompanyDataMultipleExceptions() {
+        RuntimeException profileException = new RuntimeException("exception");
         when(companyProfileService.delete(COMPANY_NUMBER)).thenThrow(profileException);
 
-        DataException authCodeException = new DataException("exception");
+        RuntimeException authCodeException = new RuntimeException("exception");
         when(companyAuthCodeService.delete(COMPANY_NUMBER)).thenThrow(authCodeException);
 
-        DataException pscStatementException = new DataException("exception");
+        RuntimeException pscStatementException = new RuntimeException("exception");
         when(companyPscStatementService.delete(COMPANY_NUMBER)).thenThrow(pscStatementException);
 
         DataException thrown = assertThrows(DataException.class,
                 () -> this.testDataService.deleteCompanyData(COMPANY_NUMBER));
 
-        assertEquals(profileException, thrown);
-        assertEquals(2, thrown.getSuppressed().length);
-        assertEquals(authCodeException, thrown.getSuppressed()[0]);
-        assertEquals(pscStatementException, thrown.getSuppressed()[1]);
+        assertEquals(3, thrown.getSuppressed().length);
+        assertEquals(profileException, thrown.getSuppressed()[0]);
+        assertEquals(authCodeException, thrown.getSuppressed()[1]);
+        assertEquals(pscStatementException, thrown.getSuppressed()[2]);
 
         verify(companyProfileService, times(1)).delete(COMPANY_NUMBER);
         verify(filingHistoryService, times(1)).delete(COMPANY_NUMBER);


### PR DESCRIPTION
Services were catching `MongoException` unnecessarily since it isn't a checked exception. 
This was adding a mongo db dependency that services should not be aware of. And also explicitly propagating the exception everywhere, making the code harder to read.
We now let non-checked exceptions go up to the `TestDataService` where we catch them and wrap them into a relevant exception.