### PR TITLE
Adding extra details to acsp profile

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/AcspProfile.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/AcspProfile.java
@@ -129,11 +129,11 @@ public class AcspProfile {
     }
 
     public void setRegisteredOfficeAddress(Address registeredOfficeAddress) {
-        this.registeredOfficeAddress = (Address) registeredOfficeAddress;
+        this.registeredOfficeAddress = registeredOfficeAddress;
     }
 
     public void setServiceAddress(Address serviceAddress) {
-        this.serviceAddress = (Address) serviceAddress;
+        this.serviceAddress = serviceAddress;
     }
 
     public static ISoleTraderDetails createSoleTraderDetails() {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/AcspProfile.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/AcspProfile.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.api.testdata.model.entity;
 
 import java.util.List;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -120,12 +121,12 @@ public class AcspProfile {
         this.amlDetails = amlDetails;
     }
 
-    public ISoleTraderDetails getSoleTraderDetails() {
+    public SoleTraderDetails getSoleTraderDetails() {
         return soleTraderDetails;
     }
 
-    public void setSoleTraderDetails(ISoleTraderDetails soleTraderDetails) {
-        this.soleTraderDetails = (SoleTraderDetails) soleTraderDetails;
+    public void setSoleTraderDetails(SoleTraderDetails soleTraderDetails) {
+        this.soleTraderDetails = soleTraderDetails;
     }
 
     public void setRegisteredOfficeAddress(Address registeredOfficeAddress) {
@@ -136,88 +137,7 @@ public class AcspProfile {
         this.serviceAddress = serviceAddress;
     }
 
-    public static ISoleTraderDetails createSoleTraderDetails() {
-        return new SoleTraderDetails();
-    }
-
-    public static Address createAddress() {
-        return new Address();
-    }
-
     public void setBusinessSector(String businessSector) {
         this.businessSector = businessSector;
-    }
-
-    public static interface ISoleTraderDetails {
-        void setForename(String forename);
-
-        void setSurname(String surname);
-
-        void setNationality(String nationality);
-
-        void setUsualResidentialCountry(String usualResidentialCountry);
-
-        String getForename();
-
-        String getSurname();
-
-        String getNationality();
-
-        String getUsualResidentialCountry();
-    }
-
-    public static interface ISensitiveData {
-        void setEmail(String email);
-    }
-
-    private static class SoleTraderDetails implements ISoleTraderDetails {
-        @Field("forename")
-        private String forename;
-        @Field("surname")
-        private String surname;
-        @Field("nationality")
-        private String nationality;
-        @Field("usual_residential_country")
-        private String usualResidentialCountry;
-
-        @Override
-        public void setForename(String forename) {
-            this.forename = forename;
-        }
-
-        @Override
-        public void setSurname(String surname) {
-            this.surname = surname;
-        }
-
-        @Override
-        public void setNationality(String nationality) {
-            this.nationality = nationality;
-        }
-
-        @Override
-        public void setUsualResidentialCountry(String usualResidentialCountry) {
-            this.usualResidentialCountry = usualResidentialCountry;
-        }
-
-        @Override
-        public String getForename() {
-            return forename;
-        }
-
-        @Override
-        public String getSurname() {
-            return surname;
-        }
-
-        @Override
-        public String getNationality() {
-            return nationality;
-        }
-
-        @Override
-        public String getUsualResidentialCountry() {
-            return usualResidentialCountry;
-        }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/AcspProfile.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/AcspProfile.java
@@ -27,7 +27,7 @@ public class AcspProfile {
     @Field("data.type")
     private String type;
 
-    @Field("data.business_Sector")
+    @Field("data.business_sector")
     private String businessSector;
 
     @Field("data.etag")

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/AcspProfile.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/AcspProfile.java
@@ -120,6 +120,10 @@ public class AcspProfile {
         this.amlDetails = amlDetails;
     }
 
+    public ISoleTraderDetails getSoleTraderDetails() {
+        return soleTraderDetails;
+    }
+
     public void setSoleTraderDetails(ISoleTraderDetails soleTraderDetails) {
         this.soleTraderDetails = (SoleTraderDetails) soleTraderDetails;
     }
@@ -152,6 +156,14 @@ public class AcspProfile {
         void setNationality(String nationality);
 
         void setUsualResidentialCountry(String usualResidentialCountry);
+
+        String getForename();
+
+        String getSurname();
+
+        String getNationality();
+
+        String getUsualResidentialCountry();
     }
 
     public static interface ISensitiveData {
@@ -186,6 +198,26 @@ public class AcspProfile {
         @Override
         public void setUsualResidentialCountry(String usualResidentialCountry) {
             this.usualResidentialCountry = usualResidentialCountry;
+        }
+
+        @Override
+        public String getForename() {
+            return forename;
+        }
+
+        @Override
+        public String getSurname() {
+            return surname;
+        }
+
+        @Override
+        public String getNationality() {
+            return nationality;
+        }
+
+        @Override
+        public String getUsualResidentialCountry() {
+            return usualResidentialCountry;
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/AcspProfile.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/AcspProfile.java
@@ -27,6 +27,9 @@ public class AcspProfile {
     @Field("data.type")
     private String type;
 
+    @Field("data.business_Sector")
+    private String businessSector;
+
     @Field("data.etag")
     private String etag;
 
@@ -35,6 +38,15 @@ public class AcspProfile {
 
     @Field("data.aml_details")
     private List<AmlDetails> amlDetails;
+
+    @Field("data.sole_trader_details")
+    private SoleTraderDetails soleTraderDetails;
+
+    @Field("data.registered_office_address")
+    private Address registeredOfficeAddress;
+
+    @Field("data.service_address")
+    private Address serviceAddress;
 
     public String getId() {
         return id;
@@ -106,5 +118,74 @@ public class AcspProfile {
 
     public void setAmlDetails(List<AmlDetails> amlDetails) {
         this.amlDetails = amlDetails;
+    }
+
+    public void setSoleTraderDetails(ISoleTraderDetails soleTraderDetails) {
+        this.soleTraderDetails = (SoleTraderDetails) soleTraderDetails;
+    }
+
+    public void setRegisteredOfficeAddress(Address registeredOfficeAddress) {
+        this.registeredOfficeAddress = (Address) registeredOfficeAddress;
+    }
+
+    public void setServiceAddress(Address serviceAddress) {
+        this.serviceAddress = (Address) serviceAddress;
+    }
+
+    public static ISoleTraderDetails createSoleTraderDetails() {
+        return new SoleTraderDetails();
+    }
+
+    public static Address createAddress() {
+        return new Address();
+    }
+
+    public void setBusinessSector(String businessSector) {
+        this.businessSector = businessSector;
+    }
+
+    public static interface ISoleTraderDetails {
+        void setForename(String forename);
+
+        void setSurname(String surname);
+
+        void setNationality(String nationality);
+
+        void setUsualResidentialCountry(String usualResidentialCountry);
+    }
+
+    public static interface ISensitiveData {
+        void setEmail(String email);
+    }
+
+    private static class SoleTraderDetails implements ISoleTraderDetails {
+        @Field("forename")
+        private String forename;
+        @Field("surname")
+        private String surname;
+        @Field("nationality")
+        private String nationality;
+        @Field("usual_residential_country")
+        private String usualResidentialCountry;
+
+        @Override
+        public void setForename(String forename) {
+            this.forename = forename;
+        }
+
+        @Override
+        public void setSurname(String surname) {
+            this.surname = surname;
+        }
+
+        @Override
+        public void setNationality(String nationality) {
+            this.nationality = nationality;
+        }
+
+        @Override
+        public void setUsualResidentialCountry(String usualResidentialCountry) {
+            this.usualResidentialCountry = usualResidentialCountry;
+        }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/SoleTraderDetails.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/SoleTraderDetails.java
@@ -1,0 +1,50 @@
+package uk.gov.companieshouse.api.testdata.model.entity;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+public class SoleTraderDetails {
+
+    @Field("forename")
+    private String forename;
+
+    @Field("surname")
+    private String surname;
+
+    @Field("nationality")
+    private String nationality;
+
+    @Field("usual_residential_country")
+    private String usualResidentialCountry;
+
+    public String getForename() {
+        return forename;
+    }
+
+    public void setForename(String forename) {
+        this.forename = forename;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public String getNationality() {
+        return nationality;
+    }
+
+    public void setNationality(String nationality) {
+        this.nationality = nationality;
+    }
+
+    public String getUsualResidentialCountry() {
+        return usualResidentialCountry;
+    }
+
+    public void setUsualResidentialCountry(String usualResidentialCountry) {
+        this.usualResidentialCountry = usualResidentialCountry;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImpl.java
@@ -31,9 +31,9 @@ public class AcspProfileServiceImpl implements DataService<AcspProfileData, Acsp
     private AddressService addressService;
 
     public AcspProfileData create(AcspProfileSpec spec) throws DataException {
-        final String soleTraderForename = "Forename ";
-        final String soleTraderSurname = "Surname ";
-        final String businessName = "financial-services";
+        var soleTraderForename = "Forename ";
+        var soleTraderSurname = "Surname ";
+        var businessName = "financial-services";
         var randomId = randomService.getString(8);
         var acspNumber = Objects.requireNonNullElse(spec.getAcspNumber(), randomId);
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImpl.java
@@ -33,7 +33,7 @@ public class AcspProfileServiceImpl implements DataService<AcspProfileData, Acsp
     public AcspProfileData create(AcspProfileSpec spec) throws DataException {
         var soleTraderForename = "Forename ";
         var soleTraderSurname = "Surname ";
-        var businessName = "financial-services";
+        var businessSector = "financial-services";
         var randomId = randomService.getString(8);
         var acspNumber = Objects.requireNonNullElse(spec.getAcspNumber(), randomId);
 
@@ -43,7 +43,7 @@ public class AcspProfileServiceImpl implements DataService<AcspProfileData, Acsp
         profile.setStatus(Objects.requireNonNullElse(spec.getStatus(), "active"));
         profile.setType(Objects.requireNonNullElse(spec.getType(), "limited-company"));
         profile.setAcspNumber(acspNumber);
-        profile.setBusinessSector(businessName);
+        profile.setBusinessSector(businessSector);
         profile.setRegisteredOfficeAddress(addressService.getAddress(Jurisdiction.UNITED_KINGDOM));
         profile.setServiceAddress(addressService.getAddress(Jurisdiction.UNITED_KINGDOM));
         profile.setName("Test Data Generator " + acspNumber + " Company Ltd");

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.AmlDetails;
+import uk.gov.companieshouse.api.testdata.model.entity.SoleTraderDetails;
 import uk.gov.companieshouse.api.testdata.model.rest.AcspProfileData;
 import uk.gov.companieshouse.api.testdata.model.rest.AcspProfileSpec;
 import uk.gov.companieshouse.api.testdata.model.rest.AmlSpec;
@@ -34,6 +35,7 @@ public class AcspProfileServiceImpl implements DataService<AcspProfileData, Acsp
         var soleTraderForename = "Forename ";
         var soleTraderSurname = "Surname ";
         var businessSector = "financial-services";
+        var nationality = "British";
         var randomId = randomService.getString(8);
         var acspNumber = Objects.requireNonNullElse(spec.getAcspNumber(), randomId);
 
@@ -58,12 +60,11 @@ public class AcspProfileServiceImpl implements DataService<AcspProfileData, Acsp
             }
             profile.setAmlDetails(amlDetailsList);
         }
-        if (Objects.equals(spec.getType(), "sole-trader")) {
-            AcspProfile.ISoleTraderDetails soleTraderDetails
-                    = AcspProfile.createSoleTraderDetails();
+        if ("sole-trader".equals(spec.getType())) {
+            SoleTraderDetails soleTraderDetails = new SoleTraderDetails();
             soleTraderDetails.setForename(soleTraderForename + acspNumber);
             soleTraderDetails.setSurname(soleTraderSurname + acspNumber);
-            soleTraderDetails.setNationality("BRITISH");
+            soleTraderDetails.setNationality(nationality);
             soleTraderDetails.setUsualResidentialCountry(
                     addressService.getCountryOfResidence(Jurisdiction.ENGLAND));
             profile.setSoleTraderDetails(soleTraderDetails);

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImpl.java
@@ -61,7 +61,7 @@ public class AcspProfileServiceImpl implements DataService<AcspProfileData, Acsp
             profile.setAmlDetails(amlDetailsList);
         }
         if (Objects.equals("sole-trader", spec.getType())) {
-            SoleTraderDetails soleTraderDetails = new SoleTraderDetails();
+            var soleTraderDetails = new SoleTraderDetails();
             soleTraderDetails.setForename(soleTraderForename + acspNumber);
             soleTraderDetails.setSurname(soleTraderSurname + acspNumber);
             soleTraderDetails.setNationality(nationality);

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImpl.java
@@ -60,7 +60,7 @@ public class AcspProfileServiceImpl implements DataService<AcspProfileData, Acsp
             }
             profile.setAmlDetails(amlDetailsList);
         }
-        if ("sole-trader".equals(spec.getType())) {
+        if (Objects.equals("sole-trader", spec.getType())) {
             SoleTraderDetails soleTraderDetails = new SoleTraderDetails();
             soleTraderDetails.setForename(soleTraderForename + acspNumber);
             soleTraderDetails.setSurname(soleTraderSurname + acspNumber);

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AddressServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AddressServiceImpl.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.Address;
 import uk.gov.companieshouse.api.testdata.model.rest.Jurisdiction;
 import uk.gov.companieshouse.api.testdata.service.AddressService;

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AddressServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AddressServiceImpl.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
 import org.springframework.stereotype.Service;
-import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.Address;
 import uk.gov.companieshouse.api.testdata.model.rest.Jurisdiction;
 import uk.gov.companieshouse.api.testdata.service.AddressService;

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImplTest.java
@@ -1,8 +1,15 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
@@ -224,6 +231,8 @@ class AcspProfileServiceImplTest {
 
         captured.setSoleTraderDetails(soleTraderDetails);
 
+        assertEquals("England", captured.getSoleTraderDetails().getUsualResidentialCountry());
+        assertEquals("BRITISH", captured.getSoleTraderDetails().getNationality());
         assertCommonProfileDetails(captured, "sole-trader", "Test Forename", "Test Surname");
     }
 

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImplTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -62,11 +61,6 @@ class AcspProfileServiceImplTest {
         savedProfile.setAcspNumber("randomId");
 
         spec = new AcspProfileSpec();
-
-        lenient().when(randomService.getString(8)).thenReturn("randomId");
-        lenient().when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
-        lenient().when(addressService.getCountryOfResidence(Jurisdiction.ENGLAND)).thenReturn("England");
-        lenient().when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
     }
 
     private AmlSpec getAmlSpec(String supervisoryBody, String membershipDetails) {
@@ -88,7 +82,7 @@ class AcspProfileServiceImplTest {
         assertNotNull(captured.getSoleTraderDetails());
         assertEquals(forename, captured.getSoleTraderDetails().getForename());
         assertEquals(surname, captured.getSoleTraderDetails().getSurname());
-        assertEquals("BRITISH", captured.getSoleTraderDetails().getNationality());
+        assertEquals("British", captured.getSoleTraderDetails().getNationality());
         assertEquals("England", captured.getSoleTraderDetails().getUsualResidentialCountry());
     }
 
@@ -96,6 +90,10 @@ class AcspProfileServiceImplTest {
     void createAcspProfile() throws DataException {
         spec.setStatus("active");
         spec.setType("ltd");
+
+        when(randomService.getString(8)).thenReturn("randomId");
+        when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
+        when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
 
         AcspProfileData result = service.create(spec);
 
@@ -118,6 +116,10 @@ class AcspProfileServiceImplTest {
 
     @Test
     void createAcspProfileWithDefaultValues() throws DataException {
+        when(randomService.getString(8)).thenReturn("randomId");
+        when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
+        when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
+
         AcspProfileData result = service.create(spec);
 
         assertNotNull(result);
@@ -145,6 +147,10 @@ class AcspProfileServiceImplTest {
         AmlSpec amlSpec3 = getAmlSpec("association-of-international-accountants-aia", "Membership Id: 656767");
 
         spec.setAmlDetails(List.of(amlSpec1, amlSpec2, amlSpec3));
+
+        when(randomService.getString(8)).thenReturn("randomId");
+        when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
+        when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
 
         AcspProfileData result = service.create(spec);
 
@@ -178,6 +184,10 @@ class AcspProfileServiceImplTest {
         spec.setType("ltd");
         spec.setAmlDetails(Collections.emptyList());
 
+        when(randomService.getString(8)).thenReturn("randomId");
+        when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
+        when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
+
         AcspProfileData result = service.create(spec);
 
         assertNotNull(result);
@@ -203,6 +213,8 @@ class AcspProfileServiceImplTest {
 
         AcspProfile savedProfileWithAcsp = new AcspProfile();
         savedProfileWithAcsp.setAcspNumber(spec.getAcspNumber());
+        when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
+        when(randomService.getString(8)).thenReturn("randomId");
         when(repository.save(any(AcspProfile.class))).thenReturn(savedProfileWithAcsp);
 
         AcspProfileData result = service.create(spec);
@@ -215,11 +227,12 @@ class AcspProfileServiceImplTest {
     @Test
     void createAcspProfileAsSoleTrader() throws DataException {
         spec.setType("sole-trader");
-        AcspProfile.ISoleTraderDetails soleTraderDetails = AcspProfile.createSoleTraderDetails();
-        soleTraderDetails.setForename("Test Forename");
-        soleTraderDetails.setSurname("Test Surname");
-        soleTraderDetails.setNationality("BRITISH");
-        soleTraderDetails.setUsualResidentialCountry("England");
+
+        when(randomService.getString(8)).thenReturn("randomId");
+        when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
+        when(addressService
+                .getCountryOfResidence(Jurisdiction.ENGLAND)).thenReturn("England");
+        when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
 
         AcspProfileData result = service.create(spec);
 
@@ -229,17 +242,20 @@ class AcspProfileServiceImplTest {
         verify(repository).save(profileCaptor.capture());
         AcspProfile captured = profileCaptor.getValue();
 
-        captured.setSoleTraderDetails(soleTraderDetails);
-
-        assertEquals("England", captured.getSoleTraderDetails().getUsualResidentialCountry());
-        assertEquals("BRITISH", captured.getSoleTraderDetails().getNationality());
-        assertCommonProfileDetails(captured, "sole-trader", "Test Forename", "Test Surname");
+        assertCommonProfileDetails(captured, "sole-trader", "Forename randomId",
+                "Surname randomId");
     }
 
     @Test
     void createAcspProfileAsSoleTraderWithDefaultValues() throws DataException {
         spec.setType("sole-trader");
 
+        when(randomService.getString(8)).thenReturn("randomId");
+        when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
+        when(addressService
+                .getCountryOfResidence(Jurisdiction.ENGLAND)).thenReturn("England");
+        when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
+
         AcspProfileData result = service.create(spec);
 
         assertNotNull(result);
@@ -248,7 +264,8 @@ class AcspProfileServiceImplTest {
         verify(repository).save(profileCaptor.capture());
         AcspProfile captured = profileCaptor.getValue();
 
-        assertCommonProfileDetails(captured, "sole-trader", "Forename randomId", "Surname randomId");
+        assertCommonProfileDetails(captured, "sole-trader", "Forename randomId",
+                "Surname randomId");
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImplTest.java
@@ -52,15 +52,15 @@ class AcspProfileServiceImplTest {
     @Captor
     private ArgumentCaptor<AcspProfile> profileCaptor;
 
-    private AcspProfile savedProfile;
-    private AcspProfileSpec spec;
+    private AcspProfile acspProfile;
+    private AcspProfileSpec acspProfileSpec;
 
     @BeforeEach
     void setUp() {
-        savedProfile = new AcspProfile();
-        savedProfile.setAcspNumber("randomId");
+        acspProfile = new AcspProfile();
+        acspProfile.setAcspNumber("randomId");
 
-        spec = new AcspProfileSpec();
+        acspProfileSpec = new AcspProfileSpec();
     }
 
     private AmlSpec getAmlSpec(String supervisoryBody, String membershipDetails) {
@@ -88,17 +88,17 @@ class AcspProfileServiceImplTest {
 
     @Test
     void createAcspProfile() throws DataException {
-        spec.setStatus("active");
-        spec.setType("ltd");
+        acspProfileSpec.setStatus("active");
+        acspProfileSpec.setType("ltd");
 
         when(randomService.getString(8)).thenReturn("randomId");
         when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
-        when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
+        when(repository.save(any(AcspProfile.class))).thenReturn(acspProfile);
 
-        AcspProfileData result = service.create(spec);
+        AcspProfileData result = service.create(acspProfileSpec);
 
         assertNotNull(result);
-        assertEquals(savedProfile.getAcspNumber(), result.getAcspNumber());
+        assertEquals(acspProfile.getAcspNumber(), result.getAcspNumber());
 
         verify(repository).save(any(AcspProfile.class));
         verify(repository).save(profileCaptor.capture());
@@ -107,8 +107,8 @@ class AcspProfileServiceImplTest {
         assertNotNull(captured);
         assertEquals("randomId", captured.getId());
         assertEquals("randomId", captured.getAcspNumber());
-        assertEquals(spec.getStatus(), captured.getStatus());
-        assertEquals(spec.getType(), captured.getType());
+        assertEquals(acspProfileSpec.getStatus(), captured.getStatus());
+        assertEquals(acspProfileSpec.getType(), captured.getType());
         assertEquals("Test Data Generator randomId Company Ltd", captured.getName());
         assertEquals("/authorised-corporate-service-providers/randomId", captured.getLinksSelf());
         assertNull(captured.getAmlDetails());
@@ -118,12 +118,12 @@ class AcspProfileServiceImplTest {
     void createAcspProfileWithDefaultValues() throws DataException {
         when(randomService.getString(8)).thenReturn("randomId");
         when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
-        when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
+        when(repository.save(any(AcspProfile.class))).thenReturn(acspProfile);
 
-        AcspProfileData result = service.create(spec);
+        AcspProfileData result = service.create(acspProfileSpec);
 
         assertNotNull(result);
-        assertEquals(savedProfile.getAcspNumber(), result.getAcspNumber());
+        assertEquals(acspProfile.getAcspNumber(), result.getAcspNumber());
 
         verify(repository).save(profileCaptor.capture());
         AcspProfile captured = profileCaptor.getValue();
@@ -139,31 +139,31 @@ class AcspProfileServiceImplTest {
 
     @Test
     void createAcspProfileWithAmlDetails() throws DataException {
-        spec.setStatus("active");
-        spec.setType("ltd");
+        acspProfileSpec.setStatus("active");
+        acspProfileSpec.setType("ltd");
 
         AmlSpec amlSpec1 = getAmlSpec("association-of-chartered-certified-accountants-acca", "Membership Id: 127678");
         AmlSpec amlSpec2 = getAmlSpec("association-of-accounting-technicians-aat", "Membership Id: 765678");
         AmlSpec amlSpec3 = getAmlSpec("association-of-international-accountants-aia", "Membership Id: 656767");
 
-        spec.setAmlDetails(List.of(amlSpec1, amlSpec2, amlSpec3));
+        acspProfileSpec.setAmlDetails(List.of(amlSpec1, amlSpec2, amlSpec3));
 
         when(randomService.getString(8)).thenReturn("randomId");
         when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
-        when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
+        when(repository.save(any(AcspProfile.class))).thenReturn(acspProfile);
 
-        AcspProfileData result = service.create(spec);
+        AcspProfileData result = service.create(acspProfileSpec);
 
         assertNotNull(result);
-        assertEquals(savedProfile.getAcspNumber(), result.getAcspNumber());
+        assertEquals(acspProfile.getAcspNumber(), result.getAcspNumber());
 
         verify(repository).save(profileCaptor.capture());
         AcspProfile captured = profileCaptor.getValue();
 
         assertEquals("randomId", captured.getId());
         assertEquals("randomId", captured.getAcspNumber());
-        assertEquals(spec.getStatus(), captured.getStatus());
-        assertEquals(spec.getType(), captured.getType());
+        assertEquals(acspProfileSpec.getStatus(), captured.getStatus());
+        assertEquals(acspProfileSpec.getType(), captured.getType());
         assertEquals("Test Data Generator randomId Company Ltd", captured.getName());
         assertEquals("/authorised-corporate-service-providers/randomId", captured.getLinksSelf());
         assertEquals(0L, captured.getVersion());
@@ -180,18 +180,18 @@ class AcspProfileServiceImplTest {
 
     @Test
     void createAcspProfileWithEmptyAmlDetails() throws DataException {
-        spec.setStatus("active");
-        spec.setType("ltd");
-        spec.setAmlDetails(Collections.emptyList());
+        acspProfileSpec.setStatus("active");
+        acspProfileSpec.setType("ltd");
+        acspProfileSpec.setAmlDetails(Collections.emptyList());
 
         when(randomService.getString(8)).thenReturn("randomId");
         when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
-        when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
+        when(repository.save(any(AcspProfile.class))).thenReturn(acspProfile);
 
-        AcspProfileData result = service.create(spec);
+        AcspProfileData result = service.create(acspProfileSpec);
 
         assertNotNull(result);
-        assertEquals(savedProfile.getAcspNumber(), result.getAcspNumber());
+        assertEquals(acspProfile.getAcspNumber(), result.getAcspNumber());
 
         verify(repository).save(profileCaptor.capture());
         AcspProfile captured = profileCaptor.getValue();
@@ -201,23 +201,23 @@ class AcspProfileServiceImplTest {
         assertTrue(captured.getAmlDetails().isEmpty());
         assertEquals("randomId", captured.getId());
         assertEquals("randomId", captured.getAcspNumber());
-        assertEquals(spec.getStatus(), captured.getStatus());
-        assertEquals(spec.getType(), captured.getType());
+        assertEquals(acspProfileSpec.getStatus(), captured.getStatus());
+        assertEquals(acspProfileSpec.getType(), captured.getType());
         assertEquals("Test Data Generator randomId Company Ltd", captured.getName());
         assertEquals("/authorised-corporate-service-providers/randomId", captured.getLinksSelf());
     }
 
     @Test
     void createAcspProfileWithProvidedAcspNumber() throws DataException {
-        spec.setAcspNumber("TestACSP");
+        acspProfileSpec.setAcspNumber("TestACSP");
 
         AcspProfile savedProfileWithAcsp = new AcspProfile();
-        savedProfileWithAcsp.setAcspNumber(spec.getAcspNumber());
+        savedProfileWithAcsp.setAcspNumber(acspProfileSpec.getAcspNumber());
         when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
         when(randomService.getString(8)).thenReturn("randomId");
         when(repository.save(any(AcspProfile.class))).thenReturn(savedProfileWithAcsp);
 
-        AcspProfileData result = service.create(spec);
+        AcspProfileData result = service.create(acspProfileSpec);
 
         assertNotNull(result);
         assertEquals("TestACSP", result.getAcspNumber());
@@ -226,18 +226,18 @@ class AcspProfileServiceImplTest {
 
     @Test
     void createAcspProfileAsSoleTrader() throws DataException {
-        spec.setType("sole-trader");
+        acspProfileSpec.setType("sole-trader");
 
         when(randomService.getString(8)).thenReturn("randomId");
         when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
         when(addressService
                 .getCountryOfResidence(Jurisdiction.ENGLAND)).thenReturn("England");
-        when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
+        when(repository.save(any(AcspProfile.class))).thenReturn(acspProfile);
 
-        AcspProfileData result = service.create(spec);
+        AcspProfileData result = service.create(acspProfileSpec);
 
         assertNotNull(result);
-        assertEquals(savedProfile.getAcspNumber(), result.getAcspNumber());
+        assertEquals(acspProfile.getAcspNumber(), result.getAcspNumber());
 
         verify(repository).save(profileCaptor.capture());
         AcspProfile captured = profileCaptor.getValue();
@@ -248,18 +248,18 @@ class AcspProfileServiceImplTest {
 
     @Test
     void createAcspProfileAsSoleTraderWithDefaultValues() throws DataException {
-        spec.setType("sole-trader");
+        acspProfileSpec.setType("sole-trader");
 
         when(randomService.getString(8)).thenReturn("randomId");
         when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
         when(addressService
                 .getCountryOfResidence(Jurisdiction.ENGLAND)).thenReturn("England");
-        when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
+        when(repository.save(any(AcspProfile.class))).thenReturn(acspProfile);
 
-        AcspProfileData result = service.create(spec);
+        AcspProfileData result = service.create(acspProfileSpec);
 
         assertNotNull(result);
-        assertEquals(savedProfile.getAcspNumber(), result.getAcspNumber());
+        assertEquals(acspProfile.getAcspNumber(), result.getAcspNumber());
 
         verify(repository).save(profileCaptor.capture());
         AcspProfile captured = profileCaptor.getValue();

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AcspProfileServiceImplTest.java
@@ -16,18 +16,21 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Captor;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
+import uk.gov.companieshouse.api.testdata.model.entity.Address;
 import uk.gov.companieshouse.api.testdata.model.rest.AcspProfileData;
 import uk.gov.companieshouse.api.testdata.model.rest.AcspProfileSpec;
 import uk.gov.companieshouse.api.testdata.model.rest.AmlSpec;
+import uk.gov.companieshouse.api.testdata.model.rest.Jurisdiction;
 import uk.gov.companieshouse.api.testdata.repository.AcspProfileRepository;
+import uk.gov.companieshouse.api.testdata.service.AddressService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,6 +38,9 @@ class AcspProfileServiceImplTest {
 
     @Mock
     private AcspProfileRepository repository;
+
+    @Mock
+    private AddressService addressService;
 
     @Mock
     private RandomService randomService;
@@ -58,6 +64,7 @@ class AcspProfileServiceImplTest {
         spec.setType("ltd");
 
         when(randomService.getString(8)).thenReturn("randomId");
+        when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
         AcspProfile savedProfile = createSavedProfile();
         when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
 
@@ -77,14 +84,13 @@ class AcspProfileServiceImplTest {
         assertEquals(spec.getType(), captured.getType());
         assertEquals("Test Data Generator randomId Company Ltd", captured.getName());
         assertEquals("/authorised-corporate-service-providers/randomId", captured.getLinksSelf());
-
-        // Validate that AML details are null
         assertNull(captured.getAmlDetails());
     }
 
     @Test
     void createAcspProfileWithDefaultValues() throws DataException {
         when(randomService.getString(8)).thenReturn("randomId");
+        when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
         AcspProfile savedProfile = createSavedProfile();
         when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
 
@@ -99,9 +105,8 @@ class AcspProfileServiceImplTest {
 
         assertEquals("randomId", captured.getId());
         assertEquals("randomId", captured.getAcspNumber());
-        assertEquals("active", captured.getStatus()); // Default value
-        assertEquals("limited-company", captured.getType()); //
-        // Default value
+        assertEquals("active", captured.getStatus());
+        assertEquals("limited-company", captured.getType());
         assertEquals("Test Data Generator randomId Company Ltd", captured.getName());
         assertEquals("/authorised-corporate-service-providers/randomId", captured.getLinksSelf());
         assertEquals(0L, captured.getVersion());
@@ -127,6 +132,7 @@ class AcspProfileServiceImplTest {
         spec.setAmlDetails(List.of(amlSpec1, amlSpec2, amlSpec3));
 
         when(randomService.getString(8)).thenReturn("randomId");
+        when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
         AcspProfile savedProfile = createSavedProfile();
 
         when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
@@ -162,9 +168,10 @@ class AcspProfileServiceImplTest {
         AcspProfileSpec spec = new AcspProfileSpec();
         spec.setStatus("active");
         spec.setType("ltd");
-        spec.setAmlDetails(Collections.emptyList()); // Setting an empty list
+        spec.setAmlDetails(Collections.emptyList());
 
         when(randomService.getString(8)).thenReturn("randomId");
+        when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
         AcspProfile savedProfile = createSavedProfile();
 
         when(repository.save(any(AcspProfile.class))).thenReturn(savedProfile);
@@ -179,7 +186,7 @@ class AcspProfileServiceImplTest {
 
         assertNotNull(captured);
         assertNotNull(captured.getAmlDetails());
-        assertTrue(captured.getAmlDetails().isEmpty()); // Ensure the list is empty
+        assertTrue(captured.getAmlDetails().isEmpty());
         assertEquals("randomId", captured.getId());
         assertEquals("randomId", captured.getAcspNumber());
         assertEquals(spec.getStatus(), captured.getStatus());
@@ -193,6 +200,7 @@ class AcspProfileServiceImplTest {
         AcspProfileSpec spec = new AcspProfileSpec();
         spec.setAcspNumber("TestACSP");
 
+        when(addressService.getAddress(Jurisdiction.UNITED_KINGDOM)).thenReturn(new Address());
         AcspProfile savedProfile = new AcspProfile();
         savedProfile.setAcspNumber(spec.getAcspNumber());
 


### PR DESCRIPTION
# Test Data Generator - Update acsp profile data

1. registered_office_address, service_address, business_sector
2. sole_trader_details (Only where the type is sole-trader)