### PR TITLE
Change PSC defaults and logic 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ In order to use the generator, there are different possible endpoints that can b
     - `subcategory`: The sub category of the filing (e.g., `appointments`, `resolution`)
     - `description`: The description of the filing (e.g., `incorporation-company`, `gazette-notice-voluntary`). Defaults to `incorporation-company`.
     - `original_description`: The original description of the filing (e.g., `First gazette notice for voluntary strike-off`). Defaults to `Certificate of incorporation general company details & statements of; officers, capital & shareholdings, guarantee, compliance memorandum of association`.
-    - `number_of_pscs`: The number of PSCs to create. Defaults to 0. Can be used to create multiple PSCs. Has a maximum allowed value of 20.
+    - `number_of_pscs`: The number of PSCs to create. Defaults to 1 (an individual PSC). Can be used to create multiple PSCs. Has a maximum allowed value of 20.
     - `psc_type`: Used alongside the `number_of_pscs`. The types of PSCs to create (e.g., `individual`, `corporate`, `legal-person`, `individual-bo`, `corporate-bo`).
     - `resolutions`: This is optional, mandatory only when type is `RESOLUTIONS`
       - `barcode`: Barcode value for resolutions type. By default, it's an empty string.
@@ -77,7 +77,7 @@ In order to use the generator, there are different possible endpoints that can b
     }
     - `psc_active`: Boolean value to determine if the PSCs are active or ceased. To be used alongside PSC requests. Where a request is creating multiple PSCs, a fasle value here will set the first PSC to inactive. Defaults to true.
   - `withdrawn_statements`: Integer value to determine the number of withdrawn PSC statements to create. Defaults to 0. has a maximum allowed value of 20.
