### PR TITLE
default to 2 directors and 1 secretary for plc companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In order to use the generator, there are different possible endpoints that can b
   - `sub_type`: The subtype of the company (e.g., `community-interest-company`, `private-fund-limited-partnership`). Defaults to no subtype.
   - `has_super_secure_pscs`: Boolean value to determine if the company has super secure PSCs. Defaults to false, `true` value will create a Psc entry of `super-secure-person-with-significant-control` or `super-secure-beneficial-owner` depending on CompanyType.
   - `registers` : The registers of the company (e.g., `directors`, `persons-with-significant-control`, ``). Defaults to no registers.
-  - `number_of_appointments`: Used alongside `officer_roles` to determine the number of appointments to create. Defaults to 1. Has a maximum allowed value of 20.
+  - `number_of_appointments`: Used alongside `officer_roles` to determine the number of appointments to create. Defaults to 1 director. Defaults to 2 directors and 1 secretary for PLC companies. Has a maximum allowed value of 20.
   - `officer_roles`: This takes a list of officer roles (`director`, `secretary`). Defaults to director when no role is passed.
   - `is_secure_officer`: Boolean value to determine if the officer is a secure officer. Defaults to false, `true` value will create an officer with `is_secure_officer` set to true.
   - `no_default_officers`: Boolean value to determine if the company is created without default officers. Defaults to false, `true` value will create a company without default officers.

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <api-security-java.version>2.0.8</api-security-java.version>
         <private-api-sdk-java.version>4.0.416</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.10</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.6</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.8</test-data-generator-library.version>
 
         <!-- Overrides -->
         <!-- CVE-2025-48924 -->

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
@@ -14,6 +14,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.AppointmentsData;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
 import uk.gov.companieshouse.api.testdata.model.entity.OfficerAppointment;
 import uk.gov.companieshouse.api.testdata.model.entity.OfficerAppointmentItem;
