### PR TITLE
bugfix-367 changed to set psc statement misspelt as in api enumeration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>2.7.0</version>
+                <version>3.1.4</version>
                 <configuration>
                     <container>
                         <expandClasspathDependencies>true</expandClasspathDependencies>

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.java
@@ -27,6 +27,13 @@ public class CompanyPscStatementServiceImpl implements DataService<CompanyPscSta
     @Autowired
     private CompanyPscStatementRepository repository;
 
+    /**
+     * creates PSC statement deliberately misspelt as 'signficant' to match api-enumeration and live data
+     * can be corrected when api-enumeration is fixed.
+     * psc-statement-data-api java services utilises the enum values and correct spelling will cause failures in environments that run the java service
+     * @param spec
+     * @return
+     */
     @Override
     public CompanyPscStatement create(CompanySpec spec) {
         final String companyNumber = spec.getCompanyNumber();
@@ -51,7 +58,7 @@ public class CompanyPscStatementServiceImpl implements DataService<CompanyPscSta
         companyPscStatement.setEtag(etag);
 
         companyPscStatement.setKind("persons-with-significant-control-statement");
-        companyPscStatement.setStatement("no-individual-or-entity-with-significant-control");
+        companyPscStatement.setStatement("no-individual-or-entity-with-signficant-control");
 
         companyPscStatement.setCreatedAt(dateTimeNow);
 

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java
@@ -70,7 +70,7 @@ class CompanyPscStatementServiceImplTest {
         assertNotNull(statement.getNotifiedOn());
         assertEquals(ETAG, statement.getEtag());
         assertEquals("persons-with-significant-control-statement", statement.getKind());
-        assertEquals("no-individual-or-entity-with-significant-control", statement.getStatement());
+        assertEquals("no-individual-or-entity-with-signficant-control", statement.getStatement());
 
         assertNotNull(statement.getCreatedAt());
 


### PR DESCRIPTION
api-enumeration has the wrong spelling for psc statement description. The TDG has to create the psc statement with the spelling error to avoid unexpected enum value error when making a call to the psc-statement-data-api.