### PR TITLE
Adding limit to integer options for tdg

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In order to use the generator, there are different possible endpoints that can b
   - `sub_type`: The subtype of the company (e.g., `community-interest-company`, `private-fund-limited-partnership`). Defaults to no subtype.
   - `has_super_secure_pscs`: Boolean value to determine if the company has super secure PSCs. Defaults to false, `true` value will create a Psc entry of `super-secure-person-with-significant-control` or `super-secure-beneficial-owner` depending on CompanyType.
   - `registers` : The registers of the company (e.g., `directors`, `persons-with-significant-control`, ``). Defaults to no registers.
-  - `number_of_appointments`: Used alongside `officer_roles` to determine the number of appointments to create. Defaults to 1.
+  - `number_of_appointments`: Used alongside `officer_roles` to determine the number of appointments to create. Defaults to 1. Has a maximum allowed value of 20.
   - `officer_roles`: This takes a list of officer roles (`director`, `secretary`). Defaults to director when no role is passed.
   - `accounts_due_status`: Set the accounts and confirmation statement due dates of the company by providing accounts_due_status (e.g., `overdue`, `due-soon`). Defaults to current date. 
   - `company_status_detail`: The status detail of the company (e.g., `active-proposal-to-strike-off`, `converted-to-plc`). Defaults to no value, field not present in the database.
@@ -60,12 +60,12 @@ In order to use the generator, there are different possible endpoints that can b
     - `category`: The category of the filing (e.g., `incorporation`, `dissolution`, `gazette`). Defaults to `incorporation`.
     - `description`: The description of the filing (e.g., `incorporation-company`, `gazette-notice-voluntary`). Defaults to `incorporation-company`.
     - `original_description`: The original description of the filing (e.g., `First gazette notice for voluntary strike-off`). Defaults to `Certificate of incorporation general company details & statements of; officers, capital & shareholdings, guarantee, compliance memorandum of association`.
-    - `number_of_psc`: The number of PSCs to create. Defaults to 0. Can be used to create multiple PSCs.
+    - `number_of_psc`: The number of PSCs to create. Defaults to 0. Can be used to create multiple PSCs. Has a maximum allowed value of 20.
     - `psc_type`: Used alongside the `number_of_psc`. The types of PSCs to create (e.g., `individual`, `corporate`, `legal-person`, `individual-bo`, `corporate-bo`).
     }
     - `psc_active`: Boolean value to determine if the PSCs are active or ceased. To be used alongside PSC requests. Where a request is creating multiple PSCs, a fasle value here will set the first PSC to inactive. Defaults to true.
-  - `withdrawn_statements`: Integer value to determine the number of withdrawn PSC statements to create. Defaults to 0.
-  - `active_statements`: Integer value to determine the number of active PSC statements to create. Defaults to 1 or `the number_of_psc` passed in the request.
+  - `withdrawn_statements`: Integer value to determine the number of withdrawn PSC statements to create. Defaults to 0. has a maximum allowed value of 20.
+  - `active_statements`: Integer value to determine the number of active PSC statements to create. Defaults to 1 or `the number_of_psc` passed in the request. Has a maximum allowed value of 20.
   - `registered_office_is_in_dispute`: Boolean value to determine if the registered office is in dispute. Defaults to false.
   - `alphabetical_search`: Boolean value to determine if the company is included in the alphabetical search. Defaults to false.
   - `advanced_search`: Boolean value to determine if the company is included in the advanced search. Defaults to false.

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/CompanySpec.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/CompanySpec.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 
 import java.util.List;
@@ -46,6 +48,8 @@ public class CompanySpec {
     @JsonProperty("filing_history")
     private FilingHistorySpec filingHistory;
 
+    @Min(value = 1, message = "Number of appointments must be at least 1")
+    @Max(value = 20, message = "Number of appointments must not exceed 20")
     @JsonProperty("number_of_appointments")
     private int numberOfAppointments = 1;
 
@@ -56,6 +60,8 @@ public class CompanySpec {
     @Pattern(regexp = "overdue|due-soon", message = "Invalid accounts due status")
     private String accountsDueStatus;
 
+    @Min(value = 1, message = "Number of PSCs must be at least 1")
+    @Max(value = 20, message = "Number of PSCs must not exceed 20")
     @JsonProperty("number_of_psc")
     private Integer numberOfPsc;
 
@@ -65,9 +71,13 @@ public class CompanySpec {
     @JsonProperty("psc_active")
     private Boolean pscActive;
 
+    @Min(value = 0, message = "Withdrawn statements must be at least 0")
+    @Max(value = 20, message = "Withdrawn statements must not exceed 20")
     @JsonProperty("withdrawn_statements")
     private Integer withdrawnStatements;
 
+    @Min(value = 0, message = "Active statements must be at least 0")
+    @Max(value = 20, message = "Active statements must not exceed 20")
     @JsonProperty("active_statements")
     private Integer activeStatements;
 

--- a/src/test/java/uk/gov/companieshouse/api/testdata/model/rest/CompanySpecTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/model/rest/CompanySpecTest.java
@@ -8,6 +8,8 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -15,6 +17,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class CompanySpecTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
 
     //Test that the CompanySpec does not accept invalid company status
     @Test
@@ -55,5 +65,122 @@ class CompanySpecTest {
         assertTrue(violations.stream().anyMatch(v ->
                 expectedViolationMessage.equals(v.getMessage())),
                 "Expected a violation message for " + expectedViolationMessage);
+    }
+
+    @Test
+    void testNumberOfAppointmentsMinValid() {
+        CompanySpec spec = new CompanySpec();
+        spec.setNumberOfAppointments(1);
+        assertNoViolations(spec);
+    }
+
+    @Test
+    void testNumberOfAppointmentsMaxValid() {
+        CompanySpec spec = new CompanySpec();
+        spec.setNumberOfAppointments(20);
+        assertNoViolations(spec);
+    }
+
+    @Test
+    void testNumberOfAppointmentsTooLow() {
+        CompanySpec spec = new CompanySpec();
+        spec.setNumberOfAppointments(0);
+        validateCompanySpec(spec, "Number of appointments must be at least 1");
+    }
+
+    @Test
+    void testNumberOfAppointmentsTooHigh() {
+        CompanySpec spec = new CompanySpec();
+        spec.setNumberOfAppointments(21);
+        validateCompanySpec(spec, "Number of appointments must not exceed 20");
+    }
+
+    @Test
+    void testNumberOfPscMinValid() {
+        CompanySpec spec = new CompanySpec();
+        spec.setNumberOfPsc(1);
+        assertNoViolations(spec);
+    }
+
+    @Test
+    void testNumberOfPscMaxValid() {
+        CompanySpec spec = new CompanySpec();
+        spec.setNumberOfPsc(20);
+        assertNoViolations(spec);
+    }
+
+    @Test
+    void testNumberOfPscTooLow() {
+        CompanySpec spec = new CompanySpec();
+        spec.setNumberOfPsc(0);
+        validateCompanySpec(spec, "Number of PSCs must be at least 1");
+    }
+
+    @Test
+    void testNumberOfPscTooHigh() {
+        CompanySpec spec = new CompanySpec();
+        spec.setNumberOfPsc(21);
+        validateCompanySpec(spec, "Number of PSCs must not exceed 20");
+    }
+
+    @Test
+    void testWithdrawnStatementsMinValid() {
+        CompanySpec spec = new CompanySpec();
+        spec.setWithdrawnStatements(0);
+        assertNoViolations(spec);
+    }
+
+    @Test
+    void testWithdrawnStatementsMaxValid() {
+        CompanySpec spec = new CompanySpec();
+        spec.setWithdrawnStatements(20);
+        assertNoViolations(spec);
+    }
+
+    @Test
+    void testWithdrawnStatementsTooLow() {
+        CompanySpec spec = new CompanySpec();
+        spec.setWithdrawnStatements(-1);
+        validateCompanySpec(spec, "Withdrawn statements must be at least 0");
+    }
+
+    @Test
+    void testWithdrawnStatementsTooHigh() {
+        CompanySpec spec = new CompanySpec();
+        spec.setWithdrawnStatements(21);
+        validateCompanySpec(spec, "Withdrawn statements must not exceed 20");
+    }
+
+    @Test
+    void testActiveStatementsMinValid() {
+        CompanySpec spec = new CompanySpec();
+        spec.setActiveStatements(0);
+        assertNoViolations(spec);
+    }
+
+    @Test
+    void testActiveStatementsMaxValid() {
+        CompanySpec spec = new CompanySpec();
+        spec.setActiveStatements(20);
+        assertNoViolations(spec);
+    }
+
+    @Test
+    void testActiveStatementsTooLow() {
+        CompanySpec spec = new CompanySpec();
+        spec.setActiveStatements(-1);
+        validateCompanySpec(spec, "Active statements must be at least 0");
+    }
+
+    @Test
+    void testActiveStatementsTooHigh() {
+        CompanySpec spec = new CompanySpec();
+        spec.setActiveStatements(21);
+        validateCompanySpec(spec, "Active statements must not exceed 20");
+    }
+
+    private void assertNoViolations(CompanySpec spec) {
+        Set<ConstraintViolation<CompanySpec>> violations = validator.validate(spec);
+        assertTrue(violations.isEmpty(), "Expected no violations, but found: " + violations);
     }
 }


### PR DESCRIPTION
Added limits of 20 max for 

- Number of PSC
- Officer Appointments
- Withdrawn Statements
- Active Statements