### PR TITLE
changed the format the psc dob is saved as from an instant to an object

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/Appointment.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/Appointment.java
@@ -61,7 +61,16 @@ public class Appointment {
     private String surname;
 
     @Field("sensitive_data.date_of_birth")
-    private Instant dateOfBirth;
+    private DateOfBirth dateOfBirth;
+
+    @Field("data.date_of_birth.day")
+    private Integer day;
+
+    @Field("data.date_of_birth.month")
+    private Integer month;
+
+    @Field("data.date_of_birth.year")
+    private Integer year;
 
     @Field("company_name")
     private String companyName;
@@ -214,12 +223,30 @@ public class Appointment {
         this.surname = surname;
     }
 
-    public Instant getDateOfBirth() {
+    public DateOfBirth getDateOfBirth() {
         return dateOfBirth;
     }
 
-    public void setDateOfBirth(Instant dateOfBirth) {
+    public void setDateOfBirth(DateOfBirth dateOfBirth) {
         this.dateOfBirth = dateOfBirth;
+    }
+
+    public Integer getDay() { return day; }
+
+    public void setDay(Integer day) {
+        this.day = day;
+    }
+
+    public Integer getMonth() { return month; }
+
+    public void setMonth(Integer month) {
+        this.month = month;
+    }
+
+    public Integer getYear() { return year; }
+
+    public void setYear(Integer year) {
+        this.year = year;
     }
 
     public String getCompanyName() {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/Appointment.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/Appointment.java
@@ -61,16 +61,7 @@ public class Appointment {
     private String surname;
 
     @Field("sensitive_data.date_of_birth")
-    private DateOfBirth dateOfBirth;
-
-    @Field("data.date_of_birth.day")
-    private Integer day;
-
-    @Field("data.date_of_birth.month")
-    private Integer month;
-
-    @Field("data.date_of_birth.year")
-    private Integer year;
+    private Instant dateOfBirth;
 
     @Field("company_name")
     private String companyName;
@@ -223,30 +214,12 @@ public class Appointment {
         this.surname = surname;
     }
 
-    public DateOfBirth getDateOfBirth() {
+    public Instant getDateOfBirth() {
         return dateOfBirth;
     }
 
-    public void setDateOfBirth(DateOfBirth dateOfBirth) {
+    public void setDateOfBirth(Instant dateOfBirth) {
         this.dateOfBirth = dateOfBirth;
-    }
-
-    public Integer getDay() { return day; }
-
-    public void setDay(Integer day) {
-        this.day = day;
-    }
-
-    public Integer getMonth() { return month; }
-
-    public void setMonth(Integer month) {
-        this.month = month;
-    }
-
-    public Integer getYear() { return year; }
-
-    public void setYear(Integer year) {
-        this.year = year;
     }
 
     public String getCompanyName() {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyPscs.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyPscs.java
@@ -62,7 +62,13 @@ public class CompanyPscs{
     @Field("data.statement_type")
     private String statementType;
     @Field("sensitive_data.date_of_birth")
-    private Instant dateOfBirth;
+    private DateOfBirth dateOfBirth;
+    @Field("data.date_of_birth.day")
+    private Integer day;
+    @Field("data.date_of_birth.month")
+    private Integer month;
+    @Field("data.date_of_birth.year")
+    private Integer year;
     @Field("data.links")
     private Links links;
     @Field("data.etag")
@@ -230,9 +236,27 @@ public class CompanyPscs{
 
     public void setCountryOfResidence(String countryOfResidence) { this.countryOfResidence = countryOfResidence; }
 
-    public Instant getDateOfBirth() { return dateOfBirth; }
+    public DateOfBirth getDateOfBirth() { return dateOfBirth; }
 
-    public void setDateOfBirth(Instant dateOfBirth) { this.dateOfBirth = dateOfBirth; }
+    public void setDateOfBirth(DateOfBirth dateOfBirth) { this.dateOfBirth = dateOfBirth; }
+
+    public Integer getDay() { return day; }
+
+    public void setDay(Integer day) {
+        this.day = day;
+    }
+
+    public Integer getMonth() { return month; }
+
+    public void setMonth(Integer month) {
+        this.month = month;
+    }
+
+    public Integer getYear() { return year; }
+
+    public void setYear(Integer year) {
+        this.year = year;
+    }
 
     public Links getLinks() { return links; }
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyPscs.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyPscs.java
@@ -63,12 +63,6 @@ public class CompanyPscs{
     private String statementType;
     @Field("sensitive_data.date_of_birth")
     private DateOfBirth dateOfBirth;
-    @Field("data.date_of_birth.day")
-    private Integer day;
-    @Field("data.date_of_birth.month")
-    private Integer month;
-    @Field("data.date_of_birth.year")
-    private Integer year;
     @Field("data.links")
     private Links links;
     @Field("data.etag")
@@ -239,24 +233,6 @@ public class CompanyPscs{
     public DateOfBirth getDateOfBirth() { return dateOfBirth; }
 
     public void setDateOfBirth(DateOfBirth dateOfBirth) { this.dateOfBirth = dateOfBirth; }
-
-    public Integer getDay() { return day; }
-
-    public void setDay(Integer day) {
-        this.day = day;
-    }
-
-    public Integer getMonth() { return month; }
-
-    public void setMonth(Integer month) {
-        this.month = month;
-    }
-
-    public Integer getYear() { return year; }
-
-    public void setYear(Integer year) {
-        this.year = year;
-    }
 
     public Links getLinks() { return links; }
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/DateOfBirth.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/DateOfBirth.java
@@ -1,0 +1,45 @@
+package uk.gov.companieshouse.api.testdata.model.entity;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+import java.util.Objects;
+
+public class DateOfBirth {
+    @Field("day")
+    private Integer day;
+    @Field("month")
+    private Integer month;
+    @Field("year")
+    private Integer year;
+
+    public DateOfBirth(int day, int month, int year){
+        this.day = day;
+        this.month = month;
+        this.year = year;
+    }
+
+    public Integer getDay() { return day; }
+
+    public Integer getMonth() { return month; }
+
+    public Integer getYear() { return year; }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        DateOfBirth that = (DateOfBirth) object;
+        return Objects.equals(day, that.day)
+                && Objects.equals(month, that.month)
+                && Objects.equals(year, that.year);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(day, month, year);
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
@@ -10,10 +10,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import uk.gov.companieshouse.api.testdata.model.entity.Appointment;
-import uk.gov.companieshouse.api.testdata.model.entity.Links;
-import uk.gov.companieshouse.api.testdata.model.entity.OfficerAppointment;
-import uk.gov.companieshouse.api.testdata.model.entity.OfficerAppointmentItem;
+import uk.gov.companieshouse.api.testdata.model.entity.*;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.model.rest.Jurisdiction;
 import uk.gov.companieshouse.api.testdata.repository.AppointmentsRepository;
@@ -56,7 +53,6 @@ public class AppointmentsServiceImpl implements DataService<Appointment> {
 
         Instant dateTimeNow = Instant.now();
         Instant dateNow = LocalDate.now().atStartOfDay(ZoneId.of("UTC")).toInstant();
-        Instant dob = officerDob.atStartOfDay(ZoneId.of("UTC")).toInstant();
 
         appointment.setId(appointmentId);
         appointment.setCreated(dateTimeNow);
@@ -86,8 +82,8 @@ public class AppointmentsServiceImpl implements DataService<Appointment> {
         appointment.setLinks(links);
 
         appointment.setSurname("DIRECTOR");
-        appointment.setDateOfBirth(dob);
-
+        DateOfBirth dateOfBirth = new DateOfBirth(14, 6, 1987);
+        appointment.setDateOfBirth(dateOfBirth);
         appointment.setCompanyName("Company " + companyNumber);
         appointment.setCompanyStatus("active");
         appointment.setOfficerId(officerId);

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
@@ -84,6 +84,7 @@ public class AppointmentsServiceImpl implements DataService<Appointment> {
 
         appointment.setSurname("DIRECTOR");
         appointment.setDateOfBirth(dob);
+
         appointment.setCompanyName("Company " + companyNumber);
         appointment.setCompanyStatus("active");
         appointment.setOfficerId(officerId);

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
@@ -49,8 +49,11 @@ public class AppointmentsServiceImpl implements DataService<Appointment> {
 
         String appointmentId = randomService.getEncodedIdWithSalt(ID_LENGTH, SALT_LENGTH);
 
+        LocalDate officerDob = LocalDate.of(1990, 3, 6);
+
         Instant dateTimeNow = Instant.now();
         Instant dateNow = LocalDate.now().atStartOfDay(ZoneId.of("UTC")).toInstant();
+        Instant dob = officerDob.atStartOfDay(ZoneId.of("UTC")).toInstant();
 
         appointment.setId(appointmentId);
         appointment.setCreated(dateTimeNow);
@@ -80,8 +83,7 @@ public class AppointmentsServiceImpl implements DataService<Appointment> {
         appointment.setLinks(links);
 
         appointment.setSurname("DIRECTOR");
-        DateOfBirth dateOfBirth = new DateOfBirth(14, 6, 1987);
-        appointment.setDateOfBirth(dateOfBirth);
+        appointment.setDateOfBirth(dob);
         appointment.setCompanyName("Company " + companyNumber);
         appointment.setCompanyStatus("active");
         appointment.setOfficerId(officerId);

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
@@ -49,8 +49,6 @@ public class AppointmentsServiceImpl implements DataService<Appointment> {
 
         String appointmentId = randomService.getEncodedIdWithSalt(ID_LENGTH, SALT_LENGTH);
 
-        LocalDate officerDob = LocalDate.of(1990, 3, 6);
-
         Instant dateTimeNow = Instant.now();
         Instant dateNow = LocalDate.now().atStartOfDay(ZoneId.of("UTC")).toInstant();
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
@@ -3,10 +3,7 @@ package uk.gov.companieshouse.api.testdata.service.impl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscs;
-import uk.gov.companieshouse.api.testdata.model.entity.Identification;
-import uk.gov.companieshouse.api.testdata.model.entity.Links;
-import uk.gov.companieshouse.api.testdata.model.entity.NameElements;
+import uk.gov.companieshouse.api.testdata.model.entity.*;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.repository.CompanyPscsRepository;
 import uk.gov.companieshouse.api.testdata.service.DataService;
@@ -127,7 +124,8 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs> {
 
         companyPsc.setCountryOfResidence(WALES);
         companyPsc.setNationality("British");
-        companyPsc.setDateOfBirth(Instant.now().minus( 69, ChronoUnit.DAYS));
+        DateOfBirth dateOfBirth = new DateOfBirth(20, 9, 1975);
+        companyPsc.setDateOfBirth(dateOfBirth);
 
         NameElements nameElements = new NameElements();
 

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImplTest.java
@@ -106,9 +106,6 @@ class AppointmentsServiceImplTest {
 
         assertEquals("DIRECTOR", appointment.getSurname());
         assertNotNull(appointment.getDateOfBirth());
-        assertNotNull(appointment.getDateOfBirth().getDay());
-        assertNotNull(appointment.getDateOfBirth().getMonth());
-        assertNotNull(appointment.getDateOfBirth().getYear());
     }
 
     @Test
@@ -168,9 +165,6 @@ class AppointmentsServiceImplTest {
 
         assertEquals("DIRECTOR", appointment.getSurname());
         assertNotNull(appointment.getDateOfBirth());
-        assertNotNull(appointment.getDateOfBirth().getDay());
-        assertNotNull(appointment.getDateOfBirth().getMonth());
-        assertNotNull(appointment.getDateOfBirth().getYear());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImplTest.java
@@ -1,9 +1,6 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -109,6 +106,9 @@ class AppointmentsServiceImplTest {
 
         assertEquals("DIRECTOR", appointment.getSurname());
         assertNotNull(appointment.getDateOfBirth());
+        assertNotNull(appointment.getDateOfBirth().getDay());
+        assertNotNull(appointment.getDateOfBirth().getMonth());
+        assertNotNull(appointment.getDateOfBirth().getYear());
     }
 
     @Test
@@ -168,6 +168,9 @@ class AppointmentsServiceImplTest {
 
         assertEquals("DIRECTOR", appointment.getSurname());
         assertNotNull(appointment.getDateOfBirth());
+        assertNotNull(appointment.getDateOfBirth().getDay());
+        assertNotNull(appointment.getDateOfBirth().getMonth());
+        assertNotNull(appointment.getDateOfBirth().getYear());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImplTest.java
@@ -120,6 +120,9 @@ class CompanyPscsServiceImplTest {
             assertEquals("Mr Test Tester Testington", companyPsc.getNameElements().toString());
             assertEquals("British", companyPsc.getNationality());
             assertNotNull(companyPsc.getDateOfBirth());
+            assertNotNull(companyPsc.getDateOfBirth().getDay());
+            assertNotNull(companyPsc.getDateOfBirth().getMonth());
+            assertNotNull(companyPsc.getDateOfBirth().getYear());
             assertEquals("Wales", companyPsc.getCountryOfResidence());
 
         } else {


### PR DESCRIPTION
Jira ticket: https://companieshouse.atlassian.net/browse/IE-270

Changes to how the date of birth is created within the test data generator. Following the datasync project the structure of the date of birth was changed, this is an update so that the test data generator generates the date of birth in the new correct format.