### PR TITLE
Updated Makefile for dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,6 @@ dist: clean build package
 sonar:
 	mvn sonar:sonar
 
-.PHONY: security-check
-security-check:
-	mvn org.owasp:dependency-check-maven:check -DassemblyAnalyzerEnabled=false
-
 .PHONY: sonar-pr-analysis
 sonar-pr-analysis:
 	mvn sonar:sonar -P sonar-pr-analysis

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.10</version>
+        <version>2.1.12</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
removed the dependency check section from the Makefile as a part of migrating to a centralized vulnerability scanning approach managed via the CI pipeline.
Updated parent pom to 2.1.12, use relativePath 2.1.12 brings in updated dependency-check settings.