-  - `active_statements`: Integer value to determine the number of active PSC statements to create. Defaults to 1 or `the number_of_pscs` passed in the request. Has a maximum allowed value of 20.
+  - `active_statements`: Integer value to determine the number of active PSC statements to create. Defaults to 0. Has a maximum allowed value of 20.
   - `registered_office_is_in_dispute`: Boolean value to determine if the registered office is in dispute. Defaults to false.
   - `alphabetical_search`: Boolean value to determine if the company is included in the alphabetical search. Defaults to false.
   - `advanced_search`: Boolean value to determine if the company is included in the advanced search. Defaults to false.

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <api-security-java.version>2.0.8</api-security-java.version>
         <private-api-sdk-java.version>4.0.416</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.10</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.3</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.5-SNAPSHOT</test-data-generator-library.version>
 
         <!-- Overrides -->
         <!-- CVE-2025-48924 -->

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <api-security-java.version>2.0.8</api-security-java.version>
         <private-api-sdk-java.version>4.0.416</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.10</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.5-SNAPSHOT</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.5</test-data-generator-library.version>
 
         <!-- Overrides -->
         <!-- CVE-2025-48924 -->

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyMetricsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyMetricsServiceImpl.java
@@ -78,11 +78,10 @@ public class CompanyMetricsServiceImpl implements DataService<CompanyMetrics, Co
 
         if (BooleanUtils.isTrue(spec.getHasSuperSecurePscs())) {
             metrics.setActivePscStatementsCount(1);
-        } else if (spec.getActiveStatements() == null) {
-            metrics.setActivePscStatementsCount(spec.getNumberOfPscs()
-                    == null ? 0 : spec.getNumberOfPscs());
-        } else {
+        } else if (spec.getActiveStatements() != null) {
             metrics.setActivePscStatementsCount(spec.getActiveStatements());
+        } else {
+            metrics.setActivePscStatementsCount(0);
         }
 
         metrics.setWithdrawnPscStatementsCount(

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImpl.java
@@ -89,11 +89,10 @@ public class CompanyPscServiceImpl implements CompanyPscService {
     public List<CompanyPscs> create(CompanyRequest spec) throws DataException {
         LOG.info("Starting creation of PSCs for company number: " + spec.getCompanyNumber());
 
-        if (CompanyType.REGISTERED_OVERSEAS_ENTITY.equals(spec.getCompanyType())) {
-            if (spec.getPscType() == null || spec.getPscType().isEmpty() ||
-                spec.getPscType().stream().anyMatch(type -> type == PscType.INDIVIDUAL)) {
-                spec.setPscType(List.of(PscType.INDIVIDUAL_BENEFICIAL_OWNER));
-            }
+        if (CompanyType.REGISTERED_OVERSEAS_ENTITY.equals(spec.getCompanyType()) &&
+            (spec.getPscType() == null || spec.getPscType().isEmpty() ||
+             spec.getPscType().stream().anyMatch(type -> type == PscType.INDIVIDUAL))) {
+             spec.setPscType(List.of(PscType.INDIVIDUAL_BENEFICIAL_OWNER));
         }
 
         if (shouldReturnNullForExcludedCompanies(spec)) {
@@ -474,3 +473,4 @@ public class CompanyPscServiceImpl implements CompanyPscService {
         }
     }
 }
+

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImpl.java
@@ -95,7 +95,7 @@ public class CompanyPscServiceImpl implements CompanyPscService {
              spec.setPscType(List.of(PscType.INDIVIDUAL_BENEFICIAL_OWNER));
         }
 
-        if (shouldReturnNullForExcludedCompanies(spec)) {
+        if (shouldReturnNullForCompaniesThatDoNotNeedPscs(spec)) {
             LOG.info("Company type does not require a PSC. No PSCs will be created.");
             spec.setNumberOfPscs(0);
             return null;
@@ -120,7 +120,7 @@ public class CompanyPscServiceImpl implements CompanyPscService {
         return createPscsBasedOnCompanyType(spec, numberOfPsc);
     }
 
-    private boolean shouldReturnNullForExcludedCompanies(CompanyRequest spec) {
+    private boolean shouldReturnNullForCompaniesThatDoNotNeedPscs(CompanyRequest spec) {
         if (spec == null || spec.getCompanyType() == null) {
             return false;
         }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -34,14 +35,20 @@ public class CompanyPscServiceImpl implements CompanyPscService {
 
     private static final Logger LOG = LoggerFactory.getLogger(String.valueOf(CompanyPscServiceImpl.class));
 
-    static final String[] NATURES_OF_CONTROL = {"ownership-of-shares-25-to-50-percent",
+    static final String[] NATURES_OF_CONTROL_SHARES = {"ownership-of-shares-25-to-50-percent",
             "ownership-of-shares-50-to-75-percent",
             "ownership-of-shares-75-to-100-percent",
             "ownership-of-shares-25-to-50-percent-as-trust",
             "ownership-of-shares-50-to-75-percent-as-trust"};
+    static final String[] NATURES_OF_CONTROL_VOTING_RIGHTS = {"voting-rights-25-to-50-percent",
+            "voting-rights-50-to-75-percent",
+            "voting-rights-75-to-100-percent",};
+    static final String[] NATURES_OF_CONTROL_RIGHT_TO_APPOINT = {"right-to-appoint-and-remove-directors",
+            "right-to-appoint-and-remove-directors-as-trust",
+            "right-to-appoint-and-remove-directors-as-firm",};
     private static final int ID_LENGTH = 10;
     private static final int SALT_LENGTH = 8;
-    public static final String NATIONALITY = "BRITISH";
+    public static final String NATIONALITY = "British";
     public static final String REGISTRATION_NUMBER = "12345678";
     public static final String LEGAL_FORM = "Legal Form";
     public static final String LEGAL_AUTHORITY = "Legal Authority";
@@ -51,10 +58,19 @@ public class CompanyPscServiceImpl implements CompanyPscService {
     public static final String TITLE = "Dr.";
     public static final String FIRST_NAME = "First";
     public static final String LAST_NAME = "Last";
-    private static final int DEFAULT_NUMBER_OF_PSC = 0;
+    private static final int DEFAULT_NUMBER_OF_PSC = 1;
     private static final String PSC_ERROR_MESSAGE = "psc_type must be accompanied by number_of_psc";
     private static final String BENEFICIAL_OWNER_ERROR =
             "Beneficial owner type is not allowed for this company type";
+
+    private static final Set<CompanyType> EXCLUDED_COMPANY_TYPES = Set.of(
+            CompanyType.CHARITABLE_INCORPORATED_ORGANISATION,
+            CompanyType.EEIG,
+            CompanyType.EEIG_ESTABLISHMENT,
+            CompanyType.FURTHER_EDUCATION_OR_SIXTH_FORM_COLLEGE_CORPORATION,
+            CompanyType.OVERSEA_COMPANY,
+            CompanyType.SCOTTISH_CHARITABLE_INCORPORATED_ORGANISATION
+    );
 
     private final RandomService randomService;
     private final CompanyPscsRepository repository;
@@ -73,8 +89,16 @@ public class CompanyPscServiceImpl implements CompanyPscService {
     public List<CompanyPscs> create(CompanyRequest spec) throws DataException {
         LOG.info("Starting creation of PSCs for company number: " + spec.getCompanyNumber());
 
-        if (shouldReturnNullForOverseaCompany(spec)) {
-            LOG.info("Company type is OVERSEA_COMPANY. No PSCs will be created.");
+        if (CompanyType.REGISTERED_OVERSEAS_ENTITY.equals(spec.getCompanyType())) {
+            if (spec.getPscType() == null || spec.getPscType().isEmpty() ||
+                spec.getPscType().stream().anyMatch(type -> type == PscType.INDIVIDUAL)) {
+                spec.setPscType(List.of(PscType.INDIVIDUAL_BENEFICIAL_OWNER));
+            }
+        }
+
+        if (shouldReturnNullForExcludedCompanies(spec)) {
+            LOG.info("Company type does not require a PSC. No PSCs will be created.");
+            spec.setNumberOfPscs(0);
             return null;
         }
 
@@ -97,9 +121,12 @@ public class CompanyPscServiceImpl implements CompanyPscService {
         return createPscsBasedOnCompanyType(spec, numberOfPsc);
     }
 
-    private boolean shouldReturnNullForOverseaCompany(CompanyRequest spec) {
-        boolean result = CompanyType.OVERSEA_COMPANY.equals(spec.getCompanyType());
-        LOG.debug("shouldReturnNullForOverseaCompany: " + result);
+    private boolean shouldReturnNullForExcludedCompanies(CompanyRequest spec) {
+        if (spec == null || spec.getCompanyType() == null) {
+            return false;
+        }
+        boolean result = EXCLUDED_COMPANY_TYPES.contains(spec.getCompanyType());
+        LOG.debug("shouldReturnNullForExcludedCompanies: " + result);
         return result;
     }
 
@@ -182,11 +209,12 @@ public class CompanyPscServiceImpl implements CompanyPscService {
     }
 
     private PscType getBeneficialOwnerType(List<PscType> requestedPscTypes, int index) {
+        // If PSC types are provided, cycle through them
         if (requestedPscTypes != null && !requestedPscTypes.isEmpty()) {
             return requestedPscTypes.get(index % requestedPscTypes.size());
         }
-        return index % 2 == 0 ? PscType.INDIVIDUAL_BENEFICIAL_OWNER
-                : PscType.CORPORATE_BENEFICIAL_OWNER;
+        // Default to INDIVIDUAL_BENEFICIAL_OWNER for registered overseas entities
+        return PscType.INDIVIDUAL_BENEFICIAL_OWNER;
     }
 
     private PscType getRegularPscType(List<PscType> requestedPscTypes, int index) {
@@ -259,12 +287,27 @@ public class CompanyPscServiceImpl implements CompanyPscService {
         return LocalDate.now().atStartOfDay(ZoneId.of("UTC")).toInstant();
     }
 
+    /**
+     * Sets the natures of control for a given CompanyPscs object.
+     * This method selects one random nature of control from each of the predefined categories:
+     * ownership of shares, voting rights, and the right to appoint and remove directors
+     * The selected values are then assigned to the CompanyPscs object.
+     *
+     * @param companyPsc the CompanyPscs object to which the natures of control will be assigned
+     */
     private void setNaturesOfControl(CompanyPscs companyPsc) {
-        List<String> nocList = Arrays.asList(NATURES_OF_CONTROL);
-        Collections.shuffle(nocList);
-        long num = randomService.getNumberInRange(0, NATURES_OF_CONTROL.length).orElse(0);
-        companyPsc.setNaturesOfControl(new ArrayList<>(nocList.subList(0, (int) num + 1)));
+        List<String> sharesList = new ArrayList<>(Arrays.asList(NATURES_OF_CONTROL_SHARES));
+        List<String> votingRightsList = new ArrayList<>(Arrays.asList(NATURES_OF_CONTROL_VOTING_RIGHTS));
+        List<String> rightToAppointList = new ArrayList<>(Arrays.asList(NATURES_OF_CONTROL_RIGHT_TO_APPOINT));
+        Collections.shuffle(sharesList);
+        Collections.shuffle(votingRightsList);
+        Collections.shuffle(rightToAppointList);
+        String randomShares = sharesList.get(0);
+        String randomVotingRights = votingRightsList.get(0);
+        String randomRightToAppoint = rightToAppointList.get(0);
+        companyPsc.setNaturesOfControl(List.of(randomShares, randomVotingRights, randomRightToAppoint));
     }
+
 
     private void buildSuperSecureBeneficialOwner(CompanyPscs companyPscs) {
         companyPscs.setKind(PscType.SUPER_SECURE_BENEFICIAL_OWNER.getKind());

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import org.apache.commons.lang.BooleanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -80,40 +79,30 @@ public class CompanyPscStatementServiceImpl implements
     public List<CompanyPscStatement> createPscStatements(CompanyRequest spec) {
         List<CompanyPscStatement> generatedStatements = new ArrayList<>();
 
-        Integer withdrawnPscStatementsCount = spec.getWithdrawnStatements();
-        Integer activePscStatementsCount = spec.getActiveStatements();
-        Integer numberOfPsc = spec.getNumberOfPscs();
+        int withdrawnPscStatementsCount = spec.getWithdrawnStatements() != null ? spec.getWithdrawnStatements() : 0;
+        int activePscStatementsCount = spec.getActiveStatements() != null ? spec.getActiveStatements() : 0;
 
-        boolean specificWithdrawnRequested = withdrawnPscStatementsCount
-                != null && withdrawnPscStatementsCount > 0;
-
-        int effectiveActivePscCount;
-        if (BooleanUtils.isTrue(spec.getHasSuperSecurePscs())) {
-            effectiveActivePscCount = 1;
-        } else {
-            effectiveActivePscCount = Objects.requireNonNullElseGet(activePscStatementsCount,
-                    () -> Objects.requireNonNullElse(numberOfPsc, 0));
-        }
-
-        boolean specificActiveOrNumberOfPscRequested = effectiveActivePscCount > 0;
+        boolean hasSuperSecure = BooleanUtils.isTrue(spec.getHasSuperSecurePscs());
+        boolean specificWithdrawnRequested = withdrawnPscStatementsCount > 0;
+        boolean specificActiveRequested = activePscStatementsCount > 0;
 
         List<CompanyPscStatement> withdrawn = new ArrayList<>();
         List<CompanyPscStatement> active = new ArrayList<>();
-        // No need for singleDefault list if it's no longer being conditionally added
 
-        if (specificWithdrawnRequested || specificActiveOrNumberOfPscRequested) {
+        if (hasSuperSecure) {
+            int count = spec.getActiveStatements() != null ? spec.getActiveStatements() : 1;
+            active = generateActivePscStatements(spec, count);
+        } else {
             if (specificWithdrawnRequested) {
                 withdrawn = generateWithdrawnPscStatements(spec, withdrawnPscStatementsCount);
             }
-            if (specificActiveOrNumberOfPscRequested) {
-                active = generateActivePscStatements(spec, effectiveActivePscCount);
+            if (specificActiveRequested) {
+                active = generateActivePscStatements(spec, activePscStatementsCount);
             }
         }
-        // The 'else' block that added a default statement has been removed.
 
         generatedStatements.addAll(withdrawn);
         generatedStatements.addAll(active);
-        // singleDefault list and its addAll call is removed.
 
         return generatedStatements;
     }
@@ -158,6 +147,7 @@ public class CompanyPscStatementServiceImpl implements
             tempSpec.setWithdrawnStatements(0);
             tempSpec.setNumberOfPscs(1);
             tempSpec.setPscActive(true);
+            tempSpec.setHasSuperSecurePscs(spec.getHasSuperSecurePscs());
             if (spec.getCompanyWithPopulatedStructureOnly() != null) {
                 tempSpec.setCompanyWithPopulatedStructureOnly(spec.getCompanyWithPopulatedStructureOnly());
             }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyMetricsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyMetricsServiceImplTest.java
@@ -162,7 +162,7 @@ class CompanyMetricsServiceImplTest {
         ArgumentCaptor<CompanyMetrics> metricsCaptor = ArgumentCaptor.forClass(CompanyMetrics.class);
         verify(repository).save(metricsCaptor.capture());
         CompanyMetrics metrics = metricsCaptor.getValue();
-        assertEquals(0, metrics.getActivePscCount());
+        assertEquals(1, metrics.getActivePscCount());
     }
 
     @Test
@@ -318,24 +318,6 @@ class CompanyMetricsServiceImplTest {
     }
 
     @Test
-    void createWithActivePscStatementsCountFromNumberOfPsc() {
-        CompanyRequest spec = new CompanyRequest();
-        spec.setCompanyNumber(COMPANY_NUMBER);
-        spec.setNumberOfPscs(2);
-        spec.setCompanyWithPopulatedStructureOnly(false);
-        when(randomService.getEtag()).thenReturn(ETAG);
-        when(repository.save(any())).thenReturn(new CompanyMetrics());
-
-        metricsService.create(spec);
-
-        ArgumentCaptor<CompanyMetrics> captor = ArgumentCaptor.forClass(CompanyMetrics.class);
-        verify(repository).save(captor.capture());
-        CompanyMetrics metrics = captor.getValue();
-
-        assertEquals(2, metrics.getActivePscStatementsCount());
-    }
-
-    @Test
     void createWithDefaultActivePscStatementsCount() {
         CompanyRequest spec = new CompanyRequest();
         spec.setCompanyNumber(COMPANY_NUMBER);
@@ -435,16 +417,6 @@ class CompanyMetricsServiceImplTest {
         metricsService.setPscCount(metrics, spec);
 
         assertEquals(1, metrics.getPscCount());
-    }
-
-    @Test
-    void setPscCount_WhenNoPscCount_ShouldSetCountToZero() {
-        CompanyRequest spec = new CompanyRequest();
-        spec.setCompanyWithPopulatedStructureOnly(false);
-        CompanyMetrics metrics = new CompanyMetrics();
-        metricsService.setPscCount(metrics, spec);
-
-        assertEquals(0, metrics.getPscCount());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyMetricsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyMetricsServiceImplTest.java
@@ -318,24 +318,6 @@ class CompanyMetricsServiceImplTest {
     }
 
     @Test
-    void createWithActivePscStatementsCountFromNumberOfPsc() {
-        CompanyRequest spec = new CompanyRequest();
-        spec.setCompanyNumber(COMPANY_NUMBER);
-        spec.setNumberOfPscs(2);
-        spec.setCompanyWithPopulatedStructureOnly(false);
-        when(randomService.getEtag()).thenReturn(ETAG);
-        when(repository.save(any())).thenReturn(new CompanyMetrics());
-
-        metricsService.create(spec);
-
-        ArgumentCaptor<CompanyMetrics> captor = ArgumentCaptor.forClass(CompanyMetrics.class);
-        verify(repository).save(captor.capture());
-        CompanyMetrics metrics = captor.getValue();
-
-        assertEquals(2, metrics.getActivePscStatementsCount());
-    }
-
-    @Test
     void createWithDefaultActivePscStatementsCount() {
         CompanyRequest spec = new CompanyRequest();
         spec.setCompanyNumber(COMPANY_NUMBER);
@@ -349,7 +331,7 @@ class CompanyMetricsServiceImplTest {
         verify(repository).save(captor.capture());
         CompanyMetrics metrics = captor.getValue();
 
-        assertEquals(1, metrics.getActivePscStatementsCount());
+        assertEquals(0, metrics.getActivePscStatementsCount());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImplTest.java
@@ -295,10 +295,10 @@ class CompanyPscServiceImplTest {
     }
 
     @Test
-    void create_WithNullNumberOfPsc_ReturnsNull() throws DataException {
+    void createWithExcludedPscCompanyTypeReturnsNull() throws DataException {
         CompanyRequest spec = new CompanyRequest();
         spec.setCompanyNumber(COMPANY_NUMBER);
-        spec.setCompanyType(CompanyType.LTD);
+        spec.setCompanyType(CompanyType.OVERSEA_COMPANY);
         spec.setPscType(null);
         spec.setNumberOfPscs(null);
         spec.setCompanyWithPopulatedStructureOnly(false);

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImplTest.java
@@ -140,6 +140,7 @@ class CompanyPscServiceImplTest {
     void create_WithAccountsDueStatus_SetsCorrectDates() throws DataException {
         CompanyRequest spec = new CompanyRequest();
         spec.setCompanyNumber(COMPANY_NUMBER);
+        spec.setCompanyType(CompanyType.LTD);
         spec.setAccountsDueStatus("due-soon");
         spec.setNumberOfPscs(1);
         spec.setPscType(List.of(PscType.INDIVIDUAL));
@@ -215,7 +216,7 @@ class CompanyPscServiceImplTest {
         CompanyRequest spec = new CompanyRequest();
         spec.setCompanyNumber(COMPANY_NUMBER);
         spec.setCompanyType(CompanyType.LTD);
-        spec.setPscType(List.of(PscType.INDIVIDUAL));
+        spec.setNumberOfPscs(null);
         spec.setCompanyWithPopulatedStructureOnly(false);
 
         DataException exception = assertThrows(DataException.class,
@@ -294,10 +295,10 @@ class CompanyPscServiceImplTest {
     }
 
     @Test
-    void create_WithNullNumberOfPsc_ReturnsNull() throws DataException {
+    void createWithExcludedPscCompanyTypeReturnsNull() throws DataException {
         CompanyRequest spec = new CompanyRequest();
         spec.setCompanyNumber(COMPANY_NUMBER);
-        spec.setCompanyType(CompanyType.LTD);
+        spec.setCompanyType(CompanyType.OVERSEA_COMPANY);
         spec.setNumberOfPscs(null);
         spec.setCompanyWithPopulatedStructureOnly(false);
 

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.api.testdata.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -465,26 +466,6 @@ class CompanyPscStatementServiceImplTest {
     }
 
     @Test
-    void createPscStatements_hasSuperSecurePscs() {
-        spec.setHasSuperSecurePscs(true);
-        spec.setNumberOfPscs(5);
-
-        doReturn(new CompanyPscStatement()).when(companyPscStatementService).create(any(CompanyRequest.class));
-
-        List<CompanyPscStatement> result = companyPscStatementService.createPscStatements(spec);
-
-        verify(companyPscStatementService, times(1)).create(any(CompanyRequest.class));
-        assertEquals(1, result.size());
-
-        ArgumentCaptor<CompanyRequest> specCaptor = ArgumentCaptor.forClass(CompanyRequest.class);
-        verify(companyPscStatementService, times(1)).create(specCaptor.capture());
-        CompanyRequest capturedSpec = specCaptor.getValue();
-        assertEquals(0, capturedSpec.getWithdrawnStatements());
-        assertEquals(1, capturedSpec.getNumberOfPscs());
-        assertTrue(capturedSpec.getPscActive());
-    }
-
-    @Test
     void createPscStatements_activeStatementsPrioritizesOverNumberOfPsc() {
         spec.setActiveStatements(2);
         spec.setNumberOfPscs(5);
@@ -500,27 +481,6 @@ class CompanyPscStatementServiceImplTest {
         verify(companyPscStatementService, times(2)).create(specCaptor.capture());
         List<CompanyRequest> capturedSpecs = specCaptor.getAllValues();
         assertEquals(2, capturedSpecs.size());
-        assertTrue(capturedSpecs.get(0).getPscActive());
-        assertEquals(1, capturedSpecs.get(0).getNumberOfPscs());
-        assertEquals(0, capturedSpecs.get(0).getWithdrawnStatements());
-    }
-
-    @Test
-    void createPscStatements_numberOfPscUsedWhenActiveStatementsIsNull() {
-        spec.setActiveStatements(null);
-        spec.setNumberOfPscs(3);
-
-        doReturn(new CompanyPscStatement()).when(companyPscStatementService).create(any(CompanyRequest.class));
-
-        List<CompanyPscStatement> result = companyPscStatementService.createPscStatements(spec);
-
-        verify(companyPscStatementService, times(3)).create(any(CompanyRequest.class));
-        assertEquals(3, result.size());
-
-        ArgumentCaptor<CompanyRequest> specCaptor = ArgumentCaptor.forClass(CompanyRequest.class);
-        verify(companyPscStatementService, times(3)).create(specCaptor.capture());
-        List<CompanyRequest> capturedSpecs = specCaptor.getAllValues();
-        assertEquals(3, capturedSpecs.size());
         assertTrue(capturedSpecs.get(0).getPscActive());
         assertEquals(1, capturedSpecs.get(0).getNumberOfPscs());
         assertEquals(0, capturedSpecs.get(0).getWithdrawnStatements());
@@ -616,4 +576,46 @@ class CompanyPscStatementServiceImplTest {
         verify(repository, never()).save(any());
     }
 
+    @Test
+    void createActivePscStatementsWithSuperSecurePscs() {
+        spec.setHasSuperSecurePscs(true);
+        spec.setActiveStatements(3);
+
+        doReturn(new CompanyPscStatement()).when(companyPscStatementService).create(any(CompanyRequest.class));
+
+        List<CompanyPscStatement> result = companyPscStatementService.createPscStatements(spec);
+
+        verify(companyPscStatementService, times(3)).create(any(CompanyRequest.class));
+        assertEquals(3, result.size());
+
+        ArgumentCaptor<CompanyRequest> specCaptor = ArgumentCaptor.forClass(CompanyRequest.class);
+        verify(companyPscStatementService, times(3)).create(specCaptor.capture());
+        List<CompanyRequest> capturedSpecs = specCaptor.getAllValues();
+        assertEquals(3, capturedSpecs.size());
+        for (CompanyRequest capturedSpec : capturedSpecs) {
+            assertEquals(Boolean.TRUE, capturedSpec.getHasSuperSecurePscs());
+        }
+    }
+
+    @Test
+    void createActivePscStatementsWithoutSuperSecurePscs() {
+        spec.setHasSuperSecurePscs(false);
+        spec.setActiveStatements(3);
+        spec.setWithdrawnStatements(2);
+
+        doReturn(new CompanyPscStatement()).when(companyPscStatementService).create(any(CompanyRequest.class));
+
+        List<CompanyPscStatement> result = companyPscStatementService.createPscStatements(spec);
+
+        verify(companyPscStatementService, times(5)).create(any(CompanyRequest.class));
+        assertEquals(5, result.size());
+
+        ArgumentCaptor<CompanyRequest> specCaptor = ArgumentCaptor.forClass(CompanyRequest.class);
+        verify(companyPscStatementService, times(5)).create(specCaptor.capture());
+        List<CompanyRequest> capturedSpecs = specCaptor.getAllValues();
+        assertEquals(5, capturedSpecs.size());
+        for (CompanyRequest capturedSpec : capturedSpecs) {
+            assertNotEquals(Boolean.TRUE, capturedSpec.getHasSuperSecurePscs());
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces several updates to the test data generation logic for companies, with a focus on PSC (Person with Significant Control) handling, default values, and exclusion rules for certain company types. The changes improve clarity in default behaviors, enforce correct PSC creation for different company types, and refining how natures of control are assigned. Documentation and tests have been updated to reflect these changes.

### Default values and documentation updates

* The default value for `number_of_pscs` is now 1 (individual PSC) instead of 0, and the default for `active_statements` is now 0 instead of 1 or the value of `number_of_pscs`. These changes are documented in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R67) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L80-R80)
* The constant `DEFAULT_NUMBER_OF_PSC` in `CompanyPscServiceImpl.java` is updated to 1, and the default nationality is now "British" (non-capitalised).
* The coupling between activeStatements and numberOfPsc is removed, preventing unintended statement generation - ensuring that PSC statements are only created when requested.
* Withdrawn statements are generated only if withdrawnStatements is set and greater than zero.
* Active statements are generated only if activeStatements is set and greater than zero.
* There is no fallback to numberOfPsc for active statements.

### PSC exclusion logic and handling

* A new exclusion set is added for company types that do not require PSCs (e.g., charitable incorporated organisations, EEIG, oversea companies, etc.). The creation logic now sets `number_of_pscs` to 0 and returns null for these types, and the helper method is renamed and updated accordingly. [[1]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dL54-R74) [[2]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dL76-R101) [[3]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dL100-R129)
* The test for PSC creation with excluded company types is updated to ensure correct null return behavior.

### PSC natures of control assignment

* The method for assigning natures of control to PSCs now selects one random value from each category (shares, voting rights, right to appoint), ensuring a more realistic and varied assignment. Previously this was just selecting a random number of nature of control ownership of shares which violates business rules as only one should be selected.

### Metrics and statement generation logic

* The logic for setting active PSC statements count is updated: if `activeStatements` is provided, it is used; otherwise, the count defaults to 0. Associated tests are updated to reflect this new behavior. [[1]](diffhunk://#diff-7d04d0cc1b97e82dcf307e80859aaca6af237efbaa49ae3cac7b855aa2098d10L81-R84) [[2]](diffhunk://#diff-b9b81f97d8f97c2eff562100dd07aa86c660b44c2c16740aebd153447df70d2eL165-R165) [[3]](diffhunk://#diff-b9b81f97d8f97c2eff562100dd07aa86c660b44c2c16740aebd153447df70d2eL320-L337) [[4]](diffhunk://#diff-b9b81f97d8f97c2eff562100dd07aa86c660b44c2c16740aebd153447df70d2eL440-L449)
* PSC statement generation is simplified: withdrawn and active statements are only generated if explicitly requested, and the logic for handling super secure PSCs is improved. [[1]](diffhunk://#diff-7e3efa7693964af8841af3220058baa0ef2bce844fcbcc038110fdb75dc3ed0eL83-L116) [[2]](diffhunk://#diff-7e3efa7693964af8841af3220058baa0ef2bce844fcbcc038110fdb75dc3ed0eR150)

### Miscellaneous improvements

* Dependency version for the test data generator library is updated in `pom.xml` from 1.0.3 to 1.0.5 https://github.com/companieshouse/test-data-generator-library/pull/7
* Minor code cleanup and test improvements, including import adjustments and assertion additions. [[1]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dR11) [[2]](diffhunk://#diff-c5d14f8fe0970be4ffac65376d7554fb6fddd1d30b7bcd6e5515c7476c86f1f6R6) [[3]](diffhunk://#diff-e20ed2cbaaf795a0b107342ac70574d088fd45dbc614695dd172e0c335186853R143) [[4]](diffhunk://#diff-e20ed2cbaaf795a0b107342ac70574d088fd45dbc614695dd172e0c335186853L218-R219)

These changes collectively improve the reliability and correctness of test data generation for companies and PSCs.