### PR TITLE
Set partial-data-available on created company

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyProfile.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyProfile.java
@@ -13,13 +13,6 @@ import org.springframework.data.mongodb.core.mapping.Field;
 @Document(collection = "company_profile")
 public class CompanyProfile {
 
-    public static final String FULL_DATA_AVAILABLE_FROM_THE_COMPANY =
-            "full-data-available-from-the-company";
-    public static final String FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY =
-            "full-data-available-from-financial-conduct-authority";
-    public static final String FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY_MUTUALS_PUBLIC_REGISTER =
-            "full-data-available-from-financial-conduct-authority-mutuals-public-register";
-
     public class Accounts {
         @Field("next_due")
         private Instant nextDue;
@@ -345,12 +338,7 @@ public class CompanyProfile {
 
     public String getPartialDataAvailable() {return this.partialDataAvailable; }
 
-    public void setPartialDataAvailable(String companyType) {
-        Map<String, String> companyTypes = new HashMap<>();
-        companyTypes.put("investment-company-with-variable-capital", FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY);
-        companyTypes.put("assurance-company", FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY);
-        companyTypes.put("royal-charter", FULL_DATA_AVAILABLE_FROM_THE_COMPANY);
-        companyTypes.put("industrial-and-provident-society", FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY_MUTUALS_PUBLIC_REGISTER);
-        this.partialDataAvailable = companyTypes.getOrDefault(companyType, "");
+    public void setPartialDataAvailable(String partialDataAvailable) {
+        this.partialDataAvailable = partialDataAvailable;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyProfile.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyProfile.java
@@ -2,7 +2,9 @@
 package uk.gov.companieshouse.api.testdata.model.entity;
 
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -10,6 +12,13 @@ import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "company_profile")
 public class CompanyProfile {
+
+    public static final String FULL_DATA_AVAILABLE_FROM_THE_COMPANY =
+            "full-data-available-from-the-company";
+    public static final String FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY =
+            "full-data-available-from-financial-conduct-authority";
+    public static final String FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY_MUTUALS_PUBLIC_REGISTER =
+            "full-data-available-from-financial-conduct-authority-mutuals-public-register";
 
     public class Accounts {
         @Field("next_due")
@@ -170,6 +179,8 @@ public class CompanyProfile {
     private String subtype;
     @Field("data.is_community_interest_company")
     private Boolean isCommunityInterestCompany;
+    @Field("data.partial_data_available")
+    private String partialDataAvailable;
 
     public String getId() {
         return id;
@@ -330,5 +341,16 @@ public class CompanyProfile {
 
     public void setIsCommunityInterestCompany(Boolean isCommunityInterestCompany) {
         this.isCommunityInterestCompany = isCommunityInterestCompany;
+    }
+
+    public String getPartialDataAvailable() {return this.partialDataAvailable; }
+
+    public void setPartialDataAvailable(String companyType) {
+        Map<String, String> companyTypes = new HashMap<>();
+        companyTypes.put("investment-company-with-variable-capital", FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY);
+        companyTypes.put("assurance-company", FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY);
+        companyTypes.put("royal-charter", FULL_DATA_AVAILABLE_FROM_THE_COMPANY);
+        companyTypes.put("industrial-and-provident-society", FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY_MUTUALS_PUBLIC_REGISTER);
+        this.partialDataAvailable = companyTypes.getOrDefault(companyType, "");
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyProfile.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyProfile.java
@@ -2,9 +2,7 @@
 package uk.gov.companieshouse.api.testdata.model.entity;
 
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/CompanySpec.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/CompanySpec.java
@@ -34,9 +34,6 @@ public class CompanySpec {
     @JsonProperty("has_super_secure_pscs")
     private Boolean hasSuperSecurePscs;
 
-    @JsonProperty("partial_data_available")
-    private String partialDataAvailable;
-
     public CompanySpec() {
         jurisdiction = Jurisdiction.ENGLAND_WALES;
     }
@@ -88,8 +85,4 @@ public class CompanySpec {
     public void setHasSuperSecurePscs(Boolean hasSuperSecurePscs) {
         this.hasSuperSecurePscs = hasSuperSecurePscs;
     }
-
-    public String getPartialDataAvailable() { return partialDataAvailable; }
-
-    public void setPartialDataAvailable(String partialDataAvailable) { this.partialDataAvailable = partialDataAvailable; }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/CompanySpec.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/CompanySpec.java
@@ -34,6 +34,9 @@ public class CompanySpec {
     @JsonProperty("has_super_secure_pscs")
     private Boolean hasSuperSecurePscs;
 
+    @JsonProperty("partial_data_available")
+    private String partialDataAvailable;
+
     public CompanySpec() {
         jurisdiction = Jurisdiction.ENGLAND_WALES;
     }
@@ -85,4 +88,8 @@ public class CompanySpec {
     public void setHasSuperSecurePscs(Boolean hasSuperSecurePscs) {
         this.hasSuperSecurePscs = hasSuperSecurePscs;
     }
+
+    public String getPartialDataAvailable() { return partialDataAvailable; }
+
+    public void setPartialDataAvailable(String partialDataAvailable) { this.partialDataAvailable = partialDataAvailable; }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -72,11 +72,6 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         profile.setDateOfCreation(dateOneYearAgo);
         profile.setType(Objects.requireNonNullElse(companyType, "ltd"));
 
-        Map<String, String> partialDataOptions = createPartialDataCompanies();
-        if (partialDataOptions.containsValue(companyType)) {
-            profile.setPartialDataAvailable(partialDataOptions.get(companyType));
-        }
-        
         profile.setUndeliverableRegisteredOfficeAddress(false);
 
         if (hasSuperSecurePscs != null) {
@@ -101,6 +96,11 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         profile.setHasCharges(false);
         profile.setCanFile(true);
 
+        Map<String, String> partialDataOptions = createPartialDataOptionsMap(String.valueOf(jurisdiction));
+        if (partialDataOptions.containsKey(companyType)) {
+            profile.setPartialDataAvailable(partialDataOptions.get(companyType));
+        }
+
         if (subType != null) {
             profile.setIsCommunityInterestCompany(subType.equals("community-interest-company"));
             profile.setSubtype(subType);
@@ -109,14 +109,19 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         return repository.save(profile);
     }
 
-    private static Map<String, String> createPartialDataCompanies() {
+    private static Map<String, String> createPartialDataOptionsMap(String companyJurisdiction) {
         Map<String, String> partialDataOptions = new HashMap<>();
         partialDataOptions.put("investment-company-with-variable-capital",
                 "full-data-available-from-financial-conduct-authority");
         partialDataOptions.put("assurance-company", "full-data-available-from-financial-conduct-authority");
         partialDataOptions.put("royal-charter", "full-data-available-from-the-company");
-        partialDataOptions.put("industrial-and-provident-society",
-                "full-data-available-from-financial-conduct-authority-mutuals-public-register");
+        if (companyJurisdiction.equals("northern-ireland")) {
+            partialDataOptions.put("industrial-and-provident-society",
+                    "full-data-available-from-department-of-the-economy");
+        } else {
+            partialDataOptions.put("industrial-and-provident-society",
+                    "full-data-available-from-financial-conduct-authority-mutuals-public-register");
+        }
         return partialDataOptions;
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -3,9 +3,7 @@ package uk.gov.companieshouse.api.testdata.service.impl;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.Collections;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -25,6 +23,13 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
     private static final ZoneId ZONE_ID_UTC = ZoneId.of("UTC");
 
     private static final String LINK_STEM = "/company/";
+
+    public static final String FULL_DATA_AVAILABLE_FROM_THE_COMPANY =
+            "full-data-available-from-the-company";
+    public static final String FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY =
+            "full-data-available-from-financial-conduct-authority";
+    public static final String FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY_MUTUALS_PUBLIC_REGISTER =
+            "full-data-available-from-financial-conduct-authority-mutuals-public-register";
 
     @Autowired
     private RandomService randomService;
@@ -69,7 +74,12 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         profile.setCompanyNumber(companyNumber);
         profile.setDateOfCreation(dateOneYearAgo);
         profile.setType(Objects.requireNonNullElse(companyType, "ltd"));
-        profile.setPartialDataAvailable(profile.getType());
+
+        Map<String, String> companyTypes = createPartialDataCompanies();
+        if (companyTypes.containsValue(companyType)) {
+            profile.setPartialDataAvailable(companyTypes.get(companyType));
+        }
+        
         profile.setUndeliverableRegisteredOfficeAddress(false);
 
         if (hasSuperSecurePscs != null) {
@@ -100,6 +110,15 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         }
 
         return repository.save(profile);
+    }
+
+    private static Map<String, String> createPartialDataCompanies() {
+        Map<String, String> companyTypes = new HashMap<>();
+        companyTypes.put("investment-company-with-variable-capital", FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY);
+        companyTypes.put("assurance-company", FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY);
+        companyTypes.put("royal-charter", FULL_DATA_AVAILABLE_FROM_THE_COMPANY);
+        companyTypes.put("industrial-and-provident-society", FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY_MUTUALS_PUBLIC_REGISTER);
+        return companyTypes;
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -24,13 +24,6 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
 
     private static final String LINK_STEM = "/company/";
 
-    public static final String FULL_DATA_AVAILABLE_FROM_THE_COMPANY =
-            "full-data-available-from-the-company";
-    public static final String FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY =
-            "full-data-available-from-financial-conduct-authority";
-    public static final String FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY_MUTUALS_PUBLIC_REGISTER =
-            "full-data-available-from-financial-conduct-authority-mutuals-public-register";
-
     @Autowired
     private RandomService randomService;
 
@@ -75,9 +68,9 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         profile.setDateOfCreation(dateOneYearAgo);
         profile.setType(Objects.requireNonNullElse(companyType, "ltd"));
 
-        Map<String, String> companyTypes = createPartialDataCompanies();
-        if (companyTypes.containsValue(companyType)) {
-            profile.setPartialDataAvailable(companyTypes.get(companyType));
+        Map<String, String> partialDataOptions = createPartialDataCompanies();
+        if (partialDataOptions.containsValue(companyType)) {
+            profile.setPartialDataAvailable(partialDataOptions.get(companyType));
         }
         
         profile.setUndeliverableRegisteredOfficeAddress(false);
@@ -113,12 +106,14 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
     }
 
     private static Map<String, String> createPartialDataCompanies() {
-        Map<String, String> companyTypes = new HashMap<>();
-        companyTypes.put("investment-company-with-variable-capital", FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY);
-        companyTypes.put("assurance-company", FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY);
-        companyTypes.put("royal-charter", FULL_DATA_AVAILABLE_FROM_THE_COMPANY);
-        companyTypes.put("industrial-and-provident-society", FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY_MUTUALS_PUBLIC_REGISTER);
-        return companyTypes;
+        Map<String, String> partialDataOptions = new HashMap<>();
+        partialDataOptions.put("investment-company-with-variable-capital",
+                "full-data-available-from-financial-conduct-authority");
+        partialDataOptions.put("assurance-company", "full-data-available-from-financial-conduct-authority");
+        partialDataOptions.put("royal-charter", "full-data-available-from-the-company");
+        partialDataOptions.put("industrial-and-provident-society",
+                "full-data-available-from-financial-conduct-authority-mutuals-public-register");
+        return partialDataOptions;
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -69,6 +69,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         profile.setCompanyNumber(companyNumber);
         profile.setDateOfCreation(dateOneYearAgo);
         profile.setType(Objects.requireNonNullElse(companyType, "ltd"));
+        profile.setPartialDataAvailable(profile.getType());
         profile.setUndeliverableRegisteredOfficeAddress(false);
 
         if (hasSuperSecurePscs != null) {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -3,7 +3,11 @@ package uk.gov.companieshouse.api.testdata.service.impl;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.*;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Map;
+import java.util.HashMap;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -341,7 +341,7 @@ class CompanyProfileServiceImplTest {
     }
 
     @Test
-    void createIndustrialAndProvidentCompanyAndVerifyPartialData() {
+    void createEnglandWalesIndustrialAndProvidentCompanyAndVerifyPartialData() {
         spec.setJurisdiction(Jurisdiction.ENGLAND_WALES);
         spec.setCompanyType(COMPANY_TYPE_INDUSTRIAL_AND_PROVIDENT_SOCIETY);
         spec.setSubType(null);
@@ -359,6 +359,27 @@ class CompanyProfileServiceImplTest {
         CompanyProfile profile = companyProfileCaptor.getValue();
         assertEquals(COMPANY_TYPE_INDUSTRIAL_AND_PROVIDENT_SOCIETY, profile.getType());
         assertEquals("full-data-available-from-financial-conduct-authority-mutuals-public-register", profile.getPartialDataAvailable());
+    }
+
+    @Test
+    void createNortherIrelandIndustrialAndProvidentCompanyAndVerifyPartialData() {
+        spec.setJurisdiction(Jurisdiction.NI);
+        spec.setCompanyType(COMPANY_TYPE_INDUSTRIAL_AND_PROVIDENT_SOCIETY);
+        spec.setSubType(null);
+
+        Address mockRegisteredAddress = new Address("", "", "", "", "", "");
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(savedProfile);
+        when(addressService.getAddress(spec.getJurisdiction())).thenReturn(mockRegisteredAddress);
+
+        CompanyProfile returnedProfile = this.companyProfileService.create(spec);
+        assertEquals(savedProfile, returnedProfile);
+        ArgumentCaptor<CompanyProfile> companyProfileCaptor = ArgumentCaptor.forClass(CompanyProfile.class);
+        verify(repository).save(companyProfileCaptor.capture());
+
+        CompanyProfile profile = companyProfileCaptor.getValue();
+        assertEquals(COMPANY_TYPE_INDUSTRIAL_AND_PROVIDENT_SOCIETY, profile.getType());
+        assertEquals("full-data-available-from-department-of-the-economy", profile.getPartialDataAvailable());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -39,10 +39,12 @@ class CompanyProfileServiceImplTest {
     private static final String COMPANY_NUMBER = "12345678";
     private static final String ETAG = "ETAG";
     private static final String COMPANY_STATUS_DISSOLVED = "dissolved";
-    private static final String COMPANY_TYPE_PLC = "plc";
     private static final String COMPANY_STATUS_ACTIVE = "active";
-    private static final String COMPANY_TYPE_LTD = "ltd";
     private static final String COMPANY_STATUS_ADMINISTRATION = "administration";
+    private static final String COMPANY_TYPE_LTD = "ltd";
+    private static final String COMPANY_TYPE_PLC = "plc";
+    private static final String COMPANY_TYPE_ROYAL_CHARTER = "royal-charter";
+    private static final String COMPANY_TYPE_INDUSTRIAL_AND_PROVIDENT_SOCIETY = "industrial-and-provident-society";
 
     @Mock
     private RandomService randomService;
@@ -315,5 +317,47 @@ class CompanyProfileServiceImplTest {
 
         CompanyProfile profile = companyProfileCaptor.getValue();
         assertEquals(null, profile.getHasSuperSecurePscs());
+    }
+
+    @Test
+    void createRoyalCharterCompanyAndVerifyPartialData() {
+        spec.setJurisdiction(Jurisdiction.ENGLAND_WALES);
+        spec.setCompanyType(COMPANY_TYPE_ROYAL_CHARTER);
+        spec.setSubType(null);
+
+        Address mockRegisteredAddress = new Address("", "", "", "", "", "");
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(savedProfile);
+        when(addressService.getAddress(spec.getJurisdiction())).thenReturn(mockRegisteredAddress);
+
+        CompanyProfile returnedProfile = this.companyProfileService.create(spec);
+        assertEquals(savedProfile, returnedProfile);
+        ArgumentCaptor<CompanyProfile> companyProfileCaptor = ArgumentCaptor.forClass(CompanyProfile.class);
+        verify(repository).save(companyProfileCaptor.capture());
+
+        CompanyProfile profile = companyProfileCaptor.getValue();
+        assertEquals(COMPANY_TYPE_ROYAL_CHARTER, profile.getType());
+        assertEquals("full-data-available-from-the-company", profile.getPartialDataAvailable());
+    }
+
+    @Test
+    void createIndustrialAndProvidentCompanyAndVerifyPartialData() {
+        spec.setJurisdiction(Jurisdiction.ENGLAND_WALES);
+        spec.setCompanyType(COMPANY_TYPE_INDUSTRIAL_AND_PROVIDENT_SOCIETY);
+        spec.setSubType(null);
+
+        Address mockRegisteredAddress = new Address("", "", "", "", "", "");
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(savedProfile);
+        when(addressService.getAddress(spec.getJurisdiction())).thenReturn(mockRegisteredAddress);
+
+        CompanyProfile returnedProfile = this.companyProfileService.create(spec);
+        assertEquals(savedProfile, returnedProfile);
+        ArgumentCaptor<CompanyProfile> companyProfileCaptor = ArgumentCaptor.forClass(CompanyProfile.class);
+        verify(repository).save(companyProfileCaptor.capture());
+
+        CompanyProfile profile = companyProfileCaptor.getValue();
+        assertEquals(COMPANY_TYPE_INDUSTRIAL_AND_PROVIDENT_SOCIETY, profile.getType());
+        assertEquals("full-data-available-from-financial-conduct-authority-mutuals-public-register", profile.getPartialDataAvailable());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -360,4 +360,25 @@ class CompanyProfileServiceImplTest {
         assertEquals(COMPANY_TYPE_INDUSTRIAL_AND_PROVIDENT_SOCIETY, profile.getType());
         assertEquals("full-data-available-from-financial-conduct-authority-mutuals-public-register", profile.getPartialDataAvailable());
     }
+
+    @Test
+    void createLtdCompanyAndVerifyNoPartialData() {
+        spec.setJurisdiction(Jurisdiction.ENGLAND_WALES);
+        spec.setCompanyType(COMPANY_TYPE_LTD);
+        spec.setSubType(null);
+
+        Address mockRegisteredAddress = new Address("", "", "", "", "", "");
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(savedProfile);
+        when(addressService.getAddress(spec.getJurisdiction())).thenReturn(mockRegisteredAddress);
+
+        CompanyProfile returnedProfile = this.companyProfileService.create(spec);
+        assertEquals(savedProfile, returnedProfile);
+        ArgumentCaptor<CompanyProfile> companyProfileCaptor = ArgumentCaptor.forClass(CompanyProfile.class);
+        verify(repository).save(companyProfileCaptor.capture());
+
+        CompanyProfile profile = companyProfileCaptor.getValue();
+        assertEquals(COMPANY_TYPE_LTD, profile.getType());
+        assertNull(profile.getPartialDataAvailable());
+    }
 }


### PR DESCRIPTION
Certain company types have a value set in the `partial-data-available` field. This change adds the correct value to these certain companies on creation.