### PR TITLE
Creating beneficial_owners, super_secure_pscs, super_secure_beneficial_owners

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In order to use the generator, there are different possible endpoints that can b
   - `type`: The type of the company (e.g., `ltd`, `plc`). Defaults to `ltd`.
   - `sub_type`: The subtype of the company (e.g., `community-interest-company`, `private-fund-limited-partnership`). Defaults to no subtype.
   - `has_super_secure_pscs`: Boolean value to determine if the company has super secure PSCs. Defaults to false, `true` value will create a Psc entry of `super-secure-person-with-significant-control` or `super-secure-beneficial-owner` depending on CompanyType.
-  -  `registers` : The registers of the company (e.g., `directors`, `persons-with-significant-control`, ``). Defaults to no registers.
+  - `registers` : The registers of the company (e.g., `directors`, `persons-with-significant-control`, ``). Defaults to no registers.
   - `number_of_appointments`: Used alongside `officer_roles` to determine the number of appointments to create. Defaults to 1.
   - `officer_roles`: This takes a list of officer roles (`director`, `secretary`). Defaults to director when no role is passed.
   - `accounts_due_status`: Set the accounts and confirmation statement due dates of the company by providing accounts_due_status (e.g., `overdue`, `due-soon`). Defaults to current date. 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ In order to use the generator, there are different possible endpoints that can b
   - `company_status`: The status of the company (e.g., `active`, `dissolved`, `administration`). Defaults to `active`.
   - `type`: The type of the company (e.g., `ltd`, `plc`). Defaults to `ltd`.
   - `sub_type`: The subtype of the company (e.g., `community-interest-company`, `private-fund-limited-partnership`). Defaults to no subtype.
-  - `has_super_secure_pscs`: Boolean value to determine if the company has super secure PSCs. Defaults to no value, field not present in the database.
-  - `registers` : The registers of the company (e.g., `directors`, `persons-with-significant-control`, ``). Defaults to no registers.
+  - `has_super_secure_pscs`: Boolean value to determine if the company has super secure PSCs. Defaults to false, `true` value will create a Psc entry of `super-secure-person-with-significant-control` or `super-secure-beneficial-owner` depending on CompanyType.
+  -  `registers` : The registers of the company (e.g., `directors`, `persons-with-significant-control`, ``). Defaults to no registers.
   - `number_of_appointments`: Used alongside `officer_roles` to determine the number of appointments to create. Defaults to 1.
   - `officer_roles`: This takes a list of officer roles (`director`, `secretary`). Defaults to director when no role is passed.
   - `accounts_due_status`: Set the accounts and confirmation statement due dates of the company by providing accounts_due_status (e.g., `overdue`, `due-soon`). Defaults to current date. 

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@
             <artifactId>api-security-java</artifactId>
             <version>${api-security-java.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyPscs.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyPscs.java
@@ -1,56 +1,81 @@
 package uk.gov.companieshouse.api.testdata.model.entity;
 
+import java.time.Instant;
+import java.util.List;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
-import java.time.Instant;
-import java.util.List;
-
 @Document(collection = "delta_company_pscs")
-public class CompanyPscs{
+public class CompanyPscs {
 
     @Id
     @Field("_id")
     private String id;
+    @Field("psc_id")
+    private String pscId;
     @Field("delta_at")
     private String deltaAt;
-    @Field("data.natures_of_control")
-    private List<String> naturesOfControl;
-    @Field("data.kind")
-    private String kind;
+    @Field("notification_id")
+    private String notificationId;
+    @Field("company_number")
+    private String companyNumber;
+    @Field("created.at")
+    private Instant createdAt;
+    @Field("updated.at")
+    private Instant updatedAt;
+    @Field("data.sanctioned")
+    private Boolean sanctioned;
+    @Field("data.etag")
+    private String etag;
     @Field("data.name_elements")
     private NameElements nameElements;
     @Field("data.name")
     private String name;
+    @Field("data.kind")
+    private String kind;
     @Field("data.notified_on")
     private Instant notifiedOn;
+    @Field("data.service_address_is_same_as_registered_office_address")
+    private Boolean serviceAddressSameAsRegisteredOfficeAddress;
+    @Field("data.is_sanctioned")
+    private Boolean isSanctioned;
+    @Field("data.natures_of_control")
+    private List<String> naturesOfControl;
+    @Field("data.links")
+    private Links links;
+    @Field("data.description")
+    private String description;
     @Field("data.nationality")
     private String nationality;
-    @Field("data.address.postal_code")
-    private String postalCode;
-    @Field("data.address.premises")
-    private String premises;
-    @Field("data.address.locality")
-    private String locality;
-    @Field("data.address.country")
-    private String country;
-    @Field("data.address.address_line_1")
-    private String addressLine1;
-    @Field("data.address.address_line_2")
-    private String addressLine2;
-    @Field("data.address.care_of")
-    private String careOf;
-    @Field("data.address.poBox")
-    private String poBox;
-    @Field("data.address.region")
-    private String region;
+    @Field("data.name_elements.title")
+    private String nameTitle;
+    @Field("data.name_elements.forename")
+    private String nameForename;
+    @Field("data.name_elements.other_forenames")
+    private String nameOtherForenames;
+    @Field("data.name_elements.surname")
+    private String nameSurname;
     @Field("data.country_of_residence")
     private String countryOfResidence;
+    @Field("data.principal_office_address")
+    private Address principalOfficeAddress;
+    @Field("data.address")
+    private Address address;
+    @Field("data.identification")
+    private Identification identification;
+    @Field("sensitive_data.usual_residential_address")
+    private Address usualResidentialAddress;
+    @Field("sensitive_data.date_of_birth")
+    private DateOfBirth dateOfBirth;
+    @Field("sensitive_data.residential_address_is_same_as_service_address")
+    private Boolean residentialAddressSameAsServiceAddress;
     @Field("data.address_same_as_registered_office_address")
     private Boolean addressSameAsRegisteredOfficeAddress;
     @Field("data.ceased_on")
     private Instant ceasedOn;
+    @Field("data.cesed")
+    private Boolean ceased;
     @Field("data.reference_etag")
     private String referenceEtag;
     @Field("data.reference_psc_id")
@@ -61,42 +86,78 @@ public class CompanyPscs{
     private Instant statementActionDate;
     @Field("data.statement_type")
     private String statementType;
-    @Field("sensitive_data.date_of_birth")
-    private DateOfBirth dateOfBirth;
-    @Field("data.links")
-    private Links links;
-    @Field("data.etag")
-    private String etag;
-    @Field("company_number")
-    private String companyNumber;
-    @Field("psc_id")
-    private String pscId;
-    @Field("updated.at")
-    private Instant updatedAt;
-    @Field("notification_id")
-    private String notificationId;
-    @Field("created.at")
-    private Instant createdAt;
-    @Field("data.identification")
-    private Identification identification;
 
     public String getId() {
         return id;
     }
 
-    public void setId(String id) { this.id = id; }
+    public void setId(String id) {
+        this.id = id;
+    }
 
-    public String getDeltaAt() { return deltaAt; }
+    public String getPscId() {
+        return pscId;
+    }
 
-    public void setDeltaAt(String deltaAt) {this.deltaAt = deltaAt; }
+    public void setPscId(String pscId) {
+        this.pscId = pscId;
+    }
 
-    public List<String> getNaturesOfControl() { return naturesOfControl; }
+    public String getDeltaAt() {
+        return deltaAt;
+    }
 
-    public void setNaturesOfControl(List<String> naturesOfControl) { this.naturesOfControl = naturesOfControl; }
+    public void setDeltaAt(String deltaAt) {
+        this.deltaAt = deltaAt;
+    }
 
-    public String getKind() { return kind; }
+    public String getNotificationId() {
+        return notificationId;
+    }
 
-    public void setKind(String kind) { this.kind = kind; }
+    public void setNotificationId(String notificationId) {
+        this.notificationId = notificationId;
+    }
+
+    public String getCompanyNumber() {
+        return companyNumber;
+    }
+
+    public void setCompanyNumber(String companyNumber) {
+        this.companyNumber = companyNumber;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Boolean getSanctioned() {
+        return sanctioned;
+    }
+
+    public void setSanctioned(Boolean sanctioned) {
+        this.sanctioned = sanctioned;
+    }
+
+    public String getEtag() {
+        return etag;
+    }
+
+    public void setEtag(String etag) {
+        this.etag = etag;
+    }
 
     public NameElements getNameElements() {
         return nameElements;
@@ -106,75 +167,167 @@ public class CompanyPscs{
         this.nameElements = nameElements;
     }
 
-    public String getName() { return name; }
-
-    public void setName(String name) { this.name = name; }
-
-    public Instant getNotifiedOn() { return notifiedOn; }
-
-    public void setNotifiedOn(Instant notifiedOn) { this.notifiedOn = notifiedOn; }
-
-    public String getNationality() { return nationality; }
-
-    public void setNationality(String nationality) { this.nationality = nationality; }
-
-    public String getPostalCode() { return postalCode; }
-
-    public void setPostalCode(String postalCode) { this.postalCode = postalCode; }
-
-    public String getPremises() { return premises; }
-
-    public void setPremises(String premises) { this.premises = premises; }
-
-    public String getLocality() { return locality; }
-
-    public void setLocality(String locality) { this.locality = locality; }
-
-    public String getCountry() { return country; }
-
-    public void setCountry(String country) { this.country = country; }
-
-    public String getAddressLine1() { return addressLine1; }
-
-    public void setAddressLine1(String addressLine1) { this.addressLine1 = addressLine1; }
-
-    public String getAddressLine2() {
-        return addressLine2;
+    public String getName() {
+        return name;
     }
 
-    public void setAddressLine2(String addressLine2) {
-        this.addressLine2 = addressLine2;
+    public void setName(String name) {
+        this.name = name;
     }
 
-    public String getCareOf() {
-        return careOf;
+    public String getKind() {
+        return kind;
     }
 
-    public void setCareOf(String careOf) {
-        this.careOf = careOf;
+    public void setKind(String kind) {
+        this.kind = kind;
     }
 
-    public String getPoBox() {
-        return poBox;
+    public Instant getNotifiedOn() {
+        return notifiedOn;
     }
 
-    public void setPoBox(String poBox) {
-        this.poBox = poBox;
+    public void setNotifiedOn(Instant notifiedOn) {
+        this.notifiedOn = notifiedOn;
     }
 
-    public String getRegion() {
-        return region;
+    public Boolean getServiceAddressSameAsRegisteredOfficeAddress() {
+        return serviceAddressSameAsRegisteredOfficeAddress;
     }
 
-    public void setRegion(String region) {
-        this.region = region;
+    public void setServiceAddressSameAsRegisteredOfficeAddress(
+            Boolean serviceAddressSameAsRegisteredOfficeAddress) {
+        this.serviceAddressSameAsRegisteredOfficeAddress =
+                serviceAddressSameAsRegisteredOfficeAddress;
+    }
+
+    public Boolean getIsSanctioned() {
+        return isSanctioned;
+    }
+
+    public void setIsSanctioned(Boolean isSanctioned) {
+        this.isSanctioned = isSanctioned;
+    }
+
+    public List<String> getNaturesOfControl() {
+        return naturesOfControl;
+    }
+
+    public void setNaturesOfControl(List<String> naturesOfControl) {
+        this.naturesOfControl = naturesOfControl;
+    }
+
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public Address getPrincipalOfficeAddress() {
+        return principalOfficeAddress;
+    }
+
+    public void setPrincipalOfficeAddress(Address principalOfficeAddress) {
+        this.principalOfficeAddress = principalOfficeAddress;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    public Address getUsualResidentialAddress() {
+        return usualResidentialAddress;
+    }
+
+    public void setUsualResidentialAddress(Address usualResidentialAddress) {
+        this.usualResidentialAddress = usualResidentialAddress;
+    }
+
+    public String getNationality() {
+        return nationality;
+    }
+
+    public void setNationality(String nationality) {
+        this.nationality = nationality;
+    }
+
+    public String getNameTitle() {
+        return nameTitle;
+    }
+
+    public void setNameTitle(String nameTitle) {
+        this.nameTitle = nameTitle;
+    }
+
+    public String getNameForename() {
+        return nameForename;
+    }
+
+    public void setNameForename(String nameForename) {
+        this.nameForename = nameForename;
+    }
+
+    public String getNameOtherForenames() {
+        return nameOtherForenames;
+    }
+
+    public void setNameOtherForenames(String nameOtherForenames) {
+        this.nameOtherForenames = nameOtherForenames;
+    }
+
+    public String getNameSurname() {
+        return nameSurname;
+    }
+
+    public void setNameSurname(String nameSurname) {
+        this.nameSurname = nameSurname;
+    }
+
+    public String getCountryOfResidence() {
+        return countryOfResidence;
+    }
+
+    public void setCountryOfResidence(String countryOfResidence) {
+        this.countryOfResidence = countryOfResidence;
+    }
+
+    public Identification getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(Identification identification) {
+        this.identification = identification;
+    }
+
+    public DateOfBirth getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(DateOfBirth dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public Boolean getResidentialAddressSameAsServiceAddress() {
+        return residentialAddressSameAsServiceAddress;
+    }
+
+    public void setResidentialAddressSameAsServiceAddress(
+            Boolean residentialAddressSameAsServiceAddress) {
+        this.residentialAddressSameAsServiceAddress = residentialAddressSameAsServiceAddress;
     }
 
     public Boolean getAddressSameAsRegisteredOfficeAddress() {
         return addressSameAsRegisteredOfficeAddress;
     }
 
-    public void setAddressSameAsRegisteredOfficeAddress(Boolean addressSameAsRegisteredOfficeAddress) {
+    public void setAddressSameAsRegisteredOfficeAddress(
+            Boolean addressSameAsRegisteredOfficeAddress) {
         this.addressSameAsRegisteredOfficeAddress = addressSameAsRegisteredOfficeAddress;
     }
 
@@ -226,47 +379,19 @@ public class CompanyPscs{
         this.statementType = statementType;
     }
 
-    public String getCountryOfResidence() { return countryOfResidence; }
-
-    public void setCountryOfResidence(String countryOfResidence) { this.countryOfResidence = countryOfResidence; }
-
-    public DateOfBirth getDateOfBirth() { return dateOfBirth; }
-
-    public void setDateOfBirth(DateOfBirth dateOfBirth) { this.dateOfBirth = dateOfBirth; }
-
-    public Links getLinks() { return links; }
-
-    public void setLinks(Links links) { this.links = links; }
-
-    public String getEtag() { return etag; }
-
-    public void setEtag(String etag) { this.etag = etag; }
-
-    public String getCompanyNumber() { return companyNumber; }
-
-    public void setCompanyNumber(String companyNumber) { this.companyNumber = companyNumber; }
-
-    public String getPscId() { return pscId; }
-
-    public void setPscId(String pscId) { this.pscId = pscId; }
-
-    public Instant getUpdatedAt() { return updatedAt; }
-
-    public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
-
-    public String getNotificationId() { return notificationId; }
-
-    public void setNotificationId(String notificationId) { this.notificationId = notificationId; }
-
-    public Instant getCreatedAt() { return createdAt; }
-
-    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
-
-    public Identification getIdentification() {
-        return identification;
+    public Boolean getCeased() {
+        return ceased;
     }
 
-    public void setIdentification(Identification identification) {
-        this.identification = identification;
+    public void setCeased(Boolean ceased) {
+        this.ceased = ceased;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyPscs.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/CompanyPscs.java
@@ -74,7 +74,7 @@ public class CompanyPscs {
     private Boolean addressSameAsRegisteredOfficeAddress;
     @Field("data.ceased_on")
     private Instant ceasedOn;
-    @Field("data.cesed")
+    @Field("data.ceased")
     private Boolean ceased;
     @Field("data.reference_etag")
     private String referenceEtag;
@@ -183,16 +183,8 @@ public class CompanyPscs {
         this.kind = kind;
     }
 
-    public Instant getNotifiedOn() {
-        return notifiedOn;
-    }
-
     public void setNotifiedOn(Instant notifiedOn) {
         this.notifiedOn = notifiedOn;
-    }
-
-    public Boolean getServiceAddressSameAsRegisteredOfficeAddress() {
-        return serviceAddressSameAsRegisteredOfficeAddress;
     }
 
     public void setServiceAddressSameAsRegisteredOfficeAddress(
@@ -201,16 +193,8 @@ public class CompanyPscs {
                 serviceAddressSameAsRegisteredOfficeAddress;
     }
 
-    public Boolean getIsSanctioned() {
-        return isSanctioned;
-    }
-
     public void setIsSanctioned(Boolean isSanctioned) {
         this.isSanctioned = isSanctioned;
-    }
-
-    public List<String> getNaturesOfControl() {
-        return naturesOfControl;
     }
 
     public void setNaturesOfControl(List<String> naturesOfControl) {
@@ -225,10 +209,6 @@ public class CompanyPscs {
         this.links = links;
     }
 
-    public Address getPrincipalOfficeAddress() {
-        return principalOfficeAddress;
-    }
-
     public void setPrincipalOfficeAddress(Address principalOfficeAddress) {
         this.principalOfficeAddress = principalOfficeAddress;
     }
@@ -241,48 +221,20 @@ public class CompanyPscs {
         this.address = address;
     }
 
-    public Address getUsualResidentialAddress() {
-        return usualResidentialAddress;
-    }
-
     public void setUsualResidentialAddress(Address usualResidentialAddress) {
         this.usualResidentialAddress = usualResidentialAddress;
-    }
-
-    public String getNationality() {
-        return nationality;
     }
 
     public void setNationality(String nationality) {
         this.nationality = nationality;
     }
 
-    public String getNameTitle() {
-        return nameTitle;
-    }
-
     public void setNameTitle(String nameTitle) {
         this.nameTitle = nameTitle;
     }
 
-    public String getNameForename() {
-        return nameForename;
-    }
-
     public void setNameForename(String nameForename) {
         this.nameForename = nameForename;
-    }
-
-    public String getNameOtherForenames() {
-        return nameOtherForenames;
-    }
-
-    public void setNameOtherForenames(String nameOtherForenames) {
-        this.nameOtherForenames = nameOtherForenames;
-    }
-
-    public String getNameSurname() {
-        return nameSurname;
     }
 
     public void setNameSurname(String nameSurname) {
@@ -297,33 +249,17 @@ public class CompanyPscs {
         this.countryOfResidence = countryOfResidence;
     }
 
-    public Identification getIdentification() {
-        return identification;
-    }
-
     public void setIdentification(Identification identification) {
         this.identification = identification;
-    }
-
-    public DateOfBirth getDateOfBirth() {
-        return dateOfBirth;
     }
 
     public void setDateOfBirth(DateOfBirth dateOfBirth) {
         this.dateOfBirth = dateOfBirth;
     }
 
-    public Boolean getResidentialAddressSameAsServiceAddress() {
-        return residentialAddressSameAsServiceAddress;
-    }
-
     public void setResidentialAddressSameAsServiceAddress(
             Boolean residentialAddressSameAsServiceAddress) {
         this.residentialAddressSameAsServiceAddress = residentialAddressSameAsServiceAddress;
-    }
-
-    public Boolean getAddressSameAsRegisteredOfficeAddress() {
-        return addressSameAsRegisteredOfficeAddress;
     }
 
     public void setAddressSameAsRegisteredOfficeAddress(
@@ -363,10 +299,6 @@ public class CompanyPscs {
         this.registerEntryDate = registerEntryDate;
     }
 
-    public Instant getStatementActionDate() {
-        return statementActionDate;
-    }
-
     public void setStatementActionDate(Instant statementActionDate) {
         this.statementActionDate = statementActionDate;
     }
@@ -377,10 +309,6 @@ public class CompanyPscs {
 
     public void setStatementType(String statementType) {
         this.statementType = statementType;
-    }
-
-    public Boolean getCeased() {
-        return ceased;
     }
 
     public void setCeased(Boolean ceased) {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -294,7 +294,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         overseasEntity.setAccounts(accounts);
 
         if (CompanyType.OVERSEA_COMPANY.equals(companyType)) {
-            overseasEntity.setHasSuperSecurePscs(Boolean.TRUE.equals(spec.getHasSuperSecurePscs()));
+            overseasEntity.setHasSuperSecurePscs(BooleanUtils.isTrue(spec.getHasSuperSecurePscs()));
             foreignCompanyDetails.setRegistrationNumber(EXT_REGISTRATION_NUMBER);
             overseasEntity.setDeltaAt(Instant.now());
             OverseasEntity.IUpdated updated = OverseasEntity.createUpdated();

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -140,8 +140,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         profile.setType(companyTypeValue);
         profile.setUndeliverableRegisteredOfficeAddress(false);
 
-        Boolean hasSuperSecurePscs = companyParams.getHasSuperSecurePscs();
-        profile.setHasSuperSecurePscs(Boolean.TRUE.equals(hasSuperSecurePscs));
+        profile.setHasSuperSecurePscs(Boolean.TRUE.equals(companyParams.getHasSuperSecurePscs()));
         setCompanyName(profile, companyNumber, companyTypeValue);
         profile.setSicCodes(Collections.singletonList("71200"));
 
@@ -294,8 +293,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         overseasEntity.setAccounts(accounts);
 
         if (CompanyType.OVERSEA_COMPANY.equals(companyType)) {
-            Boolean hasSuperSecurePscs = spec.getHasSuperSecurePscs();
-            overseasEntity.setHasSuperSecurePscs(Boolean.TRUE.equals(hasSuperSecurePscs));
+            overseasEntity.setHasSuperSecurePscs(Boolean.TRUE.equals(spec.getHasSuperSecurePscs()));
             foreignCompanyDetails.setRegistrationNumber(EXT_REGISTRATION_NUMBER);
             overseasEntity.setDeltaAt(Instant.now());
             OverseasEntity.IUpdated updated = OverseasEntity.createUpdated();

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -140,9 +140,8 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         profile.setType(companyTypeValue);
         profile.setUndeliverableRegisteredOfficeAddress(false);
 
-        if (companyParams.getHasSuperSecurePscs() != null) {
-            profile.setHasSuperSecurePscs(companyParams.getHasSuperSecurePscs());
-        }
+        Boolean hasSuperSecurePscs = companyParams.getHasSuperSecurePscs();
+        profile.setHasSuperSecurePscs(hasSuperSecurePscs != null ? hasSuperSecurePscs : false);
         setCompanyName(profile, companyNumber, companyTypeValue);
         profile.setSicCodes(Collections.singletonList("71200"));
 
@@ -295,7 +294,8 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         overseasEntity.setAccounts(accounts);
 
         if (CompanyType.OVERSEA_COMPANY.equals(companyType)) {
-            overseasEntity.setHasSuperSecurePscs(spec.getHasSuperSecurePscs());
+            Boolean hasSuperSecurePscs = spec.getHasSuperSecurePscs();
+            overseasEntity.setHasSuperSecurePscs(hasSuperSecurePscs != null ? hasSuperSecurePscs : false);
             foreignCompanyDetails.setRegistrationNumber(EXT_REGISTRATION_NUMBER);
             overseasEntity.setDeltaAt(Instant.now());
             OverseasEntity.IUpdated updated = OverseasEntity.createUpdated();

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import org.apache.commons.lang.BooleanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -141,6 +142,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         profile.setUndeliverableRegisteredOfficeAddress(false);
 
         profile.setHasSuperSecurePscs(Boolean.TRUE.equals(companyParams.getHasSuperSecurePscs()));
+        profile.setHasSuperSecurePscs(BooleanUtils.isTrue(companyParams.getHasSuperSecurePscs()));
         setCompanyName(profile, companyNumber, companyTypeValue);
         profile.setSicCodes(Collections.singletonList("71200"));
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -141,7 +141,6 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         profile.setType(companyTypeValue);
         profile.setUndeliverableRegisteredOfficeAddress(false);
 
-        profile.setHasSuperSecurePscs(Boolean.TRUE.equals(companyParams.getHasSuperSecurePscs()));
         profile.setHasSuperSecurePscs(BooleanUtils.isTrue(companyParams.getHasSuperSecurePscs()));
         setCompanyName(profile, companyNumber, companyTypeValue);
         profile.setSicCodes(Collections.singletonList("71200"));

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -141,7 +141,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         profile.setUndeliverableRegisteredOfficeAddress(false);
 
         Boolean hasSuperSecurePscs = companyParams.getHasSuperSecurePscs();
-        profile.setHasSuperSecurePscs(hasSuperSecurePscs != null ? hasSuperSecurePscs : false);
+        profile.setHasSuperSecurePscs(Boolean.TRUE.equals(hasSuperSecurePscs));
         setCompanyName(profile, companyNumber, companyTypeValue);
         profile.setSicCodes(Collections.singletonList("71200"));
 
@@ -295,7 +295,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
 
         if (CompanyType.OVERSEA_COMPANY.equals(companyType)) {
             Boolean hasSuperSecurePscs = spec.getHasSuperSecurePscs();
-            overseasEntity.setHasSuperSecurePscs(hasSuperSecurePscs != null ? hasSuperSecurePscs : false);
+            overseasEntity.setHasSuperSecurePscs(Boolean.TRUE.equals(hasSuperSecurePscs));
             foreignCompanyDetails.setRegistrationNumber(EXT_REGISTRATION_NUMBER);
             overseasEntity.setDeltaAt(Instant.now());
             OverseasEntity.IUpdated updated = OverseasEntity.createUpdated();

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
@@ -43,6 +43,9 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs, CompanyS
     public static final String SUPER_SECURE_BO = "super-secure-beneficial-owner";
     public static final String URL_PREFIX = "/company/";
     public static final String PSC_SUFFIX = "/persons-with-significant-control/";
+    public static final String TITLE = "Dr.";
+    public static final String FIRST_NAME = "First";
+    public static final String LAST_NAME = "Last";
 
     private final RandomService randomService;
     private final CompanyPscsRepository repository;
@@ -212,10 +215,10 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs, CompanyS
         beneficialOwner.setNationality(NATIONALITY);
         beneficialOwner.setDateOfBirth(new DateOfBirth(20, 9, 1975));
 
-        beneficialOwner.setNameTitle("Dr.");
-        beneficialOwner.setNameForename("Dray");
-        beneficialOwner.setNameSurname("Day");
-        beneficialOwner.setName("Dr. Dray Day");
+        beneficialOwner.setNameTitle(TITLE);
+        beneficialOwner.setNameForename(FIRST_NAME);
+        beneficialOwner.setNameSurname(LAST_NAME);
+        beneficialOwner.setName(TITLE + " " + FIRST_NAME + " " + LAST_NAME);
 
         beneficialOwner.setSanctioned(false);
         beneficialOwner.setIsSanctioned(false);
@@ -231,7 +234,7 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs, CompanyS
 
     private void buildCorporateBeneficialOwner(CompanyPscs beneficialOwner) {
         beneficialOwner.setKind(PscType.CORPORATE_BENEFICIAL_OWNER.getKind());
-        beneficialOwner.setName("James Bond");
+        beneficialOwner.setName(FIRST_NAME + " " + LAST_NAME);
 
         var links = new Links();
         links.setSelf(URL_PREFIX + beneficialOwner.getCompanyNumber()

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
@@ -40,6 +40,9 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs, CompanyS
     public static final String REGISTRATION_NUMBER = "12345678";
     public static final String LEGAL_FORM = "Legal Form";
     public static final String LEGAL_AUTHORITY = "Legal Authority";
+    public static final String SUPER_SECURE_BO = "super-secure-beneficial-owner";
+    public static final String URL_PREFIX = "/company/";
+    public static final String PSC_SUFFIX = "/persons-with-significant-control/";
 
     private final RandomService randomService;
     private final CompanyPscsRepository repository;
@@ -61,7 +64,7 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs, CompanyS
         CORPORATE_BENEFICIAL_OWNER(
                 "corporate-entity-beneficial-owner", "corporate-entity-beneficial-owner"),
         SUPER_SECURE_BENEFICIAL_OWNER(
-                "super-secure-beneficial-owner", "super-secure-beneficial-owner"),
+                SUPER_SECURE_BO, SUPER_SECURE_BO),
         SUPER_SECURE_PSC("super-secure-person-with-significant-control", "super-secure");
 
         private final String kind;
@@ -121,12 +124,12 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs, CompanyS
 
     private void buildSuperSecureBeneficialOwner(CompanyPscs companyPscs) {
         companyPscs.setKind(PscType.SUPER_SECURE_BENEFICIAL_OWNER.getKind());
-        companyPscs.setDescription("super-secure-beneficial-owner");
+        companyPscs.setDescription(SUPER_SECURE_BO);
         companyPscs.setCeased(false);
 
-        Links links = new Links();
-        links.setSelf("/company/" + companyPscs.getCompanyNumber()
-                + "/persons-with-significant-control/"
+        var links = new Links();
+        links.setSelf(URL_PREFIX + companyPscs.getCompanyNumber()
+                + PSC_SUFFIX
                 + PscType.SUPER_SECURE_BENEFICIAL_OWNER.getLinkType() + "/" + companyPscs.getId());
         companyPscs.setLinks(links);
     }
@@ -136,10 +139,9 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs, CompanyS
         companyPscs.setDescription("super-secure-persons-with-significant-control");
         companyPscs.setCeased(false);
 
-        Links links = new Links();
-        links.setSelf("/company/" + companyPscs.getCompanyNumber()
-                + "/persons-with-significant-control/"
-                + PscType.SUPER_SECURE_PSC.getLinkType() + "/" + companyPscs.getId());
+        var links = new Links();
+        links.setSelf(URL_PREFIX + companyPscs.getCompanyNumber()
+                + PSC_SUFFIX + PscType.SUPER_SECURE_PSC.getLinkType() + "/" + companyPscs.getId());
         companyPscs.setLinks(links);
     }
 
@@ -149,8 +151,7 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs, CompanyS
             case INDIVIDUAL:
                 buildIndividualPsc(companyPscs, pscType.getKind(), pscType.getLinkType());
                 break;
-            case LEGAL_PERSON:
-            case CORPORATE_ENTITY:
+            case LEGAL_PERSON, CORPORATE_ENTITY:
                 buildWithIdentificationPsc(companyPscs, pscType.getKind(), pscType.getLinkType());
                 break;
 
@@ -219,10 +220,9 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs, CompanyS
         beneficialOwner.setSanctioned(false);
         beneficialOwner.setIsSanctioned(false);
 
-        Links links = new Links();
-        links.setSelf("/company/" + beneficialOwner.getCompanyNumber()
-                + "/persons-with-significant-control/"
-                + PscType.INDIVIDUAL_BENEFICIAL_OWNER.getLinkType()
+        var links = new Links();
+        links.setSelf(URL_PREFIX + beneficialOwner.getCompanyNumber()
+                + PSC_SUFFIX + PscType.INDIVIDUAL_BENEFICIAL_OWNER.getLinkType()
                 + "/" + beneficialOwner.getId());
 
         beneficialOwner.setUsualResidentialAddress(addressService.getAddress(Jurisdiction.NON_EU));
@@ -233,17 +233,17 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs, CompanyS
         beneficialOwner.setKind(PscType.CORPORATE_BENEFICIAL_OWNER.getKind());
         beneficialOwner.setName("James Bond");
 
-        Links links = new Links();
-        links.setSelf("/company/" + beneficialOwner.getCompanyNumber()
-                + "/persons-with-significant-control/"
-                + PscType.CORPORATE_BENEFICIAL_OWNER.getLinkType() + "/" + beneficialOwner.getId());
+        var links = new Links();
+        links.setSelf(URL_PREFIX + beneficialOwner.getCompanyNumber()
+                + PSC_SUFFIX + PscType.CORPORATE_BENEFICIAL_OWNER.getLinkType()
+                + "/" + beneficialOwner.getId());
 
         beneficialOwner.setSanctioned(false);
         beneficialOwner.setIsSanctioned(false);
 
         beneficialOwner.setPrincipalOfficeAddress(addressService.getAddress(Jurisdiction.NON_EU));
 
-        Identification identification = new Identification();
+        var identification = new Identification();
         identification.setLegalAuthority(LEGAL_AUTHORITY);
         identification.setLegalForm(LEGAL_FORM);
         beneficialOwner.setIdentification(identification);
@@ -279,8 +279,8 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs, CompanyS
                 + " " + nameElements.getOtherForenames() + " " + nameElements.getSurname());
 
         Links links = new Links();
-        links.setSelf("/company/" + companyPsc.getCompanyNumber()
-                + "/persons-with-significant-control/" + linkType + "/" + companyPsc.getId());
+        links.setSelf(URL_PREFIX + companyPsc.getCompanyNumber()
+                + PSC_SUFFIX + linkType + "/" + companyPsc.getId());
         companyPsc.setLinks(links);
     }
 
@@ -300,8 +300,8 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs, CompanyS
         companyPsc.setName("Mr A Jones");
 
         Links links = new Links();
-        links.setSelf("/company/" + companyPsc.getCompanyNumber()
-                + "/persons-with-significant-control/"
+        links.setSelf(URL_PREFIX + companyPsc.getCompanyNumber()
+                + PSC_SUFFIX
                 + linkType + "/" + companyPsc.getId());
         companyPsc.setLinks(links);
     }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
@@ -266,6 +266,9 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs, CompanyS
     private void buildIndividualPsc(CompanyPscs companyPsc, String pscType, String linkType) {
         companyPsc.setKind(pscType);
         companyPsc.setCountryOfResidence(addressService.getCountryOfResidence(Jurisdiction.WALES));
+        companyPsc.setAddress(addressService.getAddress(Jurisdiction.SCOTLAND));
+        companyPsc.setUsualResidentialAddress(addressService.getAddress(Jurisdiction.WALES));
+        companyPsc.setResidentialAddressSameAsServiceAddress(false);
         companyPsc.setNationality(NATIONALITY);
         companyPsc.setDateOfBirth(new DateOfBirth(20, 9, 1975));
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -115,17 +115,7 @@ public class TestDataServiceImpl implements TestDataService {
             var authCode = companyAuthCodeService.create(spec);
             companyMetricsService.create(spec);
             companyPscStatementService.create(spec);
-
-            // Logic for creating PSCs checks the repository for existing PSCs
-            // before proceeding to create a PSC. This creates a default of 3 PSCs
-            // Personal, Legal and Corporate PSCs.
-            if (Jurisdiction.UNITED_KINGDOM.equals(spec.getJurisdiction())) {
-                companyPscsService.create(spec);
-            } else {
-                companyPscsService.create(spec);
-                companyPscsService.create(spec);
-                companyPscsService.create(spec);
-            }
+            companyPscsService.create(spec);
 
             if (spec.getRegisters() != null && !spec.getRegisters().isEmpty()) {
                 this.companyRegistersService.create(spec);

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -93,14 +93,12 @@ class CompanyProfileServiceImplTest {
         savedProfile = new CompanyProfile();
     }
 
-    // Helper method to set up common mocks for create tests.
     private void setupCommonMocks(CompanySpec spec, Address mockAddress) {
         Mockito.lenient().when(randomService.getEtag()).thenReturn(ETAG);
         Mockito.lenient().when(repository.save(any())).thenReturn(savedProfile);
         Mockito.lenient().when(addressService.getAddress(spec.getJurisdiction())).thenReturn(mockAddress);
     }
 
-    // Helper method that performs create() and captures the saved CompanyProfile.
     private CompanyProfile createAndCapture(CompanySpec spec) {
         Address mockAddress = new Address("", "", "", "", "", "");
         setupCommonMocks(spec, mockAddress);
@@ -110,7 +108,6 @@ class CompanyProfileServiceImplTest {
         return captor.getValue();
     }
 
-    // Common assertions for a created CompanyProfile.
     private void assertCreatedProfile(CompanyProfile profile, String companyStatus, String jurisdiction,
                                       String companyType, Boolean hasInsolvencyHistory) {
         assertEquals(COMPANY_NUMBER, profile.getId());
@@ -271,7 +268,7 @@ class CompanyProfileServiceImplTest {
     void createCompanyWithSuperSecurePscsNull() {
         spec.setHasSuperSecurePscs(null);
         CompanyProfile profile = createAndCapture(spec);
-        assertNull(profile.getHasSuperSecurePscs());
+        assertFalse(profile.getHasSuperSecurePscs());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImplTest.java
@@ -1,8 +1,17 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.time.LocalDate;

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImplTest.java
@@ -1,24 +1,14 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static uk.gov.companieshouse.api.testdata.service.impl.CompanyPscsServiceImpl.NATURES_OF_CONTROL;
+import static org.mockito.Mockito.*;
 
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalLong;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,324 +18,184 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscs;
-import uk.gov.companieshouse.api.testdata.model.entity.Identification;
-import uk.gov.companieshouse.api.testdata.model.entity.Links;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
+import uk.gov.companieshouse.api.testdata.model.rest.CompanyType;
 import uk.gov.companieshouse.api.testdata.repository.CompanyPscsRepository;
+import uk.gov.companieshouse.api.testdata.service.AddressService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 
 @ExtendWith(MockitoExtension.class)
 class CompanyPscsServiceImplTest {
 
-    private static final int ID_LENGTH = 10;
-    private static final int SALT_LENGTH = 8;
     private static final String COMPANY_NUMBER = "12345678";
-    private static final String ENCODED_VALUE = "ENCODED";
-    private static final String ETAG = "ETAG";
-    private static final String INDIVIDUAL = "individual-person-with-significant-control";
-    private static final Instant dateNowInstant
-            = LocalDate.now().atStartOfDay(ZoneId.of("UTC")).toInstant();
+    private static final String ENCODED_ID = "encoded123";
+    private static final String ETAG = "etag123";
+    private static final Instant NOW = LocalDate.now().atStartOfDay(ZoneId.of("UTC")).toInstant();
 
     @Mock
     private CompanyPscsRepository repository;
     @Mock
     private RandomService randomService;
+    @Mock
+    private AddressService addressService;
 
     @InjectMocks
     private CompanyPscsServiceImpl companyPscsService;
 
     @Test
-    void create() throws DataException {
-
+    void create_StandardCompany_CreatesThreePscs() throws DataException {
         CompanySpec spec = new CompanySpec();
         spec.setCompanyNumber(COMPANY_NUMBER);
+        spec.setCompanyType(CompanyType.LTD);
 
-        CompanyPscs savedPsc = new CompanyPscs();
-        when(this.repository.save(any())).thenReturn(savedPsc);
+        when(randomService.getEncodedIdWithSalt(anyInt(), anyInt())).thenReturn(ENCODED_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(new CompanyPscs());
 
-        when(this.randomService.getEncodedIdWithSalt(ID_LENGTH, SALT_LENGTH))
-                .thenReturn(ENCODED_VALUE);
-        when(this.randomService.getEtag()).thenReturn(ETAG);
-        when(randomService.getNumberInRange(0, NATURES_OF_CONTROL.length))
-                .thenReturn(OptionalLong.of(2L), OptionalLong.of(1L), OptionalLong.of(4L));
+        CompanyPscs result = companyPscsService.create(spec);
 
-        CompanyPscs returnedPsc = this.companyPscsService.create(spec);
-
-        assertEquals(savedPsc, returnedPsc);
-
-        verify(repository).save(argThat(this::hasExpectedValues));
-    }
-
-    private boolean hasExpectedValues(CompanyPscs companyPsc) {
-
-        assertNotNull(companyPsc);
-
-        assertEquals(ENCODED_VALUE, companyPsc.getId());
-
-        assertEquals(COMPANY_NUMBER, companyPsc.getCompanyNumber());
-
-        assertEquals("34 Silver Street", companyPsc.getAddressLine1());
-        assertEquals("Silverstone", companyPsc.getAddressLine2());
-        assertEquals("Care of", companyPsc.getCareOf());
-        assertEquals("Wales", companyPsc.getCountry());
-        assertEquals("Cardiff", companyPsc.getLocality());
-        assertEquals("Po Box", companyPsc.getPoBox());
-        assertEquals("CF14 3UZ", companyPsc.getPostalCode());
-        assertEquals("1", companyPsc.getPremises());
-        assertEquals("UK", companyPsc.getRegion());
-        assertEquals(true, companyPsc.getAddressSameAsRegisteredOfficeAddress());
-
-        assertNotNull(companyPsc.getCeasedOn());
-        assertEquals(dateNowInstant, companyPsc.getCeasedOn());
-        assertNotNull(companyPsc.getCreatedAt());
-        assertEquals(dateNowInstant, companyPsc.getCreatedAt());
-
-        List<String> nocList = Arrays.asList(NATURES_OF_CONTROL);
-        assertTrue(nocList.containsAll(companyPsc.getNaturesOfControl()));
-
-        assertEquals(dateNowInstant, companyPsc.getNotifiedOn());
-        assertEquals("reference etag", companyPsc.getReferenceEtag());
-        assertEquals("reference psc id", companyPsc.getReferencePscId());
-        assertEquals(dateNowInstant, companyPsc.getRegisterEntryDate());
-        assertNotNull(companyPsc.getUpdatedAt());
-        assertEquals(dateNowInstant, companyPsc.getUpdatedAt());
-
-        assertNotNull(companyPsc.getStatementActionDate());
-        assertEquals(dateNowInstant, companyPsc.getStatementActionDate());
-        assertEquals("statement type", companyPsc.getStatementType());
-
-        if (companyPsc.getKind().equals(INDIVIDUAL)) {
-
-            assertEquals("Mr Test Tester Testington", companyPsc.getNameElements().toString());
-            assertEquals("British", companyPsc.getNationality());
-            assertNotNull(companyPsc.getDateOfBirth());
-            assertNotNull(companyPsc.getDateOfBirth().getDay());
-            assertNotNull(companyPsc.getDateOfBirth().getMonth());
-            assertNotNull(companyPsc.getDateOfBirth().getYear());
-            assertEquals("Wales", companyPsc.getCountryOfResidence());
-
-        } else {
-            Identification identification = companyPsc.getIdentification();
-            assertEquals("UK", identification.getCountryRegistered());
-            assertEquals("Legal Authority", identification.getLegalAuthority());
-            assertEquals("Legal Form", identification.getLegalForm());
-            assertEquals("Wales", identification.getPlaceRegistered());
-            assertEquals("123456", identification.getRegistrationNumber());
-        }
-
-        assertEquals("individual-person-with-significant-control", companyPsc.getKind());
-
-        Links links = companyPsc.getLinks();
-        assertEquals("/company/" + COMPANY_NUMBER + "/persons-with-significant-control/individual/"
-                + ENCODED_VALUE, links.getSelf());
-        return true;
+        assertNotNull(result);
+        verify(repository, times(3)).save(any(CompanyPscs.class));
     }
 
     @Test
-    void createWhenThereIsAlreadyASinglePsc() throws DataException {
-
+    void create_OverseasEntity_CreatesBeneficialOwners() throws DataException {
         CompanySpec spec = new CompanySpec();
         spec.setCompanyNumber(COMPANY_NUMBER);
+        spec.setCompanyType(CompanyType.REGISTERED_OVERSEAS_ENTITY);
 
-        CompanyPscs savedPsc = new CompanyPscs();
-        when(this.repository.save(any())).thenReturn(savedPsc);
+        when(randomService.getEncodedIdWithSalt(anyInt(), anyInt())).thenReturn(ENCODED_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(new CompanyPscs());
 
-        when(this.randomService.getEncodedIdWithSalt(ID_LENGTH, SALT_LENGTH))
-                .thenReturn(ENCODED_VALUE);
-        when(this.randomService.getEtag()).thenReturn(ETAG);
+        CompanyPscs result = companyPscsService.create(spec);
 
-        when(repository.findByCompanyNumber(COMPANY_NUMBER))
-                .thenReturn(Optional.of(buildListOfCompanyPscs(1)));
-
-        CompanyPscs returnedPsc = this.companyPscsService.create(spec);
-
-        assertEquals(savedPsc, returnedPsc);
-
-        ArgumentCaptor<CompanyPscs> pscCaptor = ArgumentCaptor.forClass(CompanyPscs.class);
-        verify(repository).save(pscCaptor.capture());
-
-        CompanyPscs companyPsc = pscCaptor.getValue();
-        assertNotNull(companyPsc);
-
-        assertEquals("Mr A Jones", companyPsc.getName());
-        assertEquals("legal-person-person-with-significant-control", companyPsc.getKind());
-
-        Links links = companyPsc.getLinks();
-        assertEquals("/company/" + COMPANY_NUMBER
-                + "/persons-with-significant-control/legal-person/"
-                + ENCODED_VALUE, links.getSelf());
+        assertNotNull(result);
+        verify(repository, times(2)).save(any(CompanyPscs.class));
     }
 
     @Test
-    void createWhenThereAreAlreadyTwoPscs() throws DataException {
-
+    void create_SuperSecurePsc_CreatesSuperSecurePsc() throws DataException {
         CompanySpec spec = new CompanySpec();
         spec.setCompanyNumber(COMPANY_NUMBER);
+        spec.setCompanyType(CompanyType.LTD);
+        spec.setHasSuperSecurePscs(true);
 
-        CompanyPscs savedPsc = new CompanyPscs();
-        when(this.repository.save(any())).thenReturn(savedPsc);
+        when(randomService.getEncodedIdWithSalt(anyInt(), anyInt())).thenReturn(ENCODED_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(new CompanyPscs());
 
-        when(this.randomService.getEncodedIdWithSalt(ID_LENGTH, SALT_LENGTH))
-                .thenReturn(ENCODED_VALUE);
-        when(this.randomService.getEtag()).thenReturn(ETAG);
+        CompanyPscs result = companyPscsService.create(spec);
 
-        when(repository.findByCompanyNumber(COMPANY_NUMBER))
-                .thenReturn(Optional.of(buildListOfCompanyPscs(2)));
+        assertNotNull(result);
 
-        CompanyPscs returnedPsc = this.companyPscsService.create(spec);
+        ArgumentCaptor<CompanyPscs> captor = ArgumentCaptor.forClass(CompanyPscs.class);
+        verify(repository).save(captor.capture());
 
-        assertEquals(savedPsc, returnedPsc);
-
-        ArgumentCaptor<CompanyPscs> pscCaptor = ArgumentCaptor.forClass(CompanyPscs.class);
-        verify(repository).save(pscCaptor.capture());
-
-        CompanyPscs companyPsc = pscCaptor.getValue();
-        assertNotNull(companyPsc);
-
-
-        assertEquals("Mr A Jones", companyPsc.getName());
-        assertEquals("corporate-entity-person-with-significant-control", companyPsc.getKind());
-
-        Links links = companyPsc.getLinks();
-        assertEquals("/company/" + COMPANY_NUMBER
-                + "/persons-with-significant-control/corporate-entity/"
-                + ENCODED_VALUE, links.getSelf());
+        CompanyPscs savedPsc = captor.getValue();
+        assertEquals("super-secure-person-with-significant-control", savedPsc.getKind());
+        assertEquals("super-secure-persons-with-significant-control", savedPsc.getDescription());
     }
 
     @Test
-    void delete() {
-        List<CompanyPscs> companyPscs = new ArrayList<>();
-        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(companyPscs));
-
-        assertTrue(this.companyPscsService.delete(COMPANY_NUMBER));
-        verify(repository).deleteAll(companyPscs);
-    }
-
-    @Test
-    void deleteNoDataException() {
-        when(repository.findByCompanyNumber(COMPANY_NUMBER))
-                .thenReturn(Optional.empty());
-
-        assertFalse(this.companyPscsService.delete(COMPANY_NUMBER));
-        verify(repository, never()).deleteAll(any());
-    }
-
-    private List<CompanyPscs> buildListOfCompanyPscs(int howManyPscs) {
-        List<CompanyPscs> listOfCompanyPscs = new ArrayList<>();
-        var companyPscs = new CompanyPscs();
-        for (int i = 0; i < howManyPscs; i++) {
-            listOfCompanyPscs.add(companyPscs);
-        }
-        return listOfCompanyPscs;
-    }
-
-    @Test
-    void createWhenAccountsDueStatusIsNull() throws DataException {
+    void create_SuperSecureBeneficialOwner_CreatesCorrectType() throws DataException {
         CompanySpec spec = new CompanySpec();
         spec.setCompanyNumber(COMPANY_NUMBER);
-        spec.setAccountsDueStatus(null);
+        spec.setCompanyType(CompanyType.REGISTERED_OVERSEAS_ENTITY);
+        spec.setHasSuperSecurePscs(true);
 
-        CompanyPscs savedPsc = new CompanyPscs();
-        when(this.repository.save(any())).thenReturn(savedPsc);
+        when(randomService.getEncodedIdWithSalt(anyInt(), anyInt())).thenReturn(ENCODED_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(new CompanyPscs());
 
-        when(this.randomService.getEncodedIdWithSalt(ID_LENGTH, SALT_LENGTH))
-                .thenReturn(ENCODED_VALUE);
-        when(this.randomService.getEtag()).thenReturn(ETAG);
+        CompanyPscs result = companyPscsService.create(spec);
 
-        CompanyPscs returnedPsc = this.companyPscsService.create(spec);
+        assertNotNull(result);
 
-        assertEquals(savedPsc, returnedPsc);
+        ArgumentCaptor<CompanyPscs> captor = ArgumentCaptor.forClass(CompanyPscs.class);
+        verify(repository).save(captor.capture());
 
-        ArgumentCaptor<CompanyPscs> pscCaptor = ArgumentCaptor.forClass(CompanyPscs.class);
-        verify(repository).save(pscCaptor.capture());
-
-        CompanyPscs capturedPsc = pscCaptor.getValue();
-        assertNotNull(capturedPsc);
-        assertEquals(ENCODED_VALUE, capturedPsc.getId());
-        assertEquals(COMPANY_NUMBER, capturedPsc.getCompanyNumber());
-        assertNotNull(capturedPsc.getCeasedOn());
-        assertEquals(dateNowInstant, capturedPsc.getCeasedOn());
-        assertNotNull(capturedPsc.getCreatedAt());
-        assertEquals(dateNowInstant, capturedPsc.getCreatedAt());
-        assertEquals(dateNowInstant, capturedPsc.getNotifiedOn());
-        assertEquals(dateNowInstant, capturedPsc.getRegisterEntryDate());
-        assertNotNull(capturedPsc.getUpdatedAt());
-        assertEquals(dateNowInstant, capturedPsc.getUpdatedAt());
-        assertNotNull(capturedPsc.getStatementActionDate());
-        assertEquals(dateNowInstant, capturedPsc.getStatementActionDate());
+        CompanyPscs savedPsc = captor.getValue();
+        assertEquals("super-secure-beneficial-owner", savedPsc.getKind());
+        assertEquals("super-secure-beneficial-owner", savedPsc.getDescription());
     }
 
     @Test
-    void createWhenAccountsDueStatusIsDueSoon() throws DataException {
+    void create_OverseaCompany_ReturnsNull() throws DataException {
+        CompanySpec spec = new CompanySpec();
+        spec.setCompanyNumber(COMPANY_NUMBER);
+        spec.setCompanyType(CompanyType.OVERSEA_COMPANY);
+
+        CompanyPscs result = companyPscsService.create(spec);
+
+        assertNull(result);
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void create_WithAccountsDueStatus_SetsCorrectDates() throws DataException {
         CompanySpec spec = new CompanySpec();
         spec.setCompanyNumber(COMPANY_NUMBER);
         spec.setAccountsDueStatus("due-soon");
+        LocalDate dueDate = LocalDate.now().plusDays(10);
 
-        CompanyPscs savedPsc = new CompanyPscs();
-        when(this.repository.save(any())).thenReturn(savedPsc);
+        when(randomService.generateAccountsDueDateByStatus("due-soon")).thenReturn(dueDate);
+        when(randomService.getEncodedIdWithSalt(anyInt(), anyInt())).thenReturn(ENCODED_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(new CompanyPscs());
 
-        when(this.randomService.getEncodedIdWithSalt(ID_LENGTH, SALT_LENGTH))
-                .thenReturn(ENCODED_VALUE);
-        when(this.randomService.getEtag()).thenReturn(ETAG);
-        when(randomService.generateAccountsDueDateByStatus("due-soon")).thenReturn(LocalDate.now());
+        companyPscsService.create(spec);
 
-        CompanyPscs returnedPsc = this.companyPscsService.create(spec);
+        ArgumentCaptor<CompanyPscs> captor = ArgumentCaptor.forClass(CompanyPscs.class);
+        verify(repository, atLeastOnce()).save(captor.capture());
 
-        assertEquals(savedPsc, returnedPsc);
-
-        ArgumentCaptor<CompanyPscs> pscCaptor = ArgumentCaptor.forClass(CompanyPscs.class);
-        verify(repository).save(pscCaptor.capture());
-
-        CompanyPscs capturedPsc = pscCaptor.getValue();
-        assertNotNull(capturedPsc);
-        assertEquals(ENCODED_VALUE, capturedPsc.getId());
-        assertEquals(COMPANY_NUMBER, capturedPsc.getCompanyNumber());
-        assertNotNull(capturedPsc.getCeasedOn());
-        assertEquals(dateNowInstant, capturedPsc.getCeasedOn());
-        assertNotNull(capturedPsc.getCreatedAt());
-        assertEquals(dateNowInstant, capturedPsc.getCreatedAt());
-        assertEquals(dateNowInstant, capturedPsc.getNotifiedOn());
-        assertEquals(dateNowInstant, capturedPsc.getRegisterEntryDate());
-        assertNotNull(capturedPsc.getUpdatedAt());
-        assertEquals(dateNowInstant, capturedPsc.getUpdatedAt());
-        assertNotNull(capturedPsc.getStatementActionDate());
-        assertEquals(dateNowInstant, capturedPsc.getStatementActionDate());
+        Instant expectedInstant = dueDate.atStartOfDay(ZoneId.of("UTC")).toInstant();
+        assertTrue(captor.getAllValues().stream()
+                .anyMatch(psc -> expectedInstant.equals(psc.getCreatedAt())));
     }
 
     @Test
-    void createWhenAccountsDueStatusIsOverDue() throws DataException {
+    void delete_CompanyWithPscs_DeletesAll() {
+        List<CompanyPscs> pscs = List.of(new CompanyPscs(), new CompanyPscs());
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(pscs));
+
+        boolean result = companyPscsService.delete(COMPANY_NUMBER);
+
+        assertTrue(result);
+        verify(repository).deleteAll(pscs);
+    }
+
+    @Test
+    void delete_CompanyWithoutPscs_ReturnsFalse() {
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.empty());
+
+        boolean result = companyPscsService.delete(COMPANY_NUMBER);
+
+        assertFalse(result);
+        verify(repository, never()).deleteAll(any());
+    }
+
+    @Test
+    void create_StandardCompany_VerifyBaseFields() throws DataException {
         CompanySpec spec = new CompanySpec();
         spec.setCompanyNumber(COMPANY_NUMBER);
-        spec.setAccountsDueStatus("overdue");
+        spec.setCompanyType(CompanyType.LTD);
 
-        CompanyPscs savedPsc = new CompanyPscs();
-        when(this.repository.save(any())).thenReturn(savedPsc);
+        when(randomService.getEncodedIdWithSalt(anyInt(), anyInt())).thenReturn(ENCODED_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(new CompanyPscs());
 
-        when(this.randomService.getEncodedIdWithSalt(ID_LENGTH, SALT_LENGTH))
-                .thenReturn(ENCODED_VALUE);
-        when(this.randomService.getEtag()).thenReturn(ETAG);
-        when(randomService.generateAccountsDueDateByStatus("overdue")).thenReturn(LocalDate.now());
+        companyPscsService.create(spec);
 
-        CompanyPscs returnedPsc = this.companyPscsService.create(spec);
+        ArgumentCaptor<CompanyPscs> captor = ArgumentCaptor.forClass(CompanyPscs.class);
+        verify(repository, atLeastOnce()).save(captor.capture());
 
-        assertEquals(savedPsc, returnedPsc);
-
-        ArgumentCaptor<CompanyPscs> pscCaptor = ArgumentCaptor.forClass(CompanyPscs.class);
-        verify(repository).save(pscCaptor.capture());
-
-        CompanyPscs capturedPsc = pscCaptor.getValue();
-        assertNotNull(capturedPsc);
-        assertEquals(ENCODED_VALUE, capturedPsc.getId());
-        assertEquals(COMPANY_NUMBER, capturedPsc.getCompanyNumber());
-        assertNotNull(capturedPsc.getCeasedOn());
-        assertEquals(dateNowInstant, capturedPsc.getCeasedOn());
-        assertNotNull(capturedPsc.getCreatedAt());
-        assertEquals(dateNowInstant, capturedPsc.getCreatedAt());
-        assertEquals(dateNowInstant, capturedPsc.getNotifiedOn());
-        assertEquals(dateNowInstant, capturedPsc.getRegisterEntryDate());
-        assertNotNull(capturedPsc.getUpdatedAt());
-        assertEquals(dateNowInstant, capturedPsc.getUpdatedAt());
-        assertNotNull(capturedPsc.getStatementActionDate());
-        assertEquals(dateNowInstant, capturedPsc.getStatementActionDate());
+        CompanyPscs savedPsc = captor.getValue();
+        assertEquals(COMPANY_NUMBER, savedPsc.getCompanyNumber());
+        assertEquals(ENCODED_ID, savedPsc.getId());
+        assertEquals(ETAG, savedPsc.getEtag());
+        assertEquals("statement type", savedPsc.getStatementType());
+        assertNotNull(savedPsc.getCreatedAt());
+        assertNotNull(savedPsc.getUpdatedAt());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
@@ -161,7 +161,7 @@ class TestDataServiceImplTest {
         verify(appointmentService, times(1)).create(capturedSpec);
         verify(companyPscStatementService, times(1)).create(capturedSpec);
         verify(metricsService, times(1)).create(capturedSpec);
-        verify(companyPscsService, times(3)).create(capturedSpec);
+        verify(companyPscsService, times(1)).create(capturedSpec);
 
         assertEquals(expectedFullCompanyNumber, createdCompany.getCompanyNumber());
         assertEquals(API_URL + "/company/" + expectedFullCompanyNumber, createdCompany.getCompanyUri());


### PR DESCRIPTION
# Beneficial Owners and Super_Secure PSC

1. TestDataService now calls the CompanyPscsService once
2. Based on Company Type, PSC is created for Beneficial Owner or Standard PSC
3. hasSuperSecurePsc has a default value of 'false', setting it to 'true' creates; a 

- Super_Secure_Person_with_significant_control or
- super_secure_beneficial_owner