### PR TITLE
Remove redundant version of Spring Security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,13 +107,6 @@
         </dependency>
     </dependencies>
 
-    <repositories>
-        <repository>
-            <id>virtual-release</id>
-            <url>http://repository.aws.chdev.org:8081/artifactory/virtual-release</url>
-        </repository>
-    </repositories>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
-            <version>5.3.3.RELEASE</version>
         </dependency>
-
 
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>


### PR DESCRIPTION
We don't need to specify the version of Spring Security as this is defined by the Spring Boot dependencies.

The configured version of [Spring Boot 2.3.1.RELEASE](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/2.3.1.RELEASE) uses Spring Security 5.3.3.RELEASE