### PR TITLE
user endpoint to accept email optional in request

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ In order to use the generator, there are different possible endpoints that can b
 
 #### Creating test users
 - POST: Sending a POST request to create users with the associated roles `{Base URL}/test-data/user` will generate a new test user. The request body must include `UserSpec` parameter to customise the generated user.
+    - `email`: The email id of the user. This is an optional field which defaults to randomly generated string + a test email domain.
     - `password`: The password of the user. This is mandatory.
     - `roles`: The roles of the user along with `permissions`. Roles is optional. If we provide the roles, we need to provide the `id` of the role and the `permissions` associated with the role. permissions are mandatory if we provide role id and vice versa.
     - `is_company_auth_allow_list`: This is optional. If we provide this, we need to provide the value as `true` or `false`.

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/UserSpec.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/UserSpec.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.api.testdata.model.rest;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/UserSpec.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/UserSpec.java
@@ -1,7 +1,9 @@
 package uk.gov.companieshouse.api.testdata.model.rest;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 
 import java.util.List;
 
@@ -9,6 +11,11 @@ public class UserSpec {
 
     @JsonProperty
     private List<RoleSpec> roles;
+
+    @JsonProperty
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$",
+            message = "email is not a valid email address")
+    private String email;
 
     @JsonProperty
     @NotEmpty(message = "password is required")
@@ -39,5 +46,13 @@ public class UserSpec {
 
     public void setIsCompanyAuthAllowList(Boolean isCompanyAuthAllowList) {
         this.isCompanyAuthAllowList = isCompanyAuthAllowList;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
@@ -38,7 +38,9 @@ public class UserServiceImpl implements UserService {
             user.setRoles(userSpec.getRoles()
                     .stream().map(RoleSpec::getId).collect(Collectors.toList()));
         }
-        String email = "test-data-generated" + randomId + "@test.companieshouse.gov.uk";
+        String email = userSpec.getEmail() != null ? userSpec.getEmail() :
+                "test-data-generated" + randomId + "@test.companieshouse.gov.uk";
+
         user.setId(randomId);
         user.setEmail(email);
         user.setForename("Forename-" + randomId);


### PR DESCRIPTION
# TDG generated user profiles to use accept optional email in request body

- Optional email now accepted as part of request body
- defaults to randomly generated email with test domain