+import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AppointmentCreationRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AppointmentsResultResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
@@ -73,19 +74,43 @@ public class AppointmentsServiceImpl implements AppointmentService {
         final var companyNumber = spec.getCompanyNumber();
         final String countryOfResidence = addressService.getCountryOfResidence(
                 spec.getJurisdiction());
-        int numberOfAppointments = spec.getNumberOfAppointments();
-        if (numberOfAppointments <= 0) {
-            LOG.info("Number of appointments is less than or equal to 0. Defaulting to 1.");
-            numberOfAppointments = 1;
+        Integer numberOfAppointments = spec.getNumberOfAppointments();
+        boolean explicitlySet = payloadExplicitlySetNumberOfAppointments(spec);
+
+        if (spec.getCompanyType() == CompanyType.PLC) {
+            // Always ensure at least 2 directors and 1 secretary for PLC
+            if (!explicitlySet || numberOfAppointments == null || numberOfAppointments < 3) {
+                LOG.info("PLC company type and numberOfAppointments not set or less than 3. Defaulting to 2 directors and 1 secretary");
+                numberOfAppointments = 3;
+            }
+        } else {
+            if (!explicitlySet || numberOfAppointments == null || numberOfAppointments <= 0) {
+                LOG.info("Number of appointments not set or <= 0. Defaulting to 1.");
+                numberOfAppointments = 1;
+            }
         }
 
         List<OfficerType> officerRoleList = new ArrayList<>();
-        if (spec.getOfficerRoles() != null) {
-            officerRoleList.addAll(spec.getOfficerRoles());
-            LOG.debug("Officer roles provided: " + spec.getOfficerRoles());
+        List<OfficerType> providedRoles = spec.getOfficerRoles();
+        int providedCount = (providedRoles != null) ? providedRoles.size() : 0;
+        if (providedCount > 0) {
+            officerRoleList.addAll(providedRoles);
+            LOG.debug("Officer roles provided: " + providedRoles);
         }
-        while (officerRoleList.size() < numberOfAppointments) {
-            officerRoleList.add(OfficerType.DIRECTOR);
+        if (spec.getCompanyType() == CompanyType.PLC) {
+            for (int i = providedCount; i < numberOfAppointments; i++) {
+                if (i == 0 || i == 1) {
+                    officerRoleList.add(OfficerType.DIRECTOR);
+                } else if (i == 2) {
+                    officerRoleList.add(OfficerType.SECRETARY);
+                } else {
+                    officerRoleList.add(OfficerType.DIRECTOR);
+                }
+            }
+        } else {
+            for (int i = providedCount; i < numberOfAppointments; i++) {
+                officerRoleList.add(OfficerType.DIRECTOR);
+            }
         }
 
         List<String> appointmentIds = new ArrayList<>();
@@ -384,5 +409,9 @@ public class AppointmentsServiceImpl implements AppointmentService {
     private String setRoleName(String role) {
         return role.toLowerCase().replace(role.substring(0, 1),
                 role.substring(0, 1).toUpperCase());
+    }
+
+    private boolean payloadExplicitlySetNumberOfAppointments(CompanyRequest spec) {
+        return spec.isNumberOfAppointmentsSet();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImpl.java
@@ -99,13 +99,8 @@ public class AppointmentsServiceImpl implements AppointmentService {
         }
         if (spec.getCompanyType() == CompanyType.PLC) {
             for (int i = providedCount; i < numberOfAppointments; i++) {
-                if (i == 0 || i == 1) {
-                    officerRoleList.add(OfficerType.DIRECTOR);
-                } else if (i == 2) {
-                    officerRoleList.add(OfficerType.SECRETARY);
-                } else {
-                    officerRoleList.add(OfficerType.DIRECTOR);
-                }
+                OfficerType officerType = (i == 2) ? OfficerType.SECRETARY : OfficerType.DIRECTOR;
+                officerRoleList.add(officerType);
             }
         } else {
             for (int i = providedCount; i < numberOfAppointments; i++) {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -857,7 +857,9 @@ public class TestDataServiceImpl implements TestDataService {
         companySpec.setCompanyStatus(publicCompanySpec.getCompanyStatus());
         companySpec.setSubType(publicCompanySpec.getSubType());
         companySpec.setHasSuperSecurePscs(publicCompanySpec.getHasSuperSecurePscs());
-        companySpec.setNumberOfAppointments(publicCompanySpec.getNumberOfAppointments());
+        if (publicCompanySpec.getNumberOfAppointments() != null) {
+            companySpec.setNumberOfAppointments(publicCompanySpec.getNumberOfAppointments());
+        }
         companySpec.setSecureOfficer(publicCompanySpec.getSecureOfficer());
         companySpec.setRegisters(publicCompanySpec.getRegisters());
         companySpec.setCompanyStatusDetail(publicCompanySpec.getCompanyStatusDetail());

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/AppointmentsServiceImplTest.java
@@ -34,6 +34,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.AppointmentsData;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
 import uk.gov.companieshouse.api.testdata.model.entity.OfficerAppointment;
 import uk.gov.companieshouse.api.testdata.model.entity.OfficerAppointmentItem;
+import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AppointmentCreationRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.JurisdictionType;
@@ -553,6 +554,94 @@ class AppointmentsServiceImplTest {
         assertNotNull(result.getAppointmentsData());
         assertNotNull(result.getOfficerAppointment());
     }
+
+    @Test
+    void createsTwoDirectorsAndOneSecretaryForPlcWhenNoAppointmentsSpecified() {
+        CompanyRequest spec = new CompanyRequest();
+        spec.setCompanyWithPopulatedStructureOnly(false);
+        spec.setCompanyType(CompanyType.PLC);
+        spec.setOfficerRoles(null);
+        spec.setNumberOfAppointments(null);
+
+        when(randomService.getNumber(anyInt())).thenReturn(123L);
+        when(randomService.getEncodedIdWithSalt(anyInt(), anyInt())).thenReturn(ENCODED_VALUE);
+        when(randomService.addSaltAndEncode(anyString(), anyInt())).thenReturn("ENCODED_ID");
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(addressService.getAddress(any())).thenReturn(new Address("", "", "", "", "", ""));
+        when(addressService.getCountryOfResidence(any())).thenReturn(COUNTRY);
+        when(appointmentsRepository.save(any())).thenReturn(new Appointment());
+        when(appointmentsDataRepository.save(any())).thenReturn(new AppointmentsData());
+
+        appointmentsService.createAppointment(spec);
+
+        ArgumentCaptor<Appointment> aptCaptor = ArgumentCaptor.forClass(Appointment.class);
+        verify(appointmentsRepository, times(3)).save(aptCaptor.capture());
+        List<Appointment> savedAppointments = aptCaptor.getAllValues();
+        assertEquals(3, savedAppointments.size());
+        assertEquals(OfficerType.DIRECTOR.getValue(), savedAppointments.get(0).getOfficerRole());
+        assertEquals(OfficerType.DIRECTOR.getValue(), savedAppointments.get(1).getOfficerRole());
+        assertEquals(OfficerType.SECRETARY.getValue(), savedAppointments.get(2).getOfficerRole());
+    }
+
+    @Test
+    void createsTwoDirectorsAndOneSecretaryForPlcWhenAppointmentsSpecified() {
+        CompanyRequest spec = new CompanyRequest();
+        spec.setCompanyWithPopulatedStructureOnly(false);
+        spec.setCompanyType(CompanyType.PLC);
+        spec.setOfficerRoles(null);
+        spec.setNumberOfAppointments(3);
+
+        when(randomService.getNumber(anyInt())).thenReturn(123L);
+        when(randomService.getEncodedIdWithSalt(anyInt(), anyInt())).thenReturn(ENCODED_VALUE);
+        when(randomService.addSaltAndEncode(anyString(), anyInt())).thenReturn("ENCODED_ID");
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(addressService.getAddress(any())).thenReturn(new Address("", "", "", "", "", ""));
+        when(addressService.getCountryOfResidence(any())).thenReturn(COUNTRY);
+        when(appointmentsRepository.save(any())).thenReturn(new Appointment());
+        when(appointmentsDataRepository.save(any())).thenReturn(new AppointmentsData());
+
+        appointmentsService.createAppointment(spec);
+
+        ArgumentCaptor<Appointment> aptCaptor = ArgumentCaptor.forClass(Appointment.class);
+        verify(appointmentsRepository, times(3)).save(aptCaptor.capture());
+        List<Appointment> savedAppointments = aptCaptor.getAllValues();
+        assertEquals(3, savedAppointments.size());
+        assertEquals(OfficerType.DIRECTOR.getValue(), savedAppointments.get(0).getOfficerRole());
+        assertEquals(OfficerType.DIRECTOR.getValue(), savedAppointments.get(1).getOfficerRole());
+        assertEquals(OfficerType.SECRETARY.getValue(), savedAppointments.get(2).getOfficerRole());
+    }
+
+    @Test
+    void createsFiveDirectorsAndOneSecretaryForPlcWhenAppointmentsSpecified() {
+        CompanyRequest spec = new CompanyRequest();
+        spec.setCompanyWithPopulatedStructureOnly(false);
+        spec.setCompanyType(CompanyType.PLC);
+        spec.setOfficerRoles(null);
+        spec.setNumberOfAppointments(6);
+
+        when(randomService.getNumber(anyInt())).thenReturn(123L);
+        when(randomService.getEncodedIdWithSalt(anyInt(), anyInt())).thenReturn(ENCODED_VALUE);
+        when(randomService.addSaltAndEncode(anyString(), anyInt())).thenReturn("ENCODED_ID");
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(addressService.getAddress(any())).thenReturn(new Address("", "", "", "", "", ""));
+        when(addressService.getCountryOfResidence(any())).thenReturn(COUNTRY);
+        when(appointmentsRepository.save(any())).thenReturn(new Appointment());
+        when(appointmentsDataRepository.save(any())).thenReturn(new AppointmentsData());
+
+        appointmentsService.createAppointment(spec);
+
+        ArgumentCaptor<Appointment> aptCaptor = ArgumentCaptor.forClass(Appointment.class);
+        verify(appointmentsRepository, times(6)).save(aptCaptor.capture());
+        List<Appointment> savedAppointments = aptCaptor.getAllValues();
+        assertEquals(6, savedAppointments.size());
+        assertEquals(OfficerType.DIRECTOR.getValue(), savedAppointments.get(0).getOfficerRole());
+        assertEquals(OfficerType.DIRECTOR.getValue(), savedAppointments.get(1).getOfficerRole());
+        assertEquals(OfficerType.SECRETARY.getValue(), savedAppointments.get(2).getOfficerRole());
+        assertEquals(OfficerType.DIRECTOR.getValue(), savedAppointments.get(3).getOfficerRole());
+        assertEquals(OfficerType.DIRECTOR.getValue(), savedAppointments.get(4).getOfficerRole());
+        assertEquals(OfficerType.DIRECTOR.getValue(), savedAppointments.get(5).getOfficerRole());
+    }
+
 
     private AppointmentCreationRequest buildAppointmentCreationRequest(CompanyRequest spec) {
         return AppointmentCreationRequest.builder()


### PR DESCRIPTION
Updates the logic for handling officer appointments  for PLC (Public Limited Company) companies.  The main improvements ensure that PLC companies have the correct default officer appointments and that the number of appointments is set more robustly.

**Appointment handling improvements:**

* Updated `AppointmentsServiceImpl.java` so that PLC companies default to 2 directors and 1 secretary if the number of appointments is not explicitly set or is less than 3. For other company types, the default remains 1 director. The officer roles list is also populated accordingly, ensuring PLCs always have the correct officer mix.
* Added a helper method `payloadExplicitlySetNumberOfAppointments` to clearly determine if the number of appointments was explicitly set in the request.
* In `TestDataServiceImpl.java`, only sets the number of appointments in the company spec if it is present in the public company request, avoiding unintended overwrites.

**Documentation updates:**

* Updated the `README.md` to clarify the default behavior for `number_of_appointments`: 1 director for most companies, but 2 directors and 1 secretary for PLCs.

**Dependency updates:**

* Bumped the `test-data-generator-library` version from `1.0.7` to `1.0.8` in `pom.xml`.