### PR TITLE
SAN-279: Add api operations for account penalties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,11 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
@@ -22,6 +22,7 @@ import uk.gov.companieshouse.api.testdata.repository.*;
 @Configuration
 @EnableConfigurationProperties(MongoProperties.class)
 public class MongoConfig {
+
     private static final String ACCOUNT_DATABASE = "account";
     private final MongoProperties mongoProperties;
 
@@ -54,7 +55,7 @@ public class MongoConfig {
     public AppointmentsRepository appointmentsRepository() {
         return getMongoRepositoryBean(AppointmentsRepository.class, "appointments");
     }
-    
+
     @Bean
     public CompanyMetricsRepository companyMetricsRepository() {
         return getMongoRepositoryBean(CompanyMetricsRepository.class, "company_metrics");
@@ -62,7 +63,8 @@ public class MongoConfig {
 
     @Bean
     public CompanyPscStatementRepository companyPscStatement() {
-        return getMongoRepositoryBean(CompanyPscStatementRepository.class, "company_psc_statements");
+        return getMongoRepositoryBean(CompanyPscStatementRepository.class,
+                "company_psc_statements");
     }
 
     @Bean
@@ -90,7 +92,6 @@ public class MongoConfig {
         return getMongoRepositoryBean(AcspMembersRepository.class, "acsp_members");
     }
 
-
     @Bean
     public IdentityRepository identityRepository() {
         return getMongoRepositoryBean(IdentityRepository.class, "identity_verification");
@@ -117,18 +118,26 @@ public class MongoConfig {
         return getMongoRepositoryBean(CertificatesRepository.class, "items");
     }
 
+    @Bean
+    public AccountPenaltiesRepository accountPenaltiesRepository() {
+        return getMongoRepositoryBean(AccountPenaltiesRepository.class, "financial_penalties");
+    }
+
     private MongoTemplate createMongoTemplate(final String database) {
         SimpleMongoClientDatabaseFactory simpleMongoDbFactory = new SimpleMongoClientDatabaseFactory(
                 MongoClients.create(this.mongoProperties.getUri()), database);
-        MappingMongoConverter mappingMongoConverter = getMappingMongoConverter(simpleMongoDbFactory);
+        MappingMongoConverter mappingMongoConverter = getMappingMongoConverter(
+                simpleMongoDbFactory);
         return new MongoTemplate(simpleMongoDbFactory, mappingMongoConverter);
     }
 
     private MappingMongoConverter getMappingMongoConverter(MongoDatabaseFactory factory) {
         DbRefResolver dbRefResolver = new DefaultDbRefResolver(factory);
         MongoMappingContext mappingContext = new MongoMappingContext();
-        MappingMongoConverter mappingConverter = new MappingMongoConverter(dbRefResolver, mappingContext);
-        mappingContext.setSimpleTypeHolder(mappingConverter.getCustomConversions().getSimpleTypeHolder());
+        MappingMongoConverter mappingConverter = new MappingMongoConverter(dbRefResolver,
+                mappingContext);
+        mappingContext.setSimpleTypeHolder(
+                mappingConverter.getCustomConversions().getSimpleTypeHolder());
         mappingContext.afterPropertiesSet();
         mappingConverter.afterPropertiesSet();
 
@@ -138,9 +147,11 @@ public class MongoConfig {
         return mappingConverter;
     }
 
-    private <T extends Repository<S, I>, S, I extends Serializable> T getMongoRepositoryBean(Class<T> repositoryClass,
-                                                                                             String database) {
-        MongoRepositoryFactoryBean<T, S, I> mongoDbFactoryBean = new MongoRepositoryFactoryBean<>(repositoryClass);
+    private <T extends Repository<S, I>, S, I extends Serializable> T getMongoRepositoryBean(
+            Class<T> repositoryClass,
+            String database) {
+        MongoRepositoryFactoryBean<T, S, I> mongoDbFactoryBean = new MongoRepositoryFactoryBean<>(
+                repositoryClass);
         mongoDbFactoryBean.setMongoOperations(createMongoTemplate(database));
         mongoDbFactoryBean.afterPropertiesSet();
         return mongoDbFactoryBean.getObject();

--- a/src/main/java/uk/gov/companieshouse/api/testdata/config/WebConfig.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/config/WebConfig.java
@@ -13,6 +13,7 @@ public class WebConfig implements WebMvcConfigurer {
     private static final String IDENTITY_ENDPOINTS = "/test-data/identity/**";
     private static final String ACSP_ENDPOINTS = "/test-data/acsp-members/**";
     private static final String APPEALS_ENDPOINTS = "/test-data/appeals/**";
+    private static final String ACCOUNT_PENALTIES_ENDPOINTS = "/test-data/penalties/**";
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
@@ -20,7 +21,8 @@ public class WebConfig implements WebMvcConfigurer {
                 .addPathPatterns(USERS_ENDPOINTS)
                 .addPathPatterns(IDENTITY_ENDPOINTS)
                 .addPathPatterns(ACSP_ENDPOINTS)
-                .addPathPatterns(APPEALS_ENDPOINTS);
+                .addPathPatterns(APPEALS_ENDPOINTS)
+                .addPathPatterns(ACCOUNT_PENALTIES_ENDPOINTS);
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.api.testdata.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -10,8 +11,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,7 +23,8 @@ import uk.gov.companieshouse.api.testdata.Application;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.InvalidAuthCodeException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
-
+import uk.gov.companieshouse.api.testdata.model.rest.AccountPenaltiesData;
+import uk.gov.companieshouse.api.testdata.model.rest.AccountPenaltyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.AcspMembersData;
 import uk.gov.companieshouse.api.testdata.model.rest.AcspMembersSpec;
 import uk.gov.companieshouse.api.testdata.model.rest.CertificatesData;
@@ -30,9 +34,9 @@ import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.model.rest.DeleteAppealsRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.DeleteCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.IdentitySpec;
+import uk.gov.companieshouse.api.testdata.model.rest.UpdateAccountPenaltiesRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.UserData;
 import uk.gov.companieshouse.api.testdata.model.rest.UserSpec;
-
 import uk.gov.companieshouse.api.testdata.service.CompanyAuthCodeService;
 import uk.gov.companieshouse.api.testdata.service.TestDataService;
 import uk.gov.companieshouse.logging.Logger;
@@ -166,7 +170,7 @@ public class TestDataController {
 
     @DeleteMapping("/acsp-members/{acspMemberId}")
     public ResponseEntity<Map<String, Object>> deleteAcspMember(@PathVariable("acspMemberId")
-                                                                    String acspMemberId)
+    String acspMemberId)
             throws DataException {
         Map<String, Object> response = new HashMap<>();
         response.put("acsp-member-id", acspMemberId);
@@ -214,11 +218,57 @@ public class TestDataController {
         if (isDeleted) {
             LOG.info("Appeals data deleted for company number: " + request.getCompanyNumber()
                     + " and penalty reference: " + request.getPenaltyReference());
-            return  new ResponseEntity<>(HttpStatus.NO_CONTENT);
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
         } else {
             LOG.info("No appeals data found for company number: " + request.getCompanyNumber()
                     + " and penalty reference: " + request.getPenaltyReference());
-            return  new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
     }
+
+    @GetMapping("/penalties/{penaltyRef}")
+    public ResponseEntity<AccountPenaltiesData> getPenalty(
+            @NotNull @PathVariable("penaltyRef") String penaltyRef,
+            @Valid @RequestBody AccountPenaltyRequest request) throws NoDataFoundException {
+
+        AccountPenaltiesData penaltyData = testDataService.getAccountPenaltyData(
+                request.getCompanyCode(), request.getCustomerCode(), penaltyRef);
+
+        return new ResponseEntity<>(penaltyData, HttpStatus.OK);
+
+    }
+
+    @GetMapping("/penalties")
+    public ResponseEntity<AccountPenaltiesData> getAccountPenalties(
+            @Valid @RequestBody AccountPenaltyRequest request) throws NoDataFoundException {
+
+        AccountPenaltiesData accountPenaltiesData = testDataService.getAccountPenaltiesData(
+                request.getCompanyCode(), request.getCustomerCode());
+
+        return new ResponseEntity<>(accountPenaltiesData, HttpStatus.OK);
+
+    }
+
+    @PutMapping("/penalties/{penaltyRef}")
+    public ResponseEntity<AccountPenaltiesData> updateAccountPenalties(
+            @PathVariable("penaltyRef") String penaltyRef,
+            @Valid @RequestBody UpdateAccountPenaltiesRequest request)
+            throws NoDataFoundException, DataException {
+
+        AccountPenaltiesData accountPenaltiesData = testDataService.updateAccountPenaltiesData(
+                penaltyRef, request);
+
+        return new ResponseEntity<>(accountPenaltiesData, HttpStatus.OK);
+
+    }
+
+    @DeleteMapping("/penalties")
+    public ResponseEntity<Void> deleteAccountPenalties(
+            @Valid @RequestBody AccountPenaltyRequest request)
+            throws DataException, NoDataFoundException {
+
+         return testDataService.deleteAccountPenaltiesData(
+                request.getCompanyCode(), request.getCustomerCode());
+    }
+
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/AccountPenalties.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/AccountPenalties.java
@@ -1,0 +1,80 @@
+package uk.gov.companieshouse.api.testdata.model.entity;
+
+import java.time.Instant;
+import java.util.List;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Document(collection = "account_penalties")
+public class AccountPenalties {
+
+    @Id
+    @Field("_id")
+    private ObjectId id;
+
+    @Field("customer_code")
+    private String customerCode;
+
+    @Field("company_code")
+    private String companyCode;
+
+    @Field("created_at")
+    private Instant createdAt;
+
+    @Field("closed_at")
+    private Instant closedAt;
+
+    @Field("data")
+    private List<AccountPenalty> penalties;
+
+    public ObjectId getId() {
+        return id;
+    }
+
+    public void setId(ObjectId id) {
+        this.id = id;
+    }
+
+    public String getCustomerCode() {
+        return customerCode;
+    }
+
+    public void setCustomerCode(String customerCode) {
+        this.customerCode = customerCode;
+    }
+
+    public String getCompanyCode() {
+        return companyCode;
+    }
+
+    public void setCompanyCode(String companyCode) {
+        this.companyCode = companyCode;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getClosedAt() {
+        return closedAt;
+    }
+
+    public void setClosedAt(Instant closedAt) {
+        this.closedAt = closedAt;
+    }
+
+    public List<AccountPenalty> getPenalties() {
+        return penalties;
+    }
+
+    public void setPenalties(
+            List<AccountPenalty> penalties) {
+        this.penalties = penalties;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/AccountPenalty.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/entity/AccountPenalty.java
@@ -1,0 +1,173 @@
+package uk.gov.companieshouse.api.testdata.model.entity;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+public class AccountPenalty {
+
+    @Field("company_code")
+    private String companyCode;
+
+    @Field("ledger_code")
+    private String ledgerCode;
+
+    @Field("customer_code")
+    private String customerCode;
+
+    @Field("transaction_reference")
+    private String transactionReference;
+
+    @Field("transaction_date")
+    private String transactionDate;
+
+    @Field("made_up_date")
+    private String madeUpDate;
+
+    @Field("amount")
+    private Double amount;
+
+    @Field("outstanding_amount")
+    private Double outstandingAmount;
+
+    @Field("is_paid")
+    private boolean isPaid;
+
+    @Field("transaction_type")
+    private String transactionType;
+
+    @Field("transaction_sub_type")
+    private String transactionSubType;
+
+    @Field("type_description")
+    private String typeDescription;
+
+    @Field("due_date")
+    private String dueDate;
+
+    @Field("account_status")
+    private String accountStatus;
+
+    @Field("dunning_status")
+    private String dunningStatus;
+
+    public String getCompanyCode() {
+        return companyCode;
+    }
+
+    public void setCompanyCode(String companyCode) {
+        this.companyCode = companyCode;
+    }
+
+    public String getLedgerCode() {
+        return ledgerCode;
+    }
+
+    public void setLedgerCode(String ledgerCode) {
+        this.ledgerCode = ledgerCode;
+    }
+
+    public String getCustomerCode() {
+        return customerCode;
+    }
+
+    public void setCustomerCode(String customerCode) {
+        this.customerCode = customerCode;
+    }
+
+    public String getTransactionReference() {
+        return transactionReference;
+    }
+
+    public void setTransactionReference(String transactionReference) {
+        this.transactionReference = transactionReference;
+    }
+
+    public String getTransactionDate() {
+        return transactionDate;
+    }
+
+    public void setTransactionDate(String transactionDate) {
+        this.transactionDate = transactionDate;
+    }
+
+    public String getMadeUpDate() {
+        return madeUpDate;
+    }
+
+    public void setMadeUpDate(String madeUpDate) {
+        this.madeUpDate = madeUpDate;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Double amount) {
+        this.amount = amount;
+    }
+
+    public Double getOutstandingAmount() {
+        return outstandingAmount;
+    }
+
+    public void setOutstandingAmount(Double outstandingAmount) {
+        this.outstandingAmount = outstandingAmount;
+    }
+
+    public boolean isPaid() {
+        return isPaid;
+    }
+
+    public void setIsPaid(boolean paid) {
+        isPaid = paid;
+    }
+
+    public String getTransactionType() {
+        return transactionType;
+    }
+
+    public void setTransactionType(String transactionType) {
+        this.transactionType = transactionType;
+    }
+
+    public String getTransactionSubType() {
+        return transactionSubType;
+    }
+
+    public void setTransactionSubType(String transactionSubType) {
+        this.transactionSubType = transactionSubType;
+    }
+
+    public String getTypeDescription() {
+        return typeDescription;
+    }
+
+    public void setTypeDescription(String typeDescription) {
+        this.typeDescription = typeDescription;
+    }
+
+    public String getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(String dueDate) {
+        this.dueDate = dueDate;
+    }
+
+    public String getAccountStatus() {
+        return accountStatus;
+    }
+
+    public void setAccountStatus(String accountStatus) {
+        this.accountStatus = accountStatus;
+    }
+
+    public String getDunningStatus() {
+        return dunningStatus;
+    }
+
+    public void setDunningStatus(String dunningStatus) {
+        this.dunningStatus = dunningStatus;
+    }
+
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/AccountPenaltiesData.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/AccountPenaltiesData.java
@@ -1,0 +1,64 @@
+package uk.gov.companieshouse.api.testdata.model.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.List;
+
+public class AccountPenaltiesData {
+
+    @JsonProperty("company_code")
+    private String companyCode;
+
+    @JsonProperty("customer_code")
+    private String customerCode;
+
+    @JsonProperty("created_at")
+    private Instant createdAt;
+
+    @JsonProperty("closed_at")
+    private Instant closedAt;
+
+    @JsonProperty("data")
+    private List<PenaltyData> penalties;
+
+    public String getCompanyCode() {
+        return companyCode;
+    }
+
+    public void setCompanyCode(String companyCode) {
+        this.companyCode = companyCode;
+    }
+
+    public String getCustomerCode() {
+        return customerCode;
+    }
+
+    public void setCustomerCode(String customerCode) {
+        this.customerCode = customerCode;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getClosedAt() {
+        return closedAt;
+    }
+
+    public void setClosedAt(Instant closedAt) {
+        this.closedAt = closedAt;
+    }
+
+    public List<PenaltyData> getPenalties() {
+        return penalties;
+    }
+
+    public void setPenalties(
+            List<PenaltyData> penalties) {
+        this.penalties = penalties;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/AccountPenaltyRequest.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/AccountPenaltyRequest.java
@@ -1,0 +1,31 @@
+package uk.gov.companieshouse.api.testdata.model.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+public class AccountPenaltyRequest {
+
+    @JsonProperty("company_code")
+    @NotBlank(message = "company code should not be blank")
+    private String companyCode;
+
+    @JsonProperty("customer_code")
+    @NotBlank(message = "customer code should not be blank")
+    private String customerCode;
+
+    public String getCompanyCode() {
+        return companyCode;
+    }
+
+    public void setCompanyCode(String companyCode) {
+        this.companyCode = companyCode;
+    }
+
+    public String getCustomerCode() {
+        return customerCode;
+    }
+
+    public void setCustomerCode(String customerCode) {
+        this.customerCode = customerCode;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/PenaltyData.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/PenaltyData.java
@@ -1,0 +1,116 @@
+package uk.gov.companieshouse.api.testdata.model.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PenaltyData {
+
+    @JsonProperty("company_code")
+    private String companyCode;
+
+    @JsonProperty("customer_code")
+    private String customerCode;
+
+    @JsonProperty("transaction_reference")
+    private String transactionReference;
+
+    @JsonProperty("transaction_date")
+    private String transactionDate;
+
+    @JsonProperty("made_up_date")
+    private String madeUpDate;
+
+    @JsonProperty("amount")
+    private Double amount;
+
+    @JsonProperty("outstanding_amount")
+    private Double outstandingAmount;
+
+    @JsonProperty("is_paid")
+    private boolean isPaid;
+
+    @JsonProperty("account_status")
+    private String accountStatus;
+
+    @JsonProperty("dunning_status")
+    private String dunningStatus;
+
+    public String getCompanyCode() {
+        return companyCode;
+    }
+
+    public void setCompanyCode(String companyCode) {
+        this.companyCode = companyCode;
+    }
+
+    public String getCustomerCode() {
+        return customerCode;
+    }
+
+    public void setCustomerCode(String customerCode) {
+        this.customerCode = customerCode;
+    }
+
+    public String getTransactionReference() {
+        return transactionReference;
+    }
+
+    public void setTransactionReference(String transactionReference) {
+        this.transactionReference = transactionReference;
+    }
+
+    public String getTransactionDate() {
+        return transactionDate;
+    }
+
+    public void setTransactionDate(String transactionDate) {
+        this.transactionDate = transactionDate;
+    }
+
+    public String getMadeUpDate() {
+        return madeUpDate;
+    }
+
+    public void setMadeUpDate(String madeUpDate) {
+        this.madeUpDate = madeUpDate;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Double amount) {
+        this.amount = amount;
+    }
+
+    public Double getOutstandingAmount() {
+        return outstandingAmount;
+    }
+
+    public void setOutstandingAmount(Double outstandingAmount) {
+        this.outstandingAmount = outstandingAmount;
+    }
+
+    public boolean getIsPaid() {
+        return isPaid;
+    }
+
+    public void setIsPaid(boolean paid) {
+        isPaid = paid;
+    }
+
+    public String getAccountStatus() {
+        return accountStatus;
+    }
+
+    public void setAccountStatus(String accountStatus) {
+        this.accountStatus = accountStatus;
+    }
+
+    public String getDunningStatus() {
+        return dunningStatus;
+    }
+
+    public void setDunningStatus(String dunningStatus) {
+        this.dunningStatus = dunningStatus;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/UpdateAccountPenaltiesRequest.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/UpdateAccountPenaltiesRequest.java
@@ -1,0 +1,88 @@
+package uk.gov.companieshouse.api.testdata.model.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.Instant;
+
+public class UpdateAccountPenaltiesRequest {
+
+    @JsonProperty("company_code")
+    @NotBlank(message = "company code should not be blank")
+    private String companyCode;
+
+    @JsonProperty("customer_code")
+    @NotBlank(message = "customer code should not be blank")
+    private String customerCode;
+
+    @JsonProperty("created_at")
+    private Instant createdAt;
+
+    @JsonProperty("closed_at")
+    private Instant closedAt;
+
+    @JsonProperty("is_paid")
+    private Boolean isPaid;
+
+    @JsonProperty("amount")
+    private Double amount;
+
+    @JsonProperty("outstanding_amount")
+    private Double outstandingAmount;
+
+    public String getCompanyCode() {
+        return companyCode;
+    }
+
+    public void setCompanyCode(String companyCode) {
+        this.companyCode = companyCode;
+    }
+
+    public String getCustomerCode() {
+        return customerCode;
+    }
+
+    public void setCustomerCode(String customerCode) {
+        this.customerCode = customerCode;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getClosedAt() {
+        return closedAt;
+    }
+
+    public void setClosedAt(Instant closedAt) {
+        this.closedAt = closedAt;
+    }
+
+    public Boolean getIsPaid() {
+        return isPaid;
+    }
+
+    public void setIsPaid(Boolean paid) {
+        isPaid = paid;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Double amount) {
+        this.amount = amount;
+    }
+
+    public Double getOutstandingAmount() {
+        return outstandingAmount;
+    }
+
+    public void setOutstandingAmount(Double outstandingAmount) {
+        this.outstandingAmount = outstandingAmount;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/repository/AccountPenaltiesRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/repository/AccountPenaltiesRepository.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.api.testdata.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.repository.NoRepositoryBean;
+import uk.gov.companieshouse.api.testdata.model.entity.AccountPenalties;
+
+@NoRepositoryBean
+public interface AccountPenaltiesRepository extends MongoRepository<AccountPenalties, String> {
+
+    @Query("{ 'company_code':  ?0, 'customer_code':  ?1, "
+            + "'data': { '$elemMatch':  { 'transaction_reference':  ?2 }} }")
+    Optional<AccountPenalties> findPenalty(
+            String companyCode, String customerCode, String transactionReference);
+
+    Optional<AccountPenalties> findAllByCompanyCodeAndCustomerCode(
+            String companyCode, String customerCode);
+
+    Optional<AccountPenalties> deleteByCompanyCodeAndCustomerCode(String companyNumber,
+            String customerCode);
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/AccountPenaltiesService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/AccountPenaltiesService.java
@@ -1,0 +1,59 @@
+package uk.gov.companieshouse.api.testdata.service;
+
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
+import uk.gov.companieshouse.api.testdata.model.rest.AccountPenaltiesData;
+import uk.gov.companieshouse.api.testdata.model.rest.PenaltyData;
+import uk.gov.companieshouse.api.testdata.model.rest.UpdateAccountPenaltiesRequest;
+
+public interface AccountPenaltiesService {
+
+    /**
+     * Gets an account penalties entity by its company code, customer code and penalty reference.
+     *
+     * @param companyCode  the company code
+     * @param customerCode the customer code
+     * @param penaltyRef   the penalty reference
+     * @return the {@link AccountPenaltiesData} with only the penalty reference that has been
+     * requested in the {@link PenaltyData} list
+     * @throws NoDataFoundException if the account penalty cannot be found
+     */
+    AccountPenaltiesData getAccountPenalty(String companyCode, String customerCode,
+            String penaltyRef) throws NoDataFoundException;
+
+    /**
+     * Gets an account penalties entity by its company code and customer code.
+     *
+     * @param companyCode  the company code
+     * @param customerCode the customer code
+     * @return the {@link AccountPenaltiesData} with all penalties the {@link PenaltyData} list
+     * @throws NoDataFoundException if the account penalties cannot be found
+     */
+    AccountPenaltiesData getAccountPenalties(String companyCode, String customerCode)
+            throws NoDataFoundException;
+
+    /**
+     * Updates an account penalties entity for the requested penalty reference.
+     *
+     * @param penaltyRef the penalty reference
+     * @param request    the update request
+     * @return the {@link AccountPenaltiesData} with the updated penalty in the {@link PenaltyData}
+     * list
+     * @throws NoDataFoundException if the account penalty cannot be found
+     * @throws DataException if the account penalty cannot be updated
+     */
+    AccountPenaltiesData updateAccountPenalties(String penaltyRef,
+            UpdateAccountPenaltiesRequest request) throws NoDataFoundException, DataException;
+
+    /**
+     * Deletes an account penalties entity by its company code and customer code
+     *
+     * @param companyCode  the company code
+     * @param customerCode the customer code
+     * @return the {@link ResponseEntity} with the HTTP status
+     * @throws NoDataFoundException if the account penalties cannot be found
+     */
+    ResponseEntity<Void> deleteAccountPenalties(String companyCode, String customerCode)
+            throws NoDataFoundException;
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
@@ -1,6 +1,10 @@
 package uk.gov.companieshouse.api.testdata.service;
 
+import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
+import uk.gov.companieshouse.api.testdata.model.rest.AccountPenaltiesData;
+import uk.gov.companieshouse.api.testdata.model.rest.PenaltyData;
 import uk.gov.companieshouse.api.testdata.model.rest.AcspMembersData;
 import uk.gov.companieshouse.api.testdata.model.rest.AcspMembersSpec;
 import uk.gov.companieshouse.api.testdata.model.rest.CertificatesData;
@@ -9,10 +13,12 @@ import uk.gov.companieshouse.api.testdata.model.rest.CompanyData;
 import uk.gov.companieshouse.api.testdata.model.rest.CompanySpec;
 import uk.gov.companieshouse.api.testdata.model.rest.IdentityData;
 import uk.gov.companieshouse.api.testdata.model.rest.IdentitySpec;
+import uk.gov.companieshouse.api.testdata.model.rest.UpdateAccountPenaltiesRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.UserData;
 import uk.gov.companieshouse.api.testdata.model.rest.UserSpec;
 
 public interface TestDataService {
+
     /**
      * Create company data with given {@code companySpec}.
      *
@@ -101,10 +107,59 @@ public interface TestDataService {
     /**
      * Deletes all appeals data for a given penalty reference and company number.
      *
-     * @param companyNumber the company number
+     * @param companyNumber    the company number
      * @param penaltyReference the penalty reference
      * @return true if the entity was deleted, false otherwise
      * @throws DataException if there is an error during deletion
      */
     boolean deleteAppealsData(String companyNumber, String penaltyReference) throws DataException;
+
+    /**
+     * Gets the account penalty data for a given company code, customer code and penalty reference.
+     *
+     * @param companyCode      the company code
+     * @param customerCode     the customer code
+     * @param penaltyReference the penalty reference
+     * @return the {@link AccountPenaltiesData} with only the requested penalty reference in the
+     * {@link PenaltyData} list
+     * @throws NoDataFoundException if the penalty cannot be found
+     */
+    AccountPenaltiesData getAccountPenaltyData(String companyCode, String customerCode,
+            String penaltyReference) throws NoDataFoundException;
+
+    /**
+     * Gets the account penalties data for a given company code and customer code.
+     *
+     * @param companyCode  the company code
+     * @param customerCode the customer code
+     * @return @return the {@link AccountPenaltiesData}
+     * @throws NoDataFoundException if the penalty cannot be found
+     */
+    AccountPenaltiesData getAccountPenaltiesData(String companyCode, String customerCode)
+            throws NoDataFoundException;
+
+    /**
+     * Updates the account penalties data for a given penalty reference and
+     * {@link UpdateAccountPenaltiesRequest}
+     *
+     * @param penaltyRef the penalty reference
+     * @param request    the update request
+     * @return the {@link AccountPenaltiesData}
+     * @throws NoDataFoundException if the requested penalty reference cannot be found
+     * @throws DataException if the account penalties cannot be updated
+     */
+    AccountPenaltiesData updateAccountPenaltiesData(String penaltyRef,
+            UpdateAccountPenaltiesRequest request) throws NoDataFoundException, DataException;
+
+    /**
+     * Deletes all account penalties data for a given company code and customer code
+     *
+     * @param companyCode  the company code
+     * @param customerCode the customer code
+     * @return the {@link ResponseEntity} with the HTTP status
+     * @throws NoDataFoundException if the account penalties cannot be found
+     * @throws DataException        if the account penalties failed to be deleted
+     */
+    ResponseEntity<Void> deleteAccountPenaltiesData(String companyCode, String customerCode)
+            throws NoDataFoundException, DataException;
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AccountPenaltiesServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AccountPenaltiesServiceImpl.java
@@ -120,10 +120,11 @@ public class AccountPenaltiesServiceImpl implements AccountPenaltiesService {
         accountPenaltiesData.setCreatedAt(accountPenalties.getCreatedAt());
         accountPenaltiesData.setClosedAt(accountPenalties.getClosedAt());
 
-        List<PenaltyData> apd = accountPenalties.getPenalties().stream()
-                .map(this::mapToAccountPenaltyData).toList();
+        List<PenaltyData> penalties = accountPenalties.getPenalties().stream()
+                .map(this::mapToAccountPenaltyData)
+                .toList();
 
-        accountPenaltiesData.setPenalties(apd);
+        accountPenaltiesData.setPenalties(penalties);
 
         return accountPenaltiesData;
     }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AccountPenaltiesServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AccountPenaltiesServiceImpl.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.api.testdata.service.impl;
 import java.util.List;
 import java.util.Objects;
 
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -82,8 +83,12 @@ public class AccountPenaltiesServiceImpl implements AccountPenaltiesService {
     @Override
     public ResponseEntity<Void> deleteAccountPenalties(String companyCode, String customerCode)
             throws NoDataFoundException {
-        repository.findAllByCompanyCodeAndCustomerCode(companyCode, customerCode)
-                        .orElseThrow(() -> new NoDataFoundException("no account penalties"));
+        Optional<AccountPenalties> accountPenalties =
+                repository.findAllByCompanyCodeAndCustomerCode(companyCode, customerCode);
+
+        if (accountPenalties.isEmpty()) {
+            throw new NoDataFoundException("no account penalties");
+        }
 
         repository.deleteByCompanyCodeAndCustomerCode(companyCode, customerCode);
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AccountPenaltiesServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AccountPenaltiesServiceImpl.java
@@ -1,0 +1,145 @@
+package uk.gov.companieshouse.api.testdata.service.impl;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
+import uk.gov.companieshouse.api.testdata.model.entity.AccountPenalties;
+import uk.gov.companieshouse.api.testdata.model.entity.AccountPenalty;
+import uk.gov.companieshouse.api.testdata.model.rest.AccountPenaltiesData;
+import uk.gov.companieshouse.api.testdata.model.rest.PenaltyData;
+import uk.gov.companieshouse.api.testdata.model.rest.UpdateAccountPenaltiesRequest;
+import uk.gov.companieshouse.api.testdata.repository.AccountPenaltiesRepository;
+import uk.gov.companieshouse.api.testdata.service.AccountPenaltiesService;
+
+@Service
+public class AccountPenaltiesServiceImpl implements AccountPenaltiesService {
+
+    @Autowired
+    private AccountPenaltiesRepository repository;
+
+    private static final NoDataFoundException PENALTY_NOT_FOUND_EX =
+            new NoDataFoundException("penalty not found");
+
+    @Override
+    public AccountPenaltiesData getAccountPenalty(String companyCode, String customerCode,
+            String penaltyRef) throws NoDataFoundException {
+        var accountPenalties =
+                repository.findPenalty(companyCode, customerCode, penaltyRef)
+                        .orElseThrow(() -> PENALTY_NOT_FOUND_EX);
+
+        return mapToAccountPenaltiesData(accountPenalties);
+    }
+
+    @Override
+    public AccountPenaltiesData getAccountPenalties(String companyCode, String customerCode)
+            throws NoDataFoundException {
+        var accountPenalties =
+                repository.findAllByCompanyCodeAndCustomerCode(companyCode, customerCode)
+                        .orElseThrow(() -> new NoDataFoundException("no account penalties"));
+
+        return mapToAccountPenaltiesData(accountPenalties);
+    }
+
+    @Override
+    public AccountPenaltiesData updateAccountPenalties(String penaltyRef,
+            UpdateAccountPenaltiesRequest request) throws NoDataFoundException, DataException {
+
+        AccountPenalties accountPenalties =
+                repository.findPenalty(
+                                request.getCompanyCode(), request.getCustomerCode(), penaltyRef)
+                        .orElseThrow(() -> PENALTY_NOT_FOUND_EX);
+
+        AccountPenalty updatedPenalty = createPenaltyUpdate(
+                accountPenalties.getPenalties().getFirst(),
+                request.getIsPaid(), request.getAmount(), request.getOutstandingAmount());
+
+        accountPenalties.setClosedAt(request.getClosedAt());
+        if (Objects.nonNull(request.getCreatedAt())) {
+            accountPenalties.setCreatedAt(request.getCreatedAt());
+        }
+
+        for (int i = 0; i < accountPenalties.getPenalties().size(); i++) {
+            if (accountPenalties.getPenalties().get(i)
+                    .getTransactionReference().equals(penaltyRef)) {
+                accountPenalties.getPenalties().set(i, updatedPenalty);
+                break;
+            }
+        }
+
+        try {
+            AccountPenalties updateAccountPenaltyData = repository.save(accountPenalties);
+            return mapToAccountPenaltiesData(updateAccountPenaltyData);
+        } catch (Exception ex) {
+            throw new DataException("failed to update the account penalties");
+        }
+    }
+
+    @Override
+    public ResponseEntity<Void> deleteAccountPenalties(String companyCode, String customerCode)
+            throws NoDataFoundException {
+        repository.findAllByCompanyCodeAndCustomerCode(companyCode, customerCode)
+                        .orElseThrow(() -> new NoDataFoundException("no account penalties"));
+
+        repository.deleteByCompanyCodeAndCustomerCode(companyCode, customerCode);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    private AccountPenalty createPenaltyUpdate(AccountPenalty accountPenalty, Boolean isPaid,
+            Double amount, Double outStandingAmount) {
+        AccountPenalty updatedPenalty = new AccountPenalty();
+        updatedPenalty.setIsPaid(isPaid != null ? isPaid : accountPenalty.isPaid());
+        updatedPenalty.setAmount(amount != null ? amount : accountPenalty.getAmount());
+        updatedPenalty.setOutstandingAmount(outStandingAmount != null ? outStandingAmount
+                : accountPenalty.getOutstandingAmount());
+        updatedPenalty.setCompanyCode(accountPenalty.getCompanyCode());
+        updatedPenalty.setLedgerCode(accountPenalty.getLedgerCode());
+        updatedPenalty.setCustomerCode(accountPenalty.getCustomerCode());
+        updatedPenalty.setTransactionReference(accountPenalty.getTransactionReference());
+        updatedPenalty.setTransactionDate(accountPenalty.getTransactionDate());
+        updatedPenalty.setMadeUpDate(accountPenalty.getMadeUpDate());
+        updatedPenalty.setTransactionType(accountPenalty.getTransactionType());
+        updatedPenalty.setTransactionSubType(accountPenalty.getTransactionSubType());
+        updatedPenalty.setTypeDescription(accountPenalty.getTypeDescription());
+        updatedPenalty.setDueDate(accountPenalty.getDueDate());
+        updatedPenalty.setAccountStatus(accountPenalty.getAccountStatus());
+        updatedPenalty.setDunningStatus(accountPenalty.getDunningStatus());
+
+        return updatedPenalty;
+    }
+
+    private AccountPenaltiesData mapToAccountPenaltiesData(AccountPenalties accountPenalties) {
+        AccountPenaltiesData accountPenaltiesData = new AccountPenaltiesData();
+        accountPenaltiesData.setCompanyCode(accountPenalties.getCompanyCode());
+        accountPenaltiesData.setCustomerCode(accountPenalties.getCustomerCode());
+        accountPenaltiesData.setCreatedAt(accountPenalties.getCreatedAt());
+        accountPenaltiesData.setClosedAt(accountPenalties.getClosedAt());
+
+        List<PenaltyData> apd = accountPenalties.getPenalties().stream()
+                .map(this::mapToAccountPenaltyData).toList();
+
+        accountPenaltiesData.setPenalties(apd);
+
+        return accountPenaltiesData;
+    }
+
+    private PenaltyData mapToAccountPenaltyData(AccountPenalty penalty) {
+        PenaltyData penaltyData = new PenaltyData();
+        penaltyData.setCompanyCode(penalty.getCompanyCode());
+        penaltyData.setCustomerCode(penalty.getCustomerCode());
+        penaltyData.setTransactionReference(penalty.getTransactionReference());
+        penaltyData.setTransactionDate(penalty.getTransactionDate());
+        penaltyData.setMadeUpDate(penalty.getMadeUpDate());
+        penaltyData.setAmount(penalty.getAmount());
+        penaltyData.setOutstandingAmount(penalty.getOutstandingAmount());
+        penaltyData.setIsPaid(penalty.isPaid());
+        penaltyData.setAccountStatus(penalty.getAccountStatus());
+        penaltyData.setDunningStatus(penalty.getDunningStatus());
+        return penaltyData;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AccountPenaltiesServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AccountPenaltiesServiceImplTest.java
@@ -1,0 +1,215 @@
+package uk.gov.companieshouse.api.testdata.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
+import uk.gov.companieshouse.api.testdata.model.entity.AccountPenalties;
+import uk.gov.companieshouse.api.testdata.model.entity.AccountPenalty;
+import uk.gov.companieshouse.api.testdata.model.rest.AccountPenaltiesData;
+import uk.gov.companieshouse.api.testdata.model.rest.UpdateAccountPenaltiesRequest;
+import uk.gov.companieshouse.api.testdata.repository.AccountPenaltiesRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AccountPenaltiesServiceImplTest {
+
+    @Mock
+    private AccountPenaltiesRepository repository;
+
+    @InjectMocks
+    private AccountPenaltiesServiceImpl service;
+
+    private static final AccountPenalties ACCOUNT_PENALTIES = new AccountPenalties();
+    private static final String COMPANY_CODE = "LP";
+    private static final String CUSTOMER_CODE = "12345678";
+    private static final String PENALTY_REF = "A1234567";
+    private static final Instant NOW = Instant.now();
+
+    @Test
+    void testGetAccountPenaltySuccess() throws NoDataFoundException {
+        AccountPenalties accountPenalties = createAccountPenalties();
+
+        when(repository.findPenalty(
+                COMPANY_CODE, CUSTOMER_CODE, PENALTY_REF))
+                .thenReturn(Optional.of(accountPenalties));
+
+        AccountPenaltiesData result = service.getAccountPenalty(COMPANY_CODE, CUSTOMER_CODE,
+                PENALTY_REF);
+
+        assertEquals(accountPenalties.getCustomerCode(), result.getCustomerCode());
+        assertEquals(accountPenalties.getCompanyCode(), result.getCompanyCode());
+        assertEquals(accountPenalties.getPenalties().getFirst().getTransactionReference(),
+                result.getPenalties().getFirst().getTransactionReference());
+        verify(repository, times(1))
+                .findPenalty(COMPANY_CODE, CUSTOMER_CODE, PENALTY_REF);
+    }
+
+    @Test
+    void testGetAccountPenaltyNotFound() {
+        when(repository.findPenalty(
+                COMPANY_CODE, CUSTOMER_CODE, PENALTY_REF))
+                .thenReturn(Optional.empty());
+
+        NoDataFoundException exception =
+                assertThrows(NoDataFoundException.class,
+                        () -> service.getAccountPenalty(COMPANY_CODE, CUSTOMER_CODE, PENALTY_REF));
+        assertEquals("penalty not found", exception.getMessage());
+    }
+
+    @Test
+    void testGetAccountPenaltiesSuccess() throws NoDataFoundException {
+        AccountPenalties accountPenalties = createAccountPenalties();
+
+        when(repository.findAllByCompanyCodeAndCustomerCode(COMPANY_CODE, CUSTOMER_CODE))
+                .thenReturn(Optional.of(accountPenalties));
+
+        AccountPenaltiesData result = service.getAccountPenalties(COMPANY_CODE, CUSTOMER_CODE);
+
+        assertEquals(accountPenalties.getCustomerCode(), result.getCustomerCode());
+        assertEquals(accountPenalties.getCompanyCode(), result.getCompanyCode());
+        assertFalse(accountPenalties.getPenalties().isEmpty());
+        verify(repository, times(1))
+                .findAllByCompanyCodeAndCustomerCode(COMPANY_CODE, CUSTOMER_CODE);
+    }
+
+    @Test
+    void testGetAccountPenaltiesNotFound() {
+        when(repository.findAllByCompanyCodeAndCustomerCode(COMPANY_CODE, CUSTOMER_CODE))
+                .thenReturn(Optional.empty());
+
+        NoDataFoundException exception =
+                assertThrows(NoDataFoundException.class,
+                        () -> service.getAccountPenalties(COMPANY_CODE, CUSTOMER_CODE));
+        assertEquals("no account penalties", exception.getMessage());
+    }
+
+    @Test
+    void testDeleteAccountPenaltiesSuccess() throws NoDataFoundException {
+        when(repository.findAllByCompanyCodeAndCustomerCode(COMPANY_CODE, CUSTOMER_CODE))
+                .thenReturn(Optional.of(ACCOUNT_PENALTIES));
+        when(repository.deleteByCompanyCodeAndCustomerCode(COMPANY_CODE, CUSTOMER_CODE))
+                .thenReturn(Optional.of(ACCOUNT_PENALTIES));
+
+        service.deleteAccountPenalties(COMPANY_CODE, CUSTOMER_CODE);
+
+        verify(repository, times(1))
+                .deleteByCompanyCodeAndCustomerCode(COMPANY_CODE, CUSTOMER_CODE);
+    }
+
+    @Test
+    void testDeleteAccountPenaltiesNotFound() {
+        when(repository.findAllByCompanyCodeAndCustomerCode(COMPANY_CODE, CUSTOMER_CODE))
+                .thenReturn(Optional.empty());
+
+        NoDataFoundException exception =
+                assertThrows(NoDataFoundException.class,
+                        () -> service.deleteAccountPenalties(COMPANY_CODE, CUSTOMER_CODE));
+
+        assertEquals("no account penalties", exception.getMessage());
+    }
+
+    public static Stream<Arguments> updateArguments() {
+        return Stream.of(
+                Arguments.of(NOW.minusSeconds(10), NOW.minusSeconds(10), true, 0.0, 0.0),
+                Arguments.of(null, NOW.minusSeconds(10), null, null, null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("updateArguments")
+    void testUpdateAccountPenaltiesSuccess(Instant createdAt, Instant closedAt, Boolean isPaid,
+            Double amount, Double outstandingAmount) throws NoDataFoundException, DataException {
+        UpdateAccountPenaltiesRequest request = new UpdateAccountPenaltiesRequest();
+        request.setCompanyCode(COMPANY_CODE);
+        request.setCustomerCode(CUSTOMER_CODE);
+        request.setCreatedAt(createdAt);
+        request.setClosedAt(closedAt);
+        request.setIsPaid(isPaid);
+        request.setAmount(amount);
+        request.setOutstandingAmount(outstandingAmount);
+
+        AccountPenalties accountPenalties = createAccountPenalties();
+
+        when(repository.findPenalty(
+                COMPANY_CODE, CUSTOMER_CODE, PENALTY_REF))
+                .thenReturn(Optional.of(accountPenalties));
+
+        AccountPenalties updatedPenalties = createAccountPenalties();
+        updatedPenalties.setCreatedAt(NOW.plusSeconds(10));
+        updatedPenalties.setClosedAt(NOW.plusSeconds(10));
+        updatedPenalties.getPenalties().getFirst().setIsPaid(true);
+        updatedPenalties.getPenalties().getFirst().setAmount(0.0);
+        updatedPenalties.getPenalties().getFirst().setOutstandingAmount(0.0);
+
+        when(repository.save(accountPenalties)).thenReturn(accountPenalties);
+
+        AccountPenaltiesData result = service.updateAccountPenalties(PENALTY_REF, request);
+
+        assertEquals(accountPenalties.getCustomerCode(), result.getCustomerCode());
+        assertEquals(accountPenalties.getCompanyCode(), result.getCompanyCode());
+        assertEquals(accountPenalties.getPenalties().getFirst().getTransactionReference(),
+                result.getPenalties().getFirst().getTransactionReference());
+        verify(repository, times(1))
+                .findPenalty(COMPANY_CODE, CUSTOMER_CODE, PENALTY_REF);
+        verify(repository, times(1))
+                .save(accountPenalties);
+    }
+
+    private static AccountPenalties createAccountPenalties() {
+        AccountPenalty penalty = getAccountPenalty();
+        List<AccountPenalty> penalties = new ArrayList<>();
+        penalties.add(penalty);
+
+        AccountPenalties accountPenalties = new AccountPenalties();
+        accountPenalties.setId(new ObjectId());
+        accountPenalties.setCompanyCode(COMPANY_CODE);
+        accountPenalties.setCustomerCode(CUSTOMER_CODE);
+        accountPenalties.setCreatedAt(NOW);
+        accountPenalties.setClosedAt(null);
+        accountPenalties.setPenalties(penalties);
+
+        return accountPenalties;
+    }
+
+    private static AccountPenalty getAccountPenalty() {
+        AccountPenalty penalty = new AccountPenalty();
+        penalty.setCompanyCode(COMPANY_CODE);
+        penalty.setCustomerCode(CUSTOMER_CODE);
+        penalty.setTransactionReference(PENALTY_REF);
+        penalty.setTransactionDate("2025-02-25");
+        penalty.setMadeUpDate("2025-02-12");
+        penalty.setAmount(15.0);
+        penalty.setOutstandingAmount(150.0);
+        penalty.setIsPaid(false);
+        penalty.setAccountStatus("CHS");
+        penalty.setDunningStatus("PEN1");
+        penalty.setTransactionType("1");
+        penalty.setTransactionSubType("C1");
+        penalty.setTransactionDate("2025-02-25");
+        penalty.setDueDate("2025-02-12");
+        penalty.setTypeDescription("PEN2");
+        penalty.setLedgerCode("EW");
+        return penalty;
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -17,16 +16,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.validation.ConstraintViolationException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -36,6 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.AcspMembers;
 import uk.gov.companieshouse.api.testdata.model.entity.Appointment;
 import uk.gov.companieshouse.api.testdata.model.entity.Certificates;
@@ -46,7 +45,6 @@ import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscs;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyRegisters;
 import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
 import uk.gov.companieshouse.api.testdata.model.entity.User;
-
 import uk.gov.companieshouse.api.testdata.model.rest.AcspMembersData;
 import uk.gov.companieshouse.api.testdata.model.rest.AcspMembersSpec;
 import uk.gov.companieshouse.api.testdata.model.rest.AcspProfileData;
@@ -63,9 +61,11 @@ import uk.gov.companieshouse.api.testdata.model.rest.Jurisdiction;
 import uk.gov.companieshouse.api.testdata.model.rest.RegistersSpec;
 import uk.gov.companieshouse.api.testdata.model.rest.RoleData;
 import uk.gov.companieshouse.api.testdata.model.rest.RoleSpec;
+import uk.gov.companieshouse.api.testdata.model.rest.UpdateAccountPenaltiesRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.UserData;
 import uk.gov.companieshouse.api.testdata.model.rest.UserSpec;
 import uk.gov.companieshouse.api.testdata.repository.AcspMembersRepository;
+import uk.gov.companieshouse.api.testdata.service.AccountPenaltiesService;
 import uk.gov.companieshouse.api.testdata.service.AppealsService;
 import uk.gov.companieshouse.api.testdata.service.CompanyAuthAllowListService;
 import uk.gov.companieshouse.api.testdata.service.CompanyAuthCodeService;
@@ -85,6 +85,9 @@ class TestDataServiceImplTest {
     private static final String APPOINTMENT_ID = "APPOINTMENT_ID";
     private static final String SCOTTISH_COMPANY_PREFIX = "SC";
     private static final String NI_COMPANY_PREFIX = "NI";
+    private static final String COMPANY_CODE = "LP";
+    private static final String CUSTOMER_CODE = "12345678";
+    private static final String PENALTY_REF = "A1234567";
     private static final String API_URL = "http://localhost:4001";
     private static final String USER_ID = "sZJQcNxzPvcwcqDwpUyRKNvVbcq";
     private static final String CERTIFICATES_ID = "CRT-123456-789012";
@@ -111,8 +114,6 @@ class TestDataServiceImplTest {
     private DataService<RoleData, RoleSpec> roleService;
     @Mock
     private DataService<AcspMembersData, AcspMembersSpec> acspMembersService;
-    @InjectMocks
-    private TestDataServiceImpl testDataService;
     @Mock
     private AcspMembersRepository acspMembersRepository;
     @Mock
@@ -133,6 +134,10 @@ class TestDataServiceImplTest {
     private CompanySearchService companySearchService;
     @Mock
     private DataService<CertificatesData, CertificatesSpec> certificatesService;
+    @Mock
+    private AccountPenaltiesService accountPenaltiesService;
+    @InjectMocks
+    private TestDataServiceImpl testDataService;
 
     @BeforeEach
     void setUp() {
@@ -143,11 +148,13 @@ class TestDataServiceImplTest {
      * Sets up common mocks for creating a company.
      *
      * @param spec                      the CompanySpec to be created.
-     * @param companyNumber             the raw company number (as string) to be returned by randomService.
+     * @param companyNumber             the raw company number (as string) to be returned by
+     *                                  randomService.
      * @param numberDigits              the number of digits to request from randomService.
      * @param expectedFullCompanyNumber the full company number expected in the created spec.
      */
-    private void setupCompanyCreationMocks(CompanySpec spec, String companyNumber, int numberDigits, String expectedFullCompanyNumber) throws DataException {
+    private void setupCompanyCreationMocks(CompanySpec spec, String companyNumber, int numberDigits,
+            String expectedFullCompanyNumber) throws DataException {
         when(randomService.getNumber(numberDigits)).thenReturn(Long.valueOf(companyNumber));
         when(companyProfileService.companyExists(expectedFullCompanyNumber)).thenReturn(false);
         CompanyAuthCode mockAuthCode = new CompanyAuthCode();
@@ -169,7 +176,8 @@ class TestDataServiceImplTest {
 
         when(randomService.getNumber(8)).thenReturn(Long.valueOf(COMPANY_NUMBER));
         when(companyAuthCodeService.create(any())).thenReturn(mockAuthCode);
-        when(appointmentService.create(any())).thenReturn(Collections.singletonList(commonAppointment));
+        when(appointmentService.create(any())).thenReturn(
+                Collections.singletonList(commonAppointment));
 
         return testDataService.createCompanyData(spec);
     }
@@ -187,7 +195,8 @@ class TestDataServiceImplTest {
     }
 
     private void verifyCommonCompanyCreation(CompanySpec capturedSpec, CompanyData createdCompany,
-                                             String expectedFullCompanyNumber, Jurisdiction expectedJurisdiction) throws DataException {
+            String expectedFullCompanyNumber, Jurisdiction expectedJurisdiction)
+            throws DataException {
         assertEquals(expectedFullCompanyNumber, capturedSpec.getCompanyNumber());
         assertEquals(expectedJurisdiction, capturedSpec.getJurisdiction());
         verify(filingHistoryService, times(1)).create(capturedSpec);
@@ -198,7 +207,8 @@ class TestDataServiceImplTest {
         verify(companyPscsService, times(1)).create(capturedSpec);
 
         assertEquals(expectedFullCompanyNumber, createdCompany.getCompanyNumber());
-        assertEquals(API_URL + "/company/" + expectedFullCompanyNumber, createdCompany.getCompanyUri());
+        assertEquals(API_URL + "/company/" + expectedFullCompanyNumber,
+                createdCompany.getCompanyUri());
         assertEquals(AUTH_CODE, createdCompany.getAuthCode());
     }
 
@@ -212,8 +222,8 @@ class TestDataServiceImplTest {
      * @throws DataException if creation fails
      */
     private AcspMembersData createAcspMembersDataHelper(String userId,
-                                                        AcspProfileData profileData,
-                                                        AcspMembersData membersData, AcspProfileSpec profileSpec) throws DataException {
+            AcspProfileData profileData,
+            AcspMembersData membersData, AcspProfileSpec profileSpec) throws DataException {
         AcspMembersSpec spec = new AcspMembersSpec();
         spec.setUserId(userId);
         spec.setAcspProfile(profileSpec);
@@ -223,11 +233,11 @@ class TestDataServiceImplTest {
     }
 
     private void verifyAcspMembersData(AcspMembersData data,
-                                       String expectedMemberId,
-                                       String expectedAcspNumber,
-                                       String expectedUserId,
-                                       String expectedStatus,
-                                       String expectedUserRole) {
+            String expectedMemberId,
+            String expectedAcspNumber,
+            String expectedUserId,
+            String expectedStatus,
+            String expectedUserRole) {
         assertNotNull(data);
         assertEquals(expectedMemberId, data.getAcspMemberId());
         assertEquals(expectedAcspNumber, data.getAcspNumber());
@@ -244,7 +254,8 @@ class TestDataServiceImplTest {
      * @return the result of testDataService.deleteAcspMembersData(...)
      * @throws DataException if deletion fails
      */
-    private boolean deleteAcspMembersDataHelper(String acspMemberId, Optional<AcspMembers> memberOptional)
+    private boolean deleteAcspMembersDataHelper(String acspMemberId,
+            Optional<AcspMembers> memberOptional)
             throws DataException {
         when(acspMembersRepository.findById(acspMemberId)).thenReturn(memberOptional);
         return testDataService.deleteAcspMembersData(acspMemberId);
@@ -262,16 +273,20 @@ class TestDataServiceImplTest {
     }
 
     /**
-     * Helper method to assert that deleting company data results in a DataException with the expected suppressed exceptions.
-     * Also verifies that every deletion service was called exactly once.
+     * Helper method to assert that deleting company data results in a DataException with the
+     * expected suppressed exceptions. Also verifies that every deletion service was called exactly
+     * once.
      *
      * @param expectedExceptions varargs array of the expected suppressed RuntimeExceptions.
      */
     private void assertDeleteCompanyDataException(RuntimeException... expectedExceptions) {
-        DataException thrown = assertThrows(DataException.class, () -> testDataService.deleteCompanyData(COMPANY_NUMBER));
-        assertEquals(expectedExceptions.length, thrown.getSuppressed().length, "Unexpected number of suppressed exceptions");
+        DataException thrown = assertThrows(DataException.class,
+                () -> testDataService.deleteCompanyData(COMPANY_NUMBER));
+        assertEquals(expectedExceptions.length, thrown.getSuppressed().length,
+                "Unexpected number of suppressed exceptions");
         for (int i = 0; i < expectedExceptions.length; i++) {
-            assertEquals(expectedExceptions[i], thrown.getSuppressed()[i], "Mismatch in suppressed exception at index " + i);
+            assertEquals(expectedExceptions[i], thrown.getSuppressed()[i],
+                    "Mismatch in suppressed exception at index " + i);
         }
         verify(companyProfileService, times(1)).delete(COMPANY_NUMBER);
         verify(filingHistoryService, times(1)).delete(COMPANY_NUMBER);
@@ -294,7 +309,8 @@ class TestDataServiceImplTest {
 
         CompanyData createdCompany = testDataService.createCompanyData(spec);
         CompanySpec capturedSpec = captureCompanySpec();
-        verifyCommonCompanyCreation(capturedSpec, createdCompany, expectedFullCompanyNumber, Jurisdiction.ENGLAND_WALES);
+        verifyCommonCompanyCreation(capturedSpec, createdCompany, expectedFullCompanyNumber,
+                Jurisdiction.ENGLAND_WALES);
     }
 
     @Test
@@ -306,7 +322,8 @@ class TestDataServiceImplTest {
 
         CompanyData createdCompany = testDataService.createCompanyData(spec);
         CompanySpec capturedSpec = captureCompanySpec();
-        verifyCommonCompanyCreation(capturedSpec, createdCompany, expectedFullCompanyNumber, Jurisdiction.SCOTLAND);
+        verifyCommonCompanyCreation(capturedSpec, createdCompany, expectedFullCompanyNumber,
+                Jurisdiction.SCOTLAND);
     }
 
     @Test
@@ -318,7 +335,8 @@ class TestDataServiceImplTest {
 
         CompanyData createdCompany = testDataService.createCompanyData(spec);
         CompanySpec capturedSpec = captureCompanySpec();
-        verifyCommonCompanyCreation(capturedSpec, createdCompany, expectedFullCompanyNumber, Jurisdiction.NI);
+        verifyCommonCompanyCreation(capturedSpec, createdCompany, expectedFullCompanyNumber,
+                Jurisdiction.NI);
     }
 
     @Test
@@ -339,7 +357,8 @@ class TestDataServiceImplTest {
         CompanySpec capturedSpec = captureCompanySpec();
         assertEquals(companyNumber, capturedSpec.getCompanyNumber());
         assertEquals(Jurisdiction.ENGLAND_WALES, capturedSpec.getJurisdiction());
-        verifyCommonCompanyCreation(capturedSpec, createdCompany, companyNumber, Jurisdiction.ENGLAND_WALES);
+        verifyCommonCompanyCreation(capturedSpec, createdCompany, companyNumber,
+                Jurisdiction.ENGLAND_WALES);
     }
 
     @Test
@@ -351,7 +370,8 @@ class TestDataServiceImplTest {
         when(randomService.getNumber(anyInt()))
                 .thenReturn(Long.valueOf(existingCompanyNumber))
                 .thenReturn(Long.valueOf(COMPANY_NUMBER));
-        when(companyProfileService.companyExists(SCOTTISH_COMPANY_PREFIX + existingCompanyNumber)).thenReturn(true);
+        when(companyProfileService.companyExists(
+                SCOTTISH_COMPANY_PREFIX + existingCompanyNumber)).thenReturn(true);
         when(companyProfileService.companyExists(expectedFullCompanyNumber)).thenReturn(false);
 
         CompanyAuthCode mockAuthCode = new CompanyAuthCode();
@@ -366,7 +386,8 @@ class TestDataServiceImplTest {
         CompanySpec capturedSpec = captureCompanySpec();
         assertEquals(expectedFullCompanyNumber, capturedSpec.getCompanyNumber());
         assertEquals(spec.getJurisdiction(), capturedSpec.getJurisdiction());
-        verifyCommonCompanyCreation(capturedSpec, createdCompany, expectedFullCompanyNumber, Jurisdiction.SCOTLAND);
+        verifyCommonCompanyCreation(capturedSpec, createdCompany, expectedFullCompanyNumber,
+                Jurisdiction.SCOTLAND);
     }
 
     @Test
@@ -380,7 +401,8 @@ class TestDataServiceImplTest {
 
         CompanyData createdCompany = testDataService.createCompanyData(spec);
         CompanySpec capturedSpec = captureCompanySpec();
-        verifyCommonCompanyCreation(capturedSpec, createdCompany, COMPANY_NUMBER, Jurisdiction.ENGLAND_WALES);
+        verifyCommonCompanyCreation(capturedSpec, createdCompany, COMPANY_NUMBER,
+                Jurisdiction.ENGLAND_WALES);
         verify(companyRegistersService, times(1)).create(capturedSpec);
     }
 
@@ -388,7 +410,8 @@ class TestDataServiceImplTest {
     void createCompanyDataRollBack() throws DataException {
         CompanySpec spec = new CompanySpec();
         spec.setJurisdiction(Jurisdiction.NI);
-        final String fullCompanyNumber = spec.getJurisdiction().getCompanyNumberPrefix(spec) + COMPANY_NUMBER;
+        final String fullCompanyNumber =
+                spec.getJurisdiction().getCompanyNumberPrefix(spec) + COMPANY_NUMBER;
         when(randomService.getNumber(anyInt())).thenReturn(Long.valueOf(COMPANY_NUMBER));
         DataException pscStatementException = new DataException("error");
         when(companyPscStatementService.create(spec)).thenThrow(pscStatementException);
@@ -412,7 +435,8 @@ class TestDataServiceImplTest {
     void createCompanyDataOverseasSpec() throws Exception {
         CompanySpec spec = new CompanySpec();
         spec.setJurisdiction(Jurisdiction.UNITED_KINGDOM);
-        when(randomService.getNumber(6)).thenReturn(Long.valueOf(OVERSEAS_COMPANY_NUMBER.substring(2)));
+        when(randomService.getNumber(6)).thenReturn(
+                Long.valueOf(OVERSEAS_COMPANY_NUMBER.substring(2)));
         final String fullCompanyNumber = OVERSEAS_COMPANY_NUMBER;
         when(companyProfileService.companyExists(fullCompanyNumber)).thenReturn(false);
         CompanyAuthCode mockAuthCode = new CompanyAuthCode();
@@ -523,7 +547,8 @@ class TestDataServiceImplTest {
         when(companyRegistersService.delete(COMPANY_NUMBER)).thenThrow(companyRegistersException);
 
         // Expect 4 suppressed exceptions in order.
-        assertDeleteCompanyDataException(profileException, authCodeException, pscStatementException, companyRegistersException);
+        assertDeleteCompanyDataException(profileException, authCodeException, pscStatementException,
+                companyRegistersException);
     }
 
     @Test
@@ -905,7 +930,8 @@ class TestDataServiceImplTest {
 
         when(identityService.delete(identityId)).thenThrow(ex);
 
-        DataException exception = assertThrows(DataException.class, () -> testDataService.deleteIdentityData(identityId));
+        DataException exception = assertThrows(DataException.class,
+                () -> testDataService.deleteIdentityData(identityId));
 
         assertEquals("Error deleting identity", exception.getMessage());
         assertEquals(ex, exception.getCause());
@@ -930,7 +956,8 @@ class TestDataServiceImplTest {
 
         verifyAcspMembersData(result,
                 String.valueOf(expectedMembersData.getAcspMemberId()),
-                acspProfileData.getAcspNumber(), expectedMembersData.getUserId(), expectedMembersData.getStatus(), expectedMembersData.getUserRole());
+                acspProfileData.getAcspNumber(), expectedMembersData.getUserId(),
+                expectedMembersData.getStatus(), expectedMembersData.getUserRole());
         verify(acspMembersService).create(any(AcspMembersSpec.class));
         verify(acspProfileService).create(argThat(profile -> profile.getAmlDetails() == null));
     }
@@ -954,7 +981,8 @@ class TestDataServiceImplTest {
 
         DataException exception = assertThrows(DataException.class,
                 () -> testDataService.createAcspMembersData(spec));
-        assertEquals("uk.gov.companieshouse.api.testdata.exception.DataException: Error creating ACSP profile",
+        assertEquals(
+                "uk.gov.companieshouse.api.testdata.exception.DataException: Error creating ACSP profile",
                 exception.getMessage());
     }
 
@@ -965,7 +993,8 @@ class TestDataServiceImplTest {
 
         AcspProfileData acspProfileData = new AcspProfileData("acspNumber");
         AcspMembersData acspMembersData =
-                new AcspMembersData(new ObjectId(), acspProfileData.getAcspNumber(), "userId", "active", "role");
+                new AcspMembersData(new ObjectId(), acspProfileData.getAcspNumber(), "userId",
+                        "active", "role");
         var acspStatus = "active";
         var acspType = "ltd";
         var supervisoryBody = "financial-conduct-authority-fca";
@@ -989,7 +1018,8 @@ class TestDataServiceImplTest {
 
         verifyAcspMembersData(result,
                 String.valueOf(acspMembersData.getAcspMemberId()),
-                acspProfileData.getAcspNumber(), acspMembersData.getUserId(), acspMembersData.getStatus(), acspMembersData.getUserRole());
+                acspProfileData.getAcspNumber(), acspMembersData.getUserId(),
+                acspMembersData.getStatus(), acspMembersData.getUserRole());
 
         verify(acspProfileService).create(acspProfile);
 
@@ -1017,7 +1047,8 @@ class TestDataServiceImplTest {
 
         verifyAcspMembersData(result,
                 String.valueOf(acspMembersData.getAcspMemberId()),
-                acspProfileData.getAcspNumber(), acspMembersData.getUserId(), acspMembersData.getStatus(), acspMembersData.getUserRole());
+                acspProfileData.getAcspNumber(), acspMembersData.getUserId(),
+                acspMembersData.getStatus(), acspMembersData.getUserRole());
 
         verify(acspProfileService).create(argThat(profile ->
                 profile.getStatus() == null
@@ -1040,7 +1071,8 @@ class TestDataServiceImplTest {
 
         DataException exception = assertThrows(DataException.class,
                 () -> testDataService.createAcspMembersData(spec));
-        assertEquals("uk.gov.companieshouse.api.testdata.exception.DataException: Error creating ACSP profile",
+        assertEquals(
+                "uk.gov.companieshouse.api.testdata.exception.DataException: Error creating ACSP profile",
                 exception.getMessage());
     }
 
@@ -1056,7 +1088,8 @@ class TestDataServiceImplTest {
 
         DataException exception = assertThrows(DataException.class,
                 () -> testDataService.createAcspMembersData(spec));
-        assertEquals("uk.gov.companieshouse.api.testdata.exception.DataException: Error creating ACSP member",
+        assertEquals(
+                "uk.gov.companieshouse.api.testdata.exception.DataException: Error creating ACSP member",
                 exception.getMessage());
     }
 
@@ -1309,7 +1342,8 @@ class TestDataServiceImplTest {
 
         CompanyData createdCompany = createCompanyDataWithRegisters(spec);
         CompanySpec capturedSpec = captureCreatedSpec();
-        verifyCommonCompanyCreation(capturedSpec, createdCompany, COMPANY_NUMBER, Jurisdiction.ENGLAND_WALES);
+        verifyCommonCompanyCreation(capturedSpec, createdCompany, COMPANY_NUMBER,
+                Jurisdiction.ENGLAND_WALES);
 
         assertEquals(OFFICER_ID, commonAppointment.getOfficerId());
         assertEquals(APPOINTMENT_ID, commonAppointment.getAppointmentId());
@@ -1322,7 +1356,8 @@ class TestDataServiceImplTest {
 
         CompanyData createdCompany = createCompanyDataWithRegisters(spec);
         CompanySpec capturedSpec = captureCreatedSpec();
-        verifyCommonCompanyCreation(capturedSpec, createdCompany, COMPANY_NUMBER, Jurisdiction.ENGLAND_WALES);
+        verifyCommonCompanyCreation(capturedSpec, createdCompany, COMPANY_NUMBER,
+                Jurisdiction.ENGLAND_WALES);
     }
 
     @Test
@@ -1430,7 +1465,8 @@ class TestDataServiceImplTest {
 
         when(identityService.create(identitySpec)).thenThrow(new RuntimeException("error"));
 
-        DataException exception = assertThrows(DataException.class, () -> testDataService.createIdentityData(identitySpec));
+        DataException exception = assertThrows(DataException.class,
+                () -> testDataService.createIdentityData(identitySpec));
         assertEquals("Error creating identity", exception.getMessage());
         verify(userService, never()).updateUserWithOneLogin(anyString());
     }
@@ -1486,4 +1522,110 @@ class TestDataServiceImplTest {
 
         verify(companySearchService, never()).deleteCompanyFromElasticSearchIndex(COMPANY_NUMBER);
     }
+
+    @Test
+    void getAccountPenaltiesData() throws Exception {
+        testDataService.getAccountPenaltiesData(COMPANY_CODE, CUSTOMER_CODE);
+        verify(accountPenaltiesService).getAccountPenalties(COMPANY_CODE, CUSTOMER_CODE);
+    }
+
+    @Test
+    void getAccountPenaltiesDataNotFoundException() throws NoDataFoundException {
+        NoDataFoundException ex = new NoDataFoundException(
+                "Error retrieving account penalties - not found");
+        when(accountPenaltiesService.getAccountPenalties(COMPANY_CODE, CUSTOMER_CODE))
+                .thenThrow(ex);
+
+        NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
+                testDataService.getAccountPenaltiesData(COMPANY_CODE, CUSTOMER_CODE));
+        assertEquals(ex.getMessage(), thrown.getMessage());
+    }
+
+    @Test
+    void getAccountPenaltyData() throws Exception {
+        testDataService.getAccountPenaltyData(COMPANY_CODE, CUSTOMER_CODE, PENALTY_REF);
+        verify(accountPenaltiesService).getAccountPenalty(COMPANY_CODE, CUSTOMER_CODE, PENALTY_REF);
+    }
+
+    @Test
+    void getAccountPenaltyDataNotFoundException() throws NoDataFoundException {
+        NoDataFoundException ex = new NoDataFoundException(
+                "Error retrieving account penalty - not found");
+        when(accountPenaltiesService.getAccountPenalty(COMPANY_CODE, CUSTOMER_CODE, PENALTY_REF))
+                .thenThrow(ex);
+
+        NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
+                testDataService.getAccountPenaltyData(COMPANY_CODE, CUSTOMER_CODE, PENALTY_REF));
+        assertEquals(ex.getMessage(), thrown.getMessage());
+    }
+
+    @Test
+    void updateAccountPenaltiesData() throws Exception {
+        UpdateAccountPenaltiesRequest request = new UpdateAccountPenaltiesRequest();
+        request.setCompanyCode(COMPANY_CODE);
+        request.setCustomerCode(CUSTOMER_CODE);
+        testDataService.updateAccountPenaltiesData(PENALTY_REF, request);
+        verify(accountPenaltiesService).updateAccountPenalties(PENALTY_REF, request);
+    }
+
+    @Test
+    void updateAccountPenaltiesDataNotFoundException() throws NoDataFoundException, DataException {
+        UpdateAccountPenaltiesRequest request = new UpdateAccountPenaltiesRequest();
+        request.setCompanyCode(COMPANY_CODE);
+        request.setCustomerCode(CUSTOMER_CODE);
+
+        NoDataFoundException ex = new NoDataFoundException(
+                "Error updating account penalties - not found");
+        when(accountPenaltiesService.updateAccountPenalties(PENALTY_REF, request))
+                .thenThrow(ex);
+
+        NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
+                testDataService.updateAccountPenaltiesData(PENALTY_REF, request));
+        assertEquals(ex.getMessage(), thrown.getMessage());
+    }
+
+    @Test
+    void updateAccountPenaltiesDataDataException() throws NoDataFoundException, DataException {
+        UpdateAccountPenaltiesRequest request = new UpdateAccountPenaltiesRequest();
+        request.setCompanyCode(COMPANY_CODE);
+        request.setCustomerCode(CUSTOMER_CODE);
+
+        DataException ex = new DataException("Error updating account penalties");
+        when(accountPenaltiesService.updateAccountPenalties(PENALTY_REF, request))
+                .thenThrow(ex);
+
+        DataException thrown = assertThrows(DataException.class, () ->
+                testDataService.updateAccountPenaltiesData(PENALTY_REF, request));
+        assertEquals(ex.getMessage(), thrown.getMessage());
+    }
+
+    @Test
+    void deleteAccountPenaltiesData() throws Exception {
+        testDataService.deleteAccountPenaltiesData(COMPANY_CODE, CUSTOMER_CODE);
+        verify(accountPenaltiesService).deleteAccountPenalties(COMPANY_CODE, CUSTOMER_CODE);
+    }
+
+    @Test
+    void deleteAccountPenaltiesDataNotFoundException() throws NoDataFoundException {
+        NoDataFoundException ex = new NoDataFoundException(
+                "Error deleting account penalties - not found");
+        when(accountPenaltiesService.deleteAccountPenalties(COMPANY_CODE, CUSTOMER_CODE))
+                .thenThrow(ex);
+
+        NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
+                testDataService.deleteAccountPenaltiesData(COMPANY_CODE, CUSTOMER_CODE));
+        assertEquals(ex.getMessage(), thrown.getMessage());
+    }
+
+    @Test
+    void deleteAccountPenaltiesDataException() throws NoDataFoundException {
+        DataException ex = new DataException("Error deleting account penalties");
+        when(accountPenaltiesService.deleteAccountPenalties(COMPANY_CODE, CUSTOMER_CODE))
+                .thenThrow(ConstraintViolationException.class);
+
+        DataException thrown = assertThrows(DataException.class, () ->
+                testDataService.deleteAccountPenaltiesData(COMPANY_CODE, CUSTOMER_CODE));
+        assertEquals(ex.getMessage(), thrown.getMessage());
+    }
+
 }


### PR DESCRIPTION
Add the following API operations for the account_penalties collection:
- getPenalty
- getAccountPenalties
- updateAccountPenalties
- deleteAccountPenalties
This is to allow the Karate and playwright frameworks to update data during tests. The account_penalties is a new collection that we have introduced in Team Austin as part of the Sanctions work to cache penalties coming from the E5 finance system. No other teams use this table.