### PR TITLE
Add a default of 1 individual PSC to companies

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/CompanySpec.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/CompanySpec.java
@@ -80,12 +80,12 @@ public class CompanySpec {
     @Min(value = 1, message = "Number of PSCs must be at least 1")
     @Max(value = 20, message = "Number of PSCs must not exceed 20")
     @JsonProperty("number_of_pscs")
-    private Integer numberOfPscs;
+    private Integer numberOfPscs = 1;
 
     @Size(max = 20, message = "PSC types must not exceed 20")
     @Valid
     @JsonProperty("psc_type")
-    private List<PscType> pscType;
+    private List<PscType> pscType = List.of(PscType.INDIVIDUAL);
 
     @JsonProperty("psc_active")
     private Boolean pscActive;

--- a/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/PublicCompanySpec.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/model/rest/PublicCompanySpec.java
@@ -66,12 +66,12 @@ public class PublicCompanySpec {
     @Min(value = 1, message = "Number of PSCs must be at least 1")
     @Max(value = 20, message = "Number of PSCs must not exceed 20")
     @JsonProperty("number_of_pscs")
-    private Integer numberOfPscs;
+    private Integer numberOfPscs = 1;
 
     @Size(max = 20, message = "PSC types must not exceed 20")
     @Valid
     @JsonProperty("psc_type")
-    private List<PscType> pscType;
+    private List<PscType> pscType = List.of(PscType.INDIVIDUAL);
 
     @JsonProperty("psc_active")
     private Boolean pscActive;

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscsServiceImpl.java
@@ -250,11 +250,14 @@ public class CompanyPscsServiceImpl implements DataService<CompanyPscs, CompanyS
         return LocalDate.now().atStartOfDay(ZoneId.of("UTC")).toInstant();
     }
 
+    /**
+     * Assigns a single, randomly selected nature of control from the predefined
+     * NATURES_OF_CONTROL array to the given CompanyPscs instance.
+     */
     private void setNaturesOfControl(CompanyPscs companyPsc) {
         List<String> nocList = Arrays.asList(NATURES_OF_CONTROL);
-        Collections.shuffle(nocList);
-        long num = randomService.getNumberInRange(0, NATURES_OF_CONTROL.length).orElse(0);
-        companyPsc.setNaturesOfControl(new ArrayList<>(nocList.subList(0, (int) num + 1)));
+        int index = (int) randomService.getNumberInRange(0, nocList.size() - 1).orElse(0);
+        companyPsc.setNaturesOfControl(List.of(nocList.get(index)));
     }
 
     private void buildSuperSecureBeneficialOwner(CompanyPscs companyPscs) {

--- a/src/test/java/uk/gov/companieshouse/api/testdata/model/rest/CompanySpecTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/model/rest/CompanySpecTest.java
@@ -1,18 +1,19 @@
 package uk.gov.companieshouse.api.testdata.model.rest;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
+
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -121,6 +122,13 @@ class CompanySpecTest {
         CompanySpec spec = new CompanySpec();
         spec.setNumberOfPscs(21);
         validateCompanySpec(spec, "Number of PSCs must not exceed 20");
+    }
+
+    @Test
+    void testDefaultPscValuesAreSet() {
+        CompanySpec spec = new CompanySpec();
+        assertEquals(1, spec.getNumberOfPscs());
+        assertEquals(List.of(PscType.INDIVIDUAL), spec.getPscType());
     }
 
     @Test


### PR DESCRIPTION
This pull request updates default values for the handling of PSC data in company specifications. The main focus is on ensuring that the `numberOfPscs` is set to 1 and `pscType` fields have sensible defaults - an individual PSC (the most common type).

**Default value improvements:**

* Set default value of `numberOfPscs` to 1 and `pscType` to `List.of(PscType.INDIVIDUAL)` in both `CompanySpec` and `PublicCompanySpec` classes. [[1]](diffhunk://#diff-4f3670d3bec2189db34acd98da738f99824d0e73c12499257e110e76f00764c1L83-R88) [[2]](diffhunk://#diff-a1320e43120a3b8cfade55c60c63ea24d411fdb0a87092fe8024dd768da09b2bL69-R74)

**Logic updates:**

* Refactored `setNaturesOfControl` in `CompanyPscsServiceImpl` to assign a single, randomly selected nature of control instead of a shuffled sublist, in line with business rules - only 1 PSC nature of control (ownership of shares) is valid.

**Unit tests**

* Added a new unit test in `CompanySpecTest` to verify that the default values for `numberOfPscs` and `pscType` are set as expected.