### PR TITLE
IDVA6-1465 delete an ACSP membership by user_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ In order to use the generator, there are different possible endpoints that can b
 
   A usage example looks like this: `{"user_id": "rsf3pdwywvse5yz55mfodfx8","user_role": "test","status": "test","acsp_profile": {"type": "test","status": "test", "acsp_number": "TestACSP", "aml_details": [ {"supervisory_body": "association-of-chartered-certified-accountants-acca","membership_details": "test"} ] } }`
 - DELETE: Sending a DELETE request on the endpoint `{Base URL}/test-data/acsp-members/{acspMemberId}` will delete the test `Acsp Member` and associated `Acsp Profile`. `acspMemberId` is required to delete the Acsp Member.
+- DELETE: Sending a DELETE request on the endpoint `{Base URL}/test-data/acsp-members/user-id/{userId}` will delete the test `Acsp Membership` by their user_id. `userId` is required to delete the Acsp Membership. Does not delete the associated `Acsp Profile`.
 
 #### Deleting Appeals
 - DELETE: Sending a DELETE request on the endpoint `{Base URL}/test-data/appeals` will delete the appeals by providing 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -189,4 +189,25 @@ public class TestDataController {
             return  new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
     }
+
+    @DeleteMapping("/acsp-members/user-id/{userId}")
+    public ResponseEntity<Map<String, Object>> deleteAcspMemberByUserId(@PathVariable("userId")
+                                                                        String userId)
+            throws DataException {
+        Map<String, Object> response = new HashMap<>();
+        response.put("user-id", userId);
+        boolean deleteAcspMember = testDataService.deleteAcspMemberDataByUserId(userId);
+        if (deleteAcspMember) {
+            LOG.info("Acsp membership with user-id " + userId
+                            + " has been deleted",
+                    response);
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } else {
+            response.put(STATUS, HttpStatus.NOT_FOUND);
+            LOG.info("Acsp membership with user-id " + userId
+                            + " was not found",
+                    response);
+            return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/repository/AcspMembersRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/repository/AcspMembersRepository.java
@@ -1,9 +1,11 @@
 package uk.gov.companieshouse.api.testdata.repository;
 
+import java.util.List;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 import uk.gov.companieshouse.api.testdata.model.entity.AcspMembers;
 
 @NoRepositoryBean
 public interface AcspMembersRepository extends MongoRepository<AcspMembers, String> {
+    List<AcspMembers> findAllByUserId(String userId);
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/AcspMembersService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/AcspMembersService.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.api.testdata.service;
+
+import java.util.List;
+
+import uk.gov.companieshouse.api.testdata.model.entity.AcspMembers;
+import uk.gov.companieshouse.api.testdata.model.rest.AcspMembersData;
+import uk.gov.companieshouse.api.testdata.model.rest.AcspMembersSpec;
+
+public interface AcspMembersService extends DataService<AcspMembersData, AcspMembersSpec> {
+
+    /**
+     * Retrieves ACSP memberships associated with the given user_id.
+     *
+     * @param userId the user_id of the user whose acsp membership
+     *               is to be retrieved
+     * @return a List containing the acsp memberships if found
+     *          or empty if not found
+     */
+    List<AcspMembers> findAllByUserId(String userId);
+
+    /**
+     * Deletes the ACSP memberships associated with the given user_id.
+     * @param userId the user_id of the user whose acsp membership
+     *               is to be deleted
+     * @return true if the acsp membership was deleted, false otherwise
+     */
+    boolean deleteByUserId(String userId);
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
@@ -72,7 +72,7 @@ public interface TestDataService {
     AcspMembersData createAcspMembersData(AcspMembersSpec acspMembersSpec) throws DataException;
 
     /**
-     * Deletes an acsp members' test data by their user id.
+     * Deletes an acsp members' test data by their acsp membership id.
      *
      * @param acspMemberId the ID of the profile to delete
      * @throws DataException if there is an error during user deletion
@@ -88,4 +88,13 @@ public interface TestDataService {
      * @throws DataException if there is an error during deletion
      */
     boolean deleteAppealsData(String companyNumber, String penaltyReference) throws DataException;
+
+    /**
+     * Deletes acsp memberships by their user_id.
+     *
+     * @param userId user_id of the acsp membership to delete
+     * @return true if acsp membership was deleted, false otherwise
+     * @throws DataException if there is an error during deletion
+     */
+    boolean deleteAcspMemberDataByUserId(String userId) throws DataException;
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AcspMembersServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AcspMembersServiceImpl.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.api.testdata.service.impl;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Objects;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,11 +12,11 @@ import uk.gov.companieshouse.api.testdata.model.entity.AcspMembers;
 import uk.gov.companieshouse.api.testdata.model.rest.AcspMembersData;
 import uk.gov.companieshouse.api.testdata.model.rest.AcspMembersSpec;
 import uk.gov.companieshouse.api.testdata.repository.AcspMembersRepository;
-import uk.gov.companieshouse.api.testdata.service.DataService;
+import uk.gov.companieshouse.api.testdata.service.AcspMembersService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 
 @Service
-public class AcspMembersServiceImpl implements DataService<AcspMembersData, AcspMembersSpec> {
+public class AcspMembersServiceImpl implements AcspMembersService {
 
     @Autowired
     private AcspMembersRepository repository;
@@ -62,5 +63,20 @@ public class AcspMembersServiceImpl implements DataService<AcspMembersData, Acsp
 
     protected Instant getCurrentDateTime() {
         return Instant.now().atZone(ZoneOffset.UTC).toInstant();
+    }
+
+    @Override
+    public List<AcspMembers> findAllByUserId(String userId) {
+        return repository.findAllByUserId(userId);
+    }
+
+    @Override
+    public boolean deleteByUserId(String userId) {
+        var acspMemberships = repository.findAllByUserId(userId);
+        if (!acspMemberships.isEmpty()) {
+            repository.deleteAll(acspMemberships);
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -34,6 +34,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.UserData;
 import uk.gov.companieshouse.api.testdata.model.rest.UserSpec;
 
 import uk.gov.companieshouse.api.testdata.repository.AcspMembersRepository;
+import uk.gov.companieshouse.api.testdata.service.AcspMembersService;
 import uk.gov.companieshouse.api.testdata.service.AppealsService;
 import uk.gov.companieshouse.api.testdata.service.CompanyAuthAllowListService;
 import uk.gov.companieshouse.api.testdata.service.CompanyAuthCodeService;
@@ -71,7 +72,7 @@ public class TestDataServiceImpl implements TestDataService {
     @Autowired
     private UserService userService;
     @Autowired
-    private DataService<AcspMembersData, AcspMembersSpec> acspMembersService;
+    private AcspMembersService acspMembersService;
     @Autowired
     private AcspMembersRepository acspMembersRepository;
     @Autowired
@@ -356,6 +357,21 @@ public class TestDataServiceImpl implements TestDataService {
             this.acspProfileService.delete(acspNumber);
         } catch (Exception ex) {
             suppressedExceptions.add(new DataException("Error deleting ACSP profile", ex));
+        }
+    }
+
+    @Override
+    public boolean deleteAcspMemberDataByUserId(String userId) throws DataException {
+        try {
+            var acspMembership =
+                    acspMembersService.findAllByUserId(userId);
+            if (!acspMembership.isEmpty()) {
+                return acspMembersService.deleteByUserId(userId);
+            }
+            return false;
+        } catch (Exception ex) {
+            throw new DataException("Error deleting acsp membership with user-id " + userId,
+                    ex);
         }
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
@@ -440,4 +440,50 @@ class TestDataControllerTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         verify(testDataService, times(0)).deleteAppealsData(anyString(), anyString());
     }
+
+    @Test
+    void deleteAcspMemberByUserId() throws Exception {
+        final String userId = "TestUserId";
+
+        when(this.testDataService.deleteAcspMemberDataByUserId(userId)).thenReturn(true);
+        ResponseEntity<Map<String, Object>> response
+                =
+                this.testDataController.deleteAcspMemberByUserId(userId);
+
+        assertNull(response.getBody());
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(testDataService).deleteAcspMemberDataByUserId(userId);
+    }
+
+    @Test
+    void deleteAcspMemberByUserIdNotFound() throws Exception {
+        final String userId = "TestUserId";
+
+        when(this.testDataService.deleteAcspMemberDataByUserId(userId)).thenReturn(false);
+        ResponseEntity<Map<String, Object>> response
+                =
+                this.testDataController.deleteAcspMemberByUserId(userId);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals("TestUserId",
+                Objects.requireNonNull(response.getBody()).get(
+                        "user-id"));
+        assertEquals(HttpStatus.NOT_FOUND, response.getBody().get("status"));
+
+        verify(testDataService).deleteAcspMemberDataByUserId(userId);
+    }
+
+    @Test
+    void deleteAcspMemberByUserIdException() throws Exception {
+        final String userId = "TestUserId";
+        Throwable exception = new DataException("Error message");
+
+        when(this.testDataService.deleteAcspMemberDataByUserId(userId)).thenThrow(exception);
+
+        DataException thrown = assertThrows(
+                DataException.class,
+                () -> this.testDataController
+                        .deleteAcspMemberByUserId(userId));
+        assertEquals(exception, thrown);
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AcspMembersServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AcspMembersServiceImplTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -146,5 +147,44 @@ class AcspMembersServiceImplTest {
 
         assertFalse(result);
         verify(repository, never()).delete(any(AcspMembers.class));
+    }
+
+    @Test
+    void deleteAcspMemberByUserId() {
+        AcspMembers acspMember = new AcspMembers();
+
+        when(repository.findAllByUserId("TestUserId"))
+                .thenReturn(Collections.singletonList(acspMember));
+
+        boolean result = service.deleteByUserId("TestUserId");
+
+        assertTrue(result);
+        verify(repository).deleteAll(Collections.singletonList(acspMember));
+    }
+
+    @Test
+    void deleteAcspMemberByUserIdNotFound() {
+        when(repository.findAllByUserId("TestUserId")).thenReturn(Collections.emptyList());
+
+        boolean result = service.deleteByUserId("TestUserId");
+
+        assertFalse(result);
+        verify(repository, never()).deleteAll(Collections.singleton(any(AcspMembers.class)));
+    }
+
+    @Test
+    void deleteAcspMemberByUserIdException() {
+        AcspMembers acspMember = new AcspMembers();
+
+        when(repository.findAllByUserId("TestUserId"))
+                .thenReturn(Collections.singletonList(acspMember));
+        doThrow(new RuntimeException("Deletion error")).when(repository)
+                .deleteAll(Collections.singletonList(acspMember));
+
+        RuntimeException exception =
+                assertThrows(RuntimeException.class,
+                        () -> service.deleteByUserId("TestUserId"));
+
+        assertEquals("Deletion error", exception.getMessage());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AcspMembersServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AcspMembersServiceImplTest.java
@@ -9,11 +9,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -186,5 +188,31 @@ class AcspMembersServiceImplTest {
                         () -> service.deleteByUserId("TestUserId"));
 
         assertEquals("Deletion error", exception.getMessage());
+    }
+
+    @Test
+    void findAllByUserId() {
+        String userId = "userId";
+        AcspMembers acspMember = new AcspMembers();
+        acspMember.setUserId(userId);
+
+        when(repository.findAllByUserId(userId))
+                .thenReturn(Collections.singletonList(acspMember));
+
+        List<AcspMembers> result = service.findAllByUserId(userId);
+
+        assertTrue(result.contains(acspMember));
+        assertEquals(1, result.size());
+        assertEquals(userId, result.getFirst().getUserId());
+        verify(repository, times(1)).findAllByUserId(userId);
+    }
+
+    @Test
+    void findAllByUserIdNotFound() {
+        when(repository.findAllByUserId("userId")).thenReturn(Collections.emptyList());
+
+        List<AcspMembers> result = service.findAllByUserId("userId");
+
+        assertTrue(result.isEmpty());
     }
 }


### PR DESCRIPTION

Changes made:

- Added new endpoint for deleting an ACSP membership by the user's user_id