### PR TITLE
Remove unnecessary null check

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
@@ -58,7 +58,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         
         String message = "invalid request";
         Throwable cause = ex.getCause();
-        if (cause != null && cause instanceof InvalidFormatException) {
+        if (cause instanceof InvalidFormatException) {
             InvalidFormatException ife = (InvalidFormatException) cause;
             String pathReference = ife.getPathReference();
             if (pathReference != null && pathReference.startsWith(CompanySpec.class.getName())) {


### PR DESCRIPTION
Fix Sonar code smell: there's no need to null test in conjunction with an `instanceof` test. null is not an instanceof anything, so a null check is redundant.