### PR TITLE
added pscs to data created by generator

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyPscs.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyPscs.java
@@ -1,0 +1,167 @@
+package uk.gov.companieshouse.api.testdata.model.entity;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.time.Instant;
+import java.util.List;
+
+@Document(collection = "company_pscs")
+public class CompanyPscs{
+
+
+    @Id
+    @Field("_id")
+    private String id;
+    @Field("delta_at")
+    private String deltaAt;
+    @Field("data.natures_of_control")
+    private List<String> naturesOfControl;
+    @Field("data.kind")
+    private String kind;
+    @Field("data.name_elements.middle_name")
+    private String middleName;
+    @Field("data.name_elements.forename")
+    private String forename;
+    @Field("data.name_elements.title")
+    private String title;
+    @Field("data.name_elements.surname")
+    private String surname;
+    @Field("data.name")
+    private String name;
+    @Field("data.notified_on")
+    private Instant notifiedOn;
+    @Field("data.nationality")
+    private String nationality;
+    @Field("data.address.postal_code")
+    private String postalCode;
+    @Field("data.address.premises")
+    private String premises;
+    @Field("data.address.locality")
+    private String locality;
+    @Field("data.address.country")
+    private String country;
+    @Field("data.address.address_line_1")
+    private String addressLine1;
+    @Field("data.country_of_residence")
+    private String countryOfResidence;
+    @Field("data.date_of_birth")
+    private Instant dateOfBirth;
+    @Field("data.links.self")
+    private Links self;
+    @Field("data.etag")
+    private String etag;
+    @Field("company_number")
+    private String companyNumber;
+    @Field("psc_id")
+    private  String pscId;
+    @Field("updated.at")
+    private Instant updatedAt;
+    @Field("notification_id")
+    private String notificationId;
+    @Field("created.at")
+    private Instant createdAt;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) { this.id = id; }
+
+    public String getDeltaAt() { return deltaAt; }
+
+    public void setDeltaAt(String deltaAt) {this.deltaAt = deltaAt; }
+
+    public List<String> getNaturesOfControl() { return naturesOfControl; }
+
+    public void setNaturesOfControl(List<String> naturesOfControl) { this.naturesOfControl = naturesOfControl; }
+
+    public String getKind() { return kind; }
+
+    public void setKind(String kind) { this.kind = kind; }
+
+    public String getMiddleName() { return middleName; }
+
+    public void setMiddleName(String middleName) { this.middleName = middleName; }
+
+    public String getForename() { return forename; }
+
+    public void setForename(String forename) { this.forename = forename; }
+
+    public String getTitle() { return title; }
+
+    public void setTitle(String title) { this.title = title; }
+
+    public String getSurname() { return surname; }
+
+    public void setSurname(String surname) { this.surname = surname; }
+
+    public String getName() { return name; }
+
+    public void setName(String name) { this.name = name; }
+
+    public Instant getNotifiedOn() { return notifiedOn; }
+
+    public void setNotifiedOn(Instant notifiedOn) { this.notifiedOn = notifiedOn; }
+
+    public String getNationality() { return nationality; }
+
+    public void setNationality(String nationality) { this.nationality = nationality; }
+
+    public String getPostalCode() { return postalCode; }
+
+    public void setPostalCode(String postalCode) { this.postalCode = postalCode; }
+
+    public String getPremises() { return premises; }
+
+    public void setPremises(String premises) { this.premises = premises; }
+
+    public String getLocality() { return locality; }
+
+    public void setLocality(String locality) { this.locality = locality; }
+
+    public String getCountry() { return country; }
+
+    public void setCountry(String country) { this.country = country; }
+
+    public String getAddressLine1() { return addressLine1; }
+
+    public void setAddressLine1(String addressLine1) { this.addressLine1 = addressLine1; }
+
+    public String getCountryOfResidence() { return countryOfResidence; }
+
+    public void setCountryOfResidence(String countryOfResidence) { this.countryOfResidence = countryOfResidence; }
+
+    public Instant getDateOfBirth() { return dateOfBirth; }
+
+    public void setDateOfBirth(Instant dateOfBirth) { this.dateOfBirth = dateOfBirth; }
+
+    public Links getSelf() { return self; }
+
+    public void setSelf(Links self) { this.self = self; }
+
+    public String getEtag() { return etag; }
+
+    public void setEtag(String etag) { this.etag = etag; }
+
+    public String getCompanyNumber() { return companyNumber; }
+
+    public void setCompanyNumber(String companyNumber) { this.companyNumber = companyNumber; }
+
+    public String getPscId() { return pscId; }
+
+    public void setPscId(String pscId) { this.pscId = pscId; }
+
+    public Instant getUpdatedAt() { return updatedAt; }
+
+    public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+
+    public String getNotificationId() { return notificationId; }
+
+    public void setNotificationId(String notificationId) { this.notificationId = notificationId; }
+
+    public Instant getCreatedAt() { return createdAt; }
+
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/repository/CompanyPscsRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/repository/CompanyPscsRepository.java
@@ -1,0 +1,12 @@
+package uk.gov.companieshouse.api.testdata.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscs;
+
+import java.util.Optional;
+
+@NoRepositoryBean
+public interface CompanyPscsRepository extends MongoRepository<CompanyPscs, String> {
+    Optional<CompanyPscs> findByCompanyNumber(String companyNumber);
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
@@ -62,9 +62,7 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs> {
         companyPsc.setPscId(randomService.getString(30));
         companyPsc.setNotificationId(randomService.getString(30));
 
-        companyPsc = differentiatePsc(companyPsc);
-
-        return repository.save(companyPsc);
+        return repository.save(differentiatePsc(companyPsc));
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
@@ -1,0 +1,106 @@
+package uk.gov.companieshouse.api.testdata.service.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscs;
+import uk.gov.companieshouse.api.testdata.model.entity.Links;
+import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
+import uk.gov.companieshouse.api.testdata.repository.CompanyPscsRepository;
+import uk.gov.companieshouse.api.testdata.service.DataService;
+import uk.gov.companieshouse.api.testdata.service.RandomService;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.Optional;
+
+public class CompanyPscsServiceImpl implements DataService<CompanyPscs> {
+
+    private static final int ID_LENGTH = 10;
+    private static final int SALT_LENGTH = 8;
+
+    @Autowired
+    private RandomService randomService;
+
+    @Autowired
+    private CompanyPscsRepository repository;
+
+
+    @Override
+    public CompanyPscs create(CompanySpec spec) throws DataException {
+
+        final String companyNumber = spec.getCompanyNumber();
+        CompanyPscs companyPsc = new CompanyPscs();
+
+        Instant dateTimeNow = Instant.now();
+        Instant dateNow = LocalDate.now().atStartOfDay(ZoneId.of("UTC")).toInstant();
+
+        String id = this.randomService.getEncodedIdWithSalt(ID_LENGTH, SALT_LENGTH);
+        companyPsc.setId(id);
+        companyPsc.setCreatedAt(dateTimeNow);
+        companyPsc.setUpdatedAt(dateTimeNow);
+        companyPsc.setCompanyNumber(companyNumber);
+
+        companyPsc.setNaturesOfControl(Collections.singletonList("voting-rights-75-to-100-percent-as-trust"));
+        companyPsc.setMiddleName("middle");
+        companyPsc.setForename("forename");
+        companyPsc.setTitle("Mrs");
+        companyPsc.setDateOfBirth(Instant.now().minus( 69, ChronoUnit.DAYS));
+        companyPsc.setNationality("British");
+        companyPsc.setPostalCode("CF14 3UZ");
+        companyPsc.setPremises("1");
+        companyPsc.setLocality("Cardiff");
+        companyPsc.setCountry("Wales");
+        companyPsc.setAddressLine1("34 Silver Street");
+        companyPsc.setCountryOfResidence("Wales");
+
+        companyPsc.setNotifiedOn(dateNow);
+        String etag = this.randomService.getEtag();
+        companyPsc.setEtag(etag);
+        companyPsc.setPscId(randomService.getString(30));
+        companyPsc.setNotificationId(randomService.getString(30));
+
+        companyPsc = differentiatePsc(companyPsc);
+
+        return repository.save(companyPsc);
+    }
+
+    @Override
+    public boolean delete(String companyNumber) {
+        Optional<CompanyPscs> existingPscs = repository.findByCompanyNumber(companyNumber);
+        existingPscs.ifPresent(repository::delete);
+        return existingPscs.isPresent();
+    }
+
+    private CompanyPscs differentiatePsc(CompanyPscs companyPsc) {
+
+        String pscType;
+        String linkType;
+
+        switch ((int) repository.count()){
+            case 0:
+                pscType = "individual-person-with-significant-control";
+                linkType = "individual";
+                break;
+            case 1:
+                pscType = "legal-person-person-with-significant-control";
+                linkType = "legal-person";
+                break;
+            default:
+                pscType = "corporate-entity-person-with-significant-control";
+                linkType = "corporate-entity";
+        }
+
+        companyPsc.setKind(pscType);
+        companyPsc.setSurname(pscType);
+        companyPsc.setName(companyPsc.getTitle() + " " + companyPsc.getForename()
+                + " " + companyPsc.getMiddleName() + " " + companyPsc.getSurname());
+
+        Links links = new Links();
+        links.setSelf("/company/" + companyPsc.getCompanyNumber() + "/persons-with-significant-control/" + linkType +"/" + companyPsc.getId());
+        companyPsc.setSelf(links);
+        return companyPsc;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -9,11 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.testdata.Application;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.model.entity.Appointment;
-import uk.gov.companieshouse.api.testdata.model.entity.CompanyAuthCode;
-import uk.gov.companieshouse.api.testdata.model.entity.CompanyMetrics;
-import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscStatement;
-import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
+import uk.gov.companieshouse.api.testdata.model.entity.*;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanyData;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.service.CompanyAuthCodeService;
@@ -43,6 +39,8 @@ public class TestDataServiceImpl implements TestDataService {
     @Autowired
     private DataService<CompanyPscStatement> companyPscStatementService;
     @Autowired
+    private DataService<CompanyPscs> companyPscsService;
+    @Autowired
     private RandomService randomService;
 
     @Value("${api.url}")
@@ -71,6 +69,9 @@ public class TestDataServiceImpl implements TestDataService {
             CompanyAuthCode authCode = this.companyAuthCodeService.create(spec);
             this.companyMetricsService.create(spec);
             this.companyPscStatementService.create(spec);
+            this.companyPscsService.create(spec);
+            this.companyPscsService.create(spec);
+            this.companyPscsService.create(spec);
 
             String companyUri = this.apiUrl + "/company/" + spec.getCompanyNumber();
             return new CompanyData(spec.getCompanyNumber(), authCode.getAuthCode(), companyUri);
@@ -109,6 +110,11 @@ public class TestDataServiceImpl implements TestDataService {
         }
         try {
             this.companyPscStatementService.delete(companyId);
+        } catch (Exception de) {
+            suppressedExceptions.add(de);
+        }
+        try {
+            this.companyPscsService.delete(companyId);
         } catch (Exception de) {
             suppressedExceptions.add(de);
         }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImplTest.java
@@ -86,6 +86,70 @@ class CompanyPscsServiceImplTest {
     }
 
     @Test
+    void createWhenThereIsAlreadyASinglePsc() throws DataException {
+        CompanySpec spec = new CompanySpec();
+        spec.setCompanyNumber(COMPANY_NUMBER);
+
+        when(this.randomService.getString(30)).thenReturn(ENCODED_VALUE);
+        when(this.randomService.getEncodedIdWithSalt(ID_LENGTH, SALT_LENGTH)).thenReturn(ENCODED_VALUE);
+
+        when(this.randomService.getEtag()).thenReturn(ETAG);
+        CompanyPscs savedPsc = new CompanyPscs();
+        when(this.repository.save(any())).thenReturn(savedPsc);
+
+        when(repository.count()).thenReturn(1L);
+        CompanyPscs returnedPsc = this.companyPscsService.create(spec);
+
+        assertEquals(savedPsc, returnedPsc);
+
+        ArgumentCaptor<CompanyPscs> pscCaptor = ArgumentCaptor.forClass(CompanyPscs.class);
+        verify(repository).save(pscCaptor.capture());
+
+        CompanyPscs companyPsc = pscCaptor.getValue();
+        assertNotNull(companyPsc);
+
+
+        assertEquals("Mrs forename middle legal-person-person-with-significant-control", companyPsc.getName());
+        assertEquals("legal-person-person-with-significant-control", companyPsc.getKind());
+
+        Links links = companyPsc.getSelf();
+        assertEquals("/company/" + COMPANY_NUMBER + "/persons-with-significant-control/legal-person/" + ENCODED_VALUE,
+                links.getSelf());
+    }
+
+    @Test
+    void createWhenThereAreAlreadyTwoPscs() throws DataException {
+        CompanySpec spec = new CompanySpec();
+        spec.setCompanyNumber(COMPANY_NUMBER);
+
+        when(this.randomService.getString(30)).thenReturn(ENCODED_VALUE);
+        when(this.randomService.getEncodedIdWithSalt(ID_LENGTH, SALT_LENGTH)).thenReturn(ENCODED_VALUE);
+
+        when(this.randomService.getEtag()).thenReturn(ETAG);
+        CompanyPscs savedPsc = new CompanyPscs();
+        when(this.repository.save(any())).thenReturn(savedPsc);
+
+        when(repository.count()).thenReturn(2L);
+        CompanyPscs returnedPsc = this.companyPscsService.create(spec);
+
+        assertEquals(savedPsc, returnedPsc);
+
+        ArgumentCaptor<CompanyPscs> pscCaptor = ArgumentCaptor.forClass(CompanyPscs.class);
+        verify(repository).save(pscCaptor.capture());
+
+        CompanyPscs companyPsc = pscCaptor.getValue();
+        assertNotNull(companyPsc);
+
+
+        assertEquals("Mrs forename middle corporate-entity-person-with-significant-control", companyPsc.getName());
+        assertEquals("corporate-entity-person-with-significant-control", companyPsc.getKind());
+
+        Links links = companyPsc.getSelf();
+        assertEquals("/company/" + COMPANY_NUMBER + "/persons-with-significant-control/corporate-entity/" + ENCODED_VALUE,
+                links.getSelf());
+    }
+
+    @Test
     void delete() {
         CompanyPscs companyPscs = new CompanyPscs();
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(companyPscs));

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImplTest.java
@@ -1,0 +1,106 @@
+package uk.gov.companieshouse.api.testdata.service.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscs;
+import uk.gov.companieshouse.api.testdata.model.entity.Links;
+import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
+import uk.gov.companieshouse.api.testdata.repository.CompanyPscsRepository;
+import uk.gov.companieshouse.api.testdata.service.RandomService;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CompanyPscsServiceImplTest {
+
+    private static final int ID_LENGTH = 10;
+    private static final int SALT_LENGTH = 8;
+    private static final String COMPANY_NUMBER = "12345678";
+    private static final String ENCODED_VALUE = "ENCODED";
+    private static final String ETAG = "ETAG";
+
+    @Mock
+    private CompanyPscsRepository repository;
+    @Mock
+    private RandomService randomService;
+
+    @InjectMocks
+    private CompanyPscsServiceImpl companyPscsService;
+
+    @Test
+    void create() throws DataException {
+        CompanySpec spec = new CompanySpec();
+        spec.setCompanyNumber(COMPANY_NUMBER);
+
+        when(this.randomService.getString(30)).thenReturn(ENCODED_VALUE);
+        when(this.randomService.getEncodedIdWithSalt(ID_LENGTH, SALT_LENGTH)).thenReturn(ENCODED_VALUE);
+
+        when(this.randomService.getEtag()).thenReturn(ETAG);
+        CompanyPscs savedPsc = new CompanyPscs();
+        when(this.repository.save(any())).thenReturn(savedPsc);
+
+        CompanyPscs returnedPsc = this.companyPscsService.create(spec);
+
+        assertEquals(savedPsc, returnedPsc);
+
+        ArgumentCaptor<CompanyPscs> pscCaptor = ArgumentCaptor.forClass(CompanyPscs.class);
+        verify(repository).save(pscCaptor.capture());
+
+        CompanyPscs companyPsc = pscCaptor.getValue();
+        assertNotNull(companyPsc);
+        assertEquals(ENCODED_VALUE, companyPsc.getId());
+        assertNotNull(companyPsc.getCreatedAt());
+        assertNotNull(companyPsc.getUpdatedAt());
+        assertEquals(COMPANY_NUMBER, companyPsc.getCompanyNumber());
+
+        assertEquals("voting-rights-75-to-100-percent-as-trust", companyPsc.getNaturesOfControl().get(0));
+        assertEquals("Mrs forename middle individual-person-with-significant-control", companyPsc.getName());
+        assertEquals("British", companyPsc.getNationality());
+        assertNotNull(companyPsc.getDateOfBirth());
+        assertEquals("individual-person-with-significant-control", companyPsc.getKind());
+
+        assertEquals("CF14 3UZ", companyPsc.getPostalCode());
+        assertEquals("1", companyPsc.getPremises());
+        assertEquals("Cardiff",companyPsc.getLocality());
+        assertEquals("Wales",companyPsc.getCountry());
+        assertEquals("34 Silver Street", companyPsc.getAddressLine1());
+        assertEquals("Wales", companyPsc.getCountryOfResidence());
+
+        Links links = companyPsc.getSelf();
+        assertEquals("/company/" + COMPANY_NUMBER + "/persons-with-significant-control/individual/" + ENCODED_VALUE,
+                links.getSelf());
+
+        assertNotNull(companyPsc.getNotifiedOn());
+        assertEquals(ETAG, companyPsc.getEtag());
+        assertEquals(ENCODED_VALUE, companyPsc.getPscId());
+        assertEquals(ENCODED_VALUE, companyPsc.getNotificationId());
+    }
+
+    @Test
+    void delete() {
+        CompanyPscs companyPscs = new CompanyPscs();
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(companyPscs));
+
+        assertTrue(this.companyPscsService.delete(COMPANY_NUMBER));
+        verify(repository).delete(companyPscs);
+    }
+
+    @Test
+    void deleteNoDataException() {
+        CompanyPscs companyPscs = null;
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.ofNullable(companyPscs));
+
+        assertFalse(this.companyPscsService.delete(COMPANY_NUMBER));
+        verify(repository, never()).delete(companyPscs);
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
@@ -25,6 +25,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.CompanyMetrics;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscStatement;
 import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
+import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscs;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanyData;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.model.rest.Jurisdiction;
@@ -56,6 +57,9 @@ class TestDataServiceImplTest {
     private DataService<CompanyMetrics> metricsService;
     @Mock
     private DataService<CompanyPscStatement> companyPscStatementService;
+    @Mock
+    private DataService<CompanyPscs> companyPscsService;
+
     @Mock
     private RandomService randomService;
     @InjectMocks
@@ -100,6 +104,7 @@ class TestDataServiceImplTest {
         verify(appointmentService, times(1)).create(expectedSpec);
         verify(companyPscStatementService, times(1)).create(expectedSpec);
         verify(metricsService, times(1)).create(expectedSpec);
+        verify(companyPscsService, times(3)).create(expectedSpec);
 
         assertEquals(COMPANY_NUMBER, createdCompany.getCompanyNumber());
         assertEquals(API_URL + "/company/" + COMPANY_NUMBER, createdCompany.getCompanyUri());
@@ -137,6 +142,7 @@ class TestDataServiceImplTest {
         verify(appointmentService, times(1)).create(expectedSpec);
         verify(companyPscStatementService, times(1)).create(expectedSpec);
         verify(metricsService, times(1)).create(expectedSpec);
+        verify(companyPscsService, times(3)).create(expectedSpec);
 
         assertEquals(fullCompanyNumber, createdCompany.getCompanyNumber());
         assertEquals(API_URL + "/company/" + fullCompanyNumber, createdCompany.getCompanyUri());
@@ -174,6 +180,7 @@ class TestDataServiceImplTest {
         verify(appointmentService, times(1)).create(expectedSpec);
         verify(companyPscStatementService, times(1)).create(expectedSpec);
         verify(metricsService, times(1)).create(expectedSpec);
+        verify(companyPscsService, times(3)).create(expectedSpec);
 
         assertEquals(fullCompanyNumber, createdCompany.getCompanyNumber());
         assertEquals(API_URL + "/company/" + fullCompanyNumber, createdCompany.getCompanyUri());
@@ -215,6 +222,7 @@ class TestDataServiceImplTest {
         verify(appointmentService, times(1)).create(expectedSpec);
         verify(companyPscStatementService, times(1)).create(expectedSpec);
         verify(metricsService, times(1)).create(expectedSpec);
+        verify(companyPscsService, times(3)).create(expectedSpec);
 
         assertEquals(fullCompanyNumber, createdCompany.getCompanyNumber());
         assertEquals(API_URL + "/company/" + fullCompanyNumber, createdCompany.getCompanyUri());
@@ -244,7 +252,7 @@ class TestDataServiceImplTest {
         verify(companyAuthCodeService).create(expectedSpec);
         verify(appointmentService).create(expectedSpec);
         verify(metricsService).create(expectedSpec);
-        
+
         // Verify we roll back data
         verify(companyProfileService).delete(fullCompanyNumber);
         verify(filingHistoryService).delete(fullCompanyNumber);
@@ -252,6 +260,7 @@ class TestDataServiceImplTest {
         verify(appointmentService).delete(fullCompanyNumber);
         verify(companyPscStatementService).delete(fullCompanyNumber);
         verify(metricsService).delete(fullCompanyNumber);
+        verify(companyPscsService,times(1)).delete(fullCompanyNumber);
     }
 
     @Test
@@ -263,6 +272,7 @@ class TestDataServiceImplTest {
         verify(companyAuthCodeService, times(1)).delete(COMPANY_NUMBER);
         verify(appointmentService, times(1)).delete(COMPANY_NUMBER);
         verify(companyPscStatementService, times(1)).delete(COMPANY_NUMBER);
+        verify(companyPscsService, times(1)).delete(COMPANY_NUMBER);
         verify(metricsService, times(1)).delete(COMPANY_NUMBER);
     }
 
@@ -276,6 +286,7 @@ class TestDataServiceImplTest {
         verify(companyAuthCodeService, never()).delete(COMPANY_NUMBER);
         verify(appointmentService, never()).delete(COMPANY_NUMBER);
         verify(companyPscStatementService, never()).delete(COMPANY_NUMBER);
+        verify(companyPscsService, never()).delete(COMPANY_NUMBER);
         verify(metricsService, never()).delete(COMPANY_NUMBER);
     }
 
@@ -296,6 +307,7 @@ class TestDataServiceImplTest {
         verify(appointmentService, times(1)).delete(COMPANY_NUMBER);
         verify(companyPscStatementService, times(1)).delete(COMPANY_NUMBER);
         verify(metricsService, times(1)).delete(COMPANY_NUMBER);
+        verify(companyPscsService, times(1)).delete(COMPANY_NUMBER);
     }
 
     @Test
@@ -315,6 +327,7 @@ class TestDataServiceImplTest {
         verify(appointmentService, times(1)).delete(COMPANY_NUMBER);
         verify(companyPscStatementService, times(1)).delete(COMPANY_NUMBER);
         verify(metricsService, times(1)).delete(COMPANY_NUMBER);
+        verify(companyPscsService, times(1)).delete(COMPANY_NUMBER);
     }
 
     @Test
@@ -334,6 +347,7 @@ class TestDataServiceImplTest {
         verify(appointmentService, times(1)).delete(COMPANY_NUMBER);
         verify(companyPscStatementService, times(1)).delete(COMPANY_NUMBER);
         verify(metricsService, times(1)).delete(COMPANY_NUMBER);
+        verify(companyPscsService, times(1)).delete(COMPANY_NUMBER);
     }
 
     @Test
@@ -353,6 +367,7 @@ class TestDataServiceImplTest {
         verify(appointmentService, times(1)).delete(COMPANY_NUMBER);
         verify(companyPscStatementService, times(1)).delete(COMPANY_NUMBER);
         verify(metricsService, times(1)).delete(COMPANY_NUMBER);
+        verify(companyPscsService, times(1)).delete(COMPANY_NUMBER);
     }
 
     @Test
@@ -372,6 +387,28 @@ class TestDataServiceImplTest {
         verify(appointmentService, times(1)).delete(COMPANY_NUMBER);
         verify(companyPscStatementService, times(1)).delete(COMPANY_NUMBER);
         verify(metricsService, times(1)).delete(COMPANY_NUMBER);
+        verify(companyPscsService, times(1)).delete(COMPANY_NUMBER);
+    }
+
+    @Test
+    void deleteCompanyDataPscsException() {
+        RuntimeException ex = new RuntimeException("exception");
+        when(companyPscsService.delete(COMPANY_NUMBER)).thenThrow(ex);
+
+        DataException thrown = assertThrows(DataException.class,
+                () -> this.testDataService.deleteCompanyData(COMPANY_NUMBER));
+
+        assertEquals(1, thrown.getSuppressed().length);
+        assertEquals(ex, thrown.getSuppressed()[0]);
+
+        verify(companyProfileService, times(1)).delete(COMPANY_NUMBER);
+        verify(filingHistoryService, times(1)).delete(COMPANY_NUMBER);
+        verify(companyAuthCodeService, times(1)).delete(COMPANY_NUMBER);
+        verify(appointmentService, times(1)).delete(COMPANY_NUMBER);
+        verify(companyPscStatementService, times(1)).delete(COMPANY_NUMBER);
+        verify(metricsService, times(1)).delete(COMPANY_NUMBER);
+        verify(companyPscsService, times(1)).delete(COMPANY_NUMBER);
+
     }
 
     @Test
@@ -391,6 +428,7 @@ class TestDataServiceImplTest {
         verify(appointmentService, times(1)).delete(COMPANY_NUMBER);
         verify(companyPscStatementService, times(1)).delete(COMPANY_NUMBER);
         verify(metricsService, times(1)).delete(COMPANY_NUMBER);
+        verify(companyPscsService, times(1)).delete(COMPANY_NUMBER);
     }
 
     @Test
@@ -417,6 +455,7 @@ class TestDataServiceImplTest {
         verify(companyAuthCodeService, times(1)).delete(COMPANY_NUMBER);
         verify(appointmentService, times(1)).delete(COMPANY_NUMBER);
         verify(companyPscStatementService, times(1)).delete(COMPANY_NUMBER);
+        verify(companyPscsService, times(1)).delete(COMPANY_NUMBER);
         verify(metricsService, times(1)).delete(COMPANY_NUMBER);
     }
 }


### PR DESCRIPTION
JIRA Ticket: https://companieshouse.atlassian.net/browse/BI-10902

Added PSCs to the data being created when a user generates a test company.
Three PSCS of types individual, legal entity and corporate entity are now associated with every company created by the test generator.
Also added unit tests for the new classes and modified existing tests where appropriate 