### PR TITLE
Fix issue with creation of company PSCs

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyPscs.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyPscs.java
@@ -47,8 +47,8 @@ public class CompanyPscs{
     private String countryOfResidence;
     @Field("data.date_of_birth")
     private Instant dateOfBirth;
-    @Field("data.links.self")
-    private Links self;
+    @Field("data.links")
+    private Links links;
     @Field("data.etag")
     private String etag;
     @Field("company_number")
@@ -136,9 +136,9 @@ public class CompanyPscs{
 
     public void setDateOfBirth(Instant dateOfBirth) { this.dateOfBirth = dateOfBirth; }
 
-    public Links getSelf() { return self; }
+    public Links getLinks() { return links; }
 
-    public void setSelf(Links self) { this.self = self; }
+    public void setLinks(Links links) { this.links = links; }
 
     public String getEtag() { return etag; }
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -79,8 +80,9 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs> {
 
         String pscType;
         String linkType;
+        Optional<List<CompanyPscs>> existingPscs = repository.findByCompanyNumber(companyPsc.getCompanyNumber());
 
-        switch ((int) repository.count()){
+        switch (existingPscs.orElse(new ArrayList<>()).size()){
             case 0:
                 pscType = "individual-person-with-significant-control";
                 linkType = "individual";
@@ -101,7 +103,7 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs> {
 
         Links links = new Links();
         links.setSelf("/company/" + companyPsc.getCompanyNumber() + "/persons-with-significant-control/" + linkType +"/" + companyPsc.getId());
-        companyPsc.setSelf(links);
+        companyPsc.setLinks(links);
         return companyPsc;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImplTest.java
@@ -77,7 +77,7 @@ class CompanyPscsServiceImplTest {
         assertEquals("34 Silver Street", companyPsc.getAddressLine1());
         assertEquals("Wales", companyPsc.getCountryOfResidence());
 
-        Links links = companyPsc.getSelf();
+        Links links = companyPsc.getLinks();
         assertEquals("/company/" + COMPANY_NUMBER + "/persons-with-significant-control/individual/" + ENCODED_VALUE,
                 links.getSelf());
 
@@ -98,8 +98,9 @@ class CompanyPscsServiceImplTest {
         when(this.randomService.getEtag()).thenReturn(ETAG);
         CompanyPscs savedPsc = new CompanyPscs();
         when(this.repository.save(any())).thenReturn(savedPsc);
+        
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(buildListOfCompanyPscs(1)));
 
-        when(repository.count()).thenReturn(1L);
         CompanyPscs returnedPsc = this.companyPscsService.create(spec);
 
         assertEquals(savedPsc, returnedPsc);
@@ -114,7 +115,7 @@ class CompanyPscsServiceImplTest {
         assertEquals("Mrs forename middle legal-person-person-with-significant-control", companyPsc.getName());
         assertEquals("legal-person-person-with-significant-control", companyPsc.getKind());
 
-        Links links = companyPsc.getSelf();
+        Links links = companyPsc.getLinks();
         assertEquals("/company/" + COMPANY_NUMBER + "/persons-with-significant-control/legal-person/" + ENCODED_VALUE,
                 links.getSelf());
     }
@@ -131,7 +132,8 @@ class CompanyPscsServiceImplTest {
         CompanyPscs savedPsc = new CompanyPscs();
         when(this.repository.save(any())).thenReturn(savedPsc);
 
-        when(repository.count()).thenReturn(2L);
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(buildListOfCompanyPscs(2)));
+
         CompanyPscs returnedPsc = this.companyPscsService.create(spec);
 
         assertEquals(savedPsc, returnedPsc);
@@ -146,7 +148,7 @@ class CompanyPscsServiceImplTest {
         assertEquals("Mrs forename middle corporate-entity-person-with-significant-control", companyPsc.getName());
         assertEquals("corporate-entity-person-with-significant-control", companyPsc.getKind());
 
-        Links links = companyPsc.getSelf();
+        Links links = companyPsc.getLinks();
         assertEquals("/company/" + COMPANY_NUMBER + "/persons-with-significant-control/corporate-entity/" + ENCODED_VALUE,
                 links.getSelf());
     }
@@ -169,4 +171,15 @@ class CompanyPscsServiceImplTest {
         verify(repository, never()).deleteAll(companyPscs);
     }
 
+    private List<CompanyPscs> buildListOfCompanyPscs(int howManyPscs) {
+
+        List<CompanyPscs> listOfCompanyPscs = new ArrayList<>();
+        CompanyPscs aCompanyPsc = new CompanyPscs();
+
+        for(int i = 0; i < howManyPscs; i++) {
+        	listOfCompanyPscs.add(aCompanyPsc);
+        }
+        
+        return listOfCompanyPscs;
+    }
 }


### PR DESCRIPTION
The self link on a company PSC was incorrect. In the links object it would create another object called self which would contain an item called self.
In CompanyPscs.java changed the Field annotation for links to data.links. Renamed the field to links and any references.
The creation of the PSCs would always create a corporate PSC when checking the count of all PSCs in the repository. Changed this to only check the number of PSCs created for the test company the PSCs are being created for.
Updated unit tests

BI-11762