### PR TITLE
Use latest version of Spring Security to verify auth codes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-spring-boot-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
         <relativePath/>
     </parent>
 
@@ -52,7 +52,7 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-helper-java</artifactId>
@@ -62,9 +62,8 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
-            <version>5.3.0.RELEASE</version>
         </dependency>
-        
+
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>structured-logging</artifactId>
@@ -87,6 +86,11 @@
             <groupId>org.sonarsource.scanner.maven</groupId>
             <artifactId>sonar-maven-plugin</artifactId>
             <version>${sonar-maven-plugin.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
+            <version>5.3.0.RELEASE</version>
         </dependency>
         
         <dependency>

--- a/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.mongo.MongoProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.data.mongodb.core.convert.DbRefResolver;
@@ -79,8 +80,8 @@ public class MongoConfig {
         return new MongoTemplate(simpleMongoDbFactory, mappingMongoConverter);
     }
 
-    private MappingMongoConverter getMappingMongoConverter(SimpleMongoClientDatabaseFactory simpleMongoDbFactory) {
-        DbRefResolver dbRefResolver = new DefaultDbRefResolver(simpleMongoDbFactory);
+    private MappingMongoConverter getMappingMongoConverter(MongoDatabaseFactory factory) {
+        DbRefResolver dbRefResolver = new DefaultDbRefResolver(factory);
         MappingMongoConverter mappingConverter = new MappingMongoConverter(dbRefResolver, new MongoMappingContext());
 
         // Don't save _class to mongo

--- a/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
@@ -6,9 +6,8 @@ import org.springframework.boot.autoconfigure.mongo.MongoProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.SimpleMongoClientDbFactory;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.data.mongodb.core.convert.DbRefResolver;
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
 import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
@@ -74,14 +73,14 @@ public class MongoConfig {
     }
 
     private MongoTemplate createMongoTemplate(final String database) {
-        SimpleMongoClientDbFactory simpleMongoDbFactory = new SimpleMongoClientDbFactory(
+        SimpleMongoClientDatabaseFactory simpleMongoDbFactory = new SimpleMongoClientDatabaseFactory(
                 MongoClients.create(this.mongoProperties.getUri()), database);
         MappingMongoConverter mappingMongoConverter = getMappingMongoConverter(simpleMongoDbFactory);
         return new MongoTemplate(simpleMongoDbFactory, mappingMongoConverter);
     }
 
-    private MappingMongoConverter getMappingMongoConverter(MongoDbFactory factory) {
-        DbRefResolver dbRefResolver = new DefaultDbRefResolver(factory);
+    private MappingMongoConverter getMappingMongoConverter(SimpleMongoClientDatabaseFactory simpleMongoDbFactory) {
+        DbRefResolver dbRefResolver = new DefaultDbRefResolver(simpleMongoDbFactory);
         MappingMongoConverter mappingConverter = new MappingMongoConverter(dbRefResolver, new MongoMappingContext());
 
         // Don't save _class to mongo

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImpl.java
@@ -70,18 +70,6 @@ public class CompanyAuthCodeServiceImpl implements CompanyAuthCodeService {
         String encryptedAuthCode = repository.findById(companyNumber)
                 .orElseThrow(() -> new NoDataFoundException(COMPANY_AUTH_DATA_NOT_FOUND)).getEncryptedAuthCode();
 
-        // Ideally we would use the following line to verify the encryption:
-        //
-        // return BCrypt.checkpw(sha256(plainAuthCode), encryptedAuthCode);
-        //
-        // However, the latest version of Spring Security at the time of developing this
-        // (5.2.1.RELEASE) does not provide a checkpw method accepting a byte[] as a
-        // password. It only expects a UTF-8 String but our password isn't UTF-8.
-        // That is why we need to verify it ourselves by just hashing the authcode using
-        // the same salt (present in the encrypted auth code) and then compare the
-        // hashed values.
-        String encrypted = BCrypt.hashpw(sha256(plainAuthCode), encryptedAuthCode);
-        return MessageDigest.isEqual(encryptedAuthCode.getBytes(StandardCharsets.UTF_8),
-                encrypted.getBytes(StandardCharsets.UTF_8));
+        return BCrypt.checkpw(sha256(plainAuthCode), encryptedAuthCode);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyAuthCodeServiceImplTest.java
@@ -69,17 +69,7 @@ class CompanyAuthCodeServiceImplTest {
         assertTrue(authCode.getIsActive());
         assertEquals(COMPANY_NUMBER, authCode.getId());
 
-        // Ideally we would use the following line to verify the encryption:
-        //
-        // assertTrue(BCrypt.checkpw(password, authCode.getEncryptedAuthCode()));
-        //
-        // However, the latest version of Spring Security at the time of developing this
-        // (5.2.1.RELEASE) does not provide a checkpw method accepting a byte[] as a
-        // password. It only expects a UTF-8 String but our password isn't UTF-8.
-        // That is why we need to verify it ourselves by just hashing the authcode using
-        // the same salt (present in the auth code) and then comparing the hashed
-        // values.
-        assertEquals(authCode.getEncryptedAuthCode(), BCrypt.hashpw(password, authCode.getEncryptedAuthCode()));
+         assertTrue(BCrypt.checkpw(password, authCode.getEncryptedAuthCode()));
     }
 
     @Test


### PR DESCRIPTION
Remove work around to verify encrypted auth codes by using the latest version of Spring Security which now provides this functionality

Resolves #54 