### PR TITLE
Feature/delete item groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,11 @@ In order to use the generator, there are different possible endpoints that can b
 
   - A usage example looks like this: `{ "penalty_ref": "A123456" }`
 
+#### Deleting Item groups
+
+- DELETE: Sending a DELETE request to the endpoint `{Base URL}/test-data/internal/item-groups/{orderNumber}` will delete the entire item group and all its nested items.
+  - `orderNumber`: The unique order reference (e.g., ORD-177632-985311) is required in the path.
+
 #### Retrieving Postcode
 - GET: Sending a GET request to retrieve the Postcode `{Base URL}/test-data/postcode/{countrycode}`.
     - `countrycode`: The country code to retrieve the postcode for. This will return a random postcode for the specified country code.

--- a/README.md
+++ b/README.md
@@ -366,9 +366,9 @@ In order to use the generator, there are different possible endpoints that can b
 
   - A usage example looks like this: `{ "penalty_ref": "A123456" }`
 
-#### Deleting Item groups
+#### Deleting Item Groups
 
-- DELETE: Sending a DELETE request to the endpoint `{Base URL}/test-data/internal/item-groups/{orderNumber}` will delete the entire item group and all its nested items.
+- DELETE: Sending a DELETE request to the endpoint `{Base URL}/test-data/internal/item-groups/{orderNumber}` will delete the entire Item Groups and all its nested items.
   - `orderNumber`: The unique order reference (e.g., ORD-177632-985311) is required in the path.
 
 #### Retrieving Postcode

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>4.0.416</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.8-SNAPSHOT</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.11</test-data-generator-library.version>
 
         <!-- Overrides -->
         <!-- CVE-2025-48924 -->

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>4.0.416</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.8</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.8-SNAPSHOT</test-data-generator-library.version>
 
         <!-- Overrides -->
         <!-- CVE-2025-48924 -->

--- a/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
@@ -34,6 +34,7 @@ import uk.gov.companieshouse.api.testdata.repository.CompanyRegistersRepository;
 import uk.gov.companieshouse.api.testdata.repository.DisqualificationsRepository;
 import uk.gov.companieshouse.api.testdata.repository.FilingHistoryRepository;
 import uk.gov.companieshouse.api.testdata.repository.IdentityRepository;
+import uk.gov.companieshouse.api.testdata.repository.ItemGroupsRepository;
 import uk.gov.companieshouse.api.testdata.repository.MissingImageDeliveriesRepository;
 import uk.gov.companieshouse.api.testdata.repository.OfficerRepository;
 import uk.gov.companieshouse.api.testdata.repository.TransactionsRepository;
@@ -51,6 +52,7 @@ public class MongoConfig {
     private static final String ITEMS_DATABASE = "items";
     private static final String SIC_CODE_DATABASE = "sic_code";
     private static final String IDENTITY_VERIFICATION = "identity_verification";
+    private static final String ITEM_GROUPS_DATABASE = "orders_item_groups";
 
     private final MongoProperties mongoProperties;
 
@@ -191,6 +193,11 @@ public class MongoConfig {
     public UserCompanyAssociationRepository userCompanyAssociationRepository() {
         return getMongoRepositoryBean(UserCompanyAssociationRepository.class,
                 "user_company_associations");
+    }
+
+    @Bean
+    public ItemGroupsRepository itemGroupsRepository() {
+        return getMongoRepositoryBean(ItemGroupsRepository.class, ITEM_GROUPS_DATABASE);
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
@@ -52,7 +52,7 @@ public class MongoConfig {
     private static final String ITEMS_DATABASE = "items";
     private static final String SIC_CODE_DATABASE = "sic_code";
     private static final String IDENTITY_VERIFICATION = "identity_verification";
-    private static final String ITEM_GROUPS_DATABASE = "orders_item_groups";
+    private static final String ORDERS_ITEM_GROUPS_DATABASE = "orders_item_groups";
 
     private final MongoProperties mongoProperties;
 
@@ -197,7 +197,7 @@ public class MongoConfig {
 
     @Bean
     public ItemGroupsRepository itemGroupsRepository() {
-        return getMongoRepositoryBean(ItemGroupsRepository.class, ITEM_GROUPS_DATABASE);
+        return getMongoRepositoryBean(ItemGroupsRepository.class, ORDERS_ITEM_GROUPS_DATABASE);
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -589,4 +589,22 @@ public class TestDataController {
         return new ResponseEntity<>(createdCompany, HttpStatus.CREATED);
     }
 
+    @DeleteMapping("/internal/item-groups/{orderNumber}")
+    public ResponseEntity<Map<String, Object>> deleteItemGroups(@PathVariable("orderNumber")
+    String orderNumber)
+            throws DataException {
+        Map<String, Object> response = new HashMap<>();
+        response.put("orderNumber", orderNumber);
+        boolean deleteItemGroups = testDataService.deleteItemGroupsData(orderNumber);
+
+        if (deleteItemGroups) {
+            LOG.info("Item Groups is deleted", response);
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } else {
+            response.put(STATUS, HttpStatus.NOT_FOUND);
+            LOG.info("Item Groups Not Found", response);
+            return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+        }
+    }
+
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/repository/ItemGroupsRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/repository/ItemGroupsRepository.java
@@ -3,9 +3,7 @@ package uk.gov.companieshouse.api.testdata.repository;
 import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.repository.NoRepositoryBean;
-import uk.gov.companieshouse.api.testdata.model.entity.Certificates;
 import uk.gov.companieshouse.api.testdata.model.entity.ItemGroups;
-import uk.gov.companieshouse.api.testdata.model.entity.Uvid;
 
 @NoRepositoryBean
 public interface ItemGroupsRepository extends MongoRepository<ItemGroups, String> {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/repository/ItemGroupsRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/repository/ItemGroupsRepository.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.api.testdata.repository;
+
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+import uk.gov.companieshouse.api.testdata.model.entity.Certificates;
+import uk.gov.companieshouse.api.testdata.model.entity.ItemGroups;
+import uk.gov.companieshouse.api.testdata.model.entity.Uvid;
+
+@NoRepositoryBean
+public interface ItemGroupsRepository extends MongoRepository<ItemGroups, String> {
+    Optional<ItemGroups> findByDataOrderNumber(String orderNumber);
+
+    long deleteByDataOrderNumber(String orderNumber);
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/ItemGroupsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/ItemGroupsService.java
@@ -7,8 +7,8 @@ public interface ItemGroupsService {
     /**
      * Deletes Item Groups from the DB
      *
-     * @param orderNumber the items groups needs to be deleted
-     * @return the null on success and error for failure with the HTTP status
+     * @param orderNumber the item groups that needs to be deleted
+     * @return null on success and error with the HTTP status for failure
      * @throws NoDataFoundException if the item groups for the order number not found
      * @throws DataException if the item groups not deleted successfully
      */

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/ItemGroupsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/ItemGroupsService.java
@@ -1,8 +1,5 @@
 package uk.gov.companieshouse.api.testdata.service;
 
-import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
-import uk.gov.companieshouse.api.testdata.model.rest.response.AppointmentsResultResponse;
-
 public interface ItemGroupsService {
     boolean deleteItemGroups(String orderNumber);
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/ItemGroupsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/ItemGroupsService.java
@@ -1,5 +1,16 @@
 package uk.gov.companieshouse.api.testdata.service;
 
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
+
 public interface ItemGroupsService {
+    /**
+     * Deletes Item Groups from the DB
+     *
+     * @param orderNumber the items groups needs to be deleted
+     * @return the null on success and error for failure with the HTTP status
+     * @throws NoDataFoundException if the item groups for the order number not found
+     * @throws DataException if the item groups not deleted successfully
+     */
     boolean deleteItemGroups(String orderNumber);
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/ItemGroupsService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/ItemGroupsService.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.api.testdata.service;
+
+import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.response.AppointmentsResultResponse;
+
+public interface ItemGroupsService {
+    boolean deleteItemGroups(String orderNumber);
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
@@ -327,7 +327,7 @@ public interface TestDataService {
     /**
      * Deletes the Item Groups test data for the given order number.
      *
-     * @param orderNumber the order number generated while creating Item groups
+     * @param orderNumber the order number generated while creating Item Groups
      * @throws DataException if there is an error during user deletion
      */
     boolean deleteItemGroupsData(String orderNumber) throws DataException;

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
@@ -323,4 +323,13 @@ public interface TestDataService {
      * @throws DataException If any error occurs
      */
     CompanyProfileResponse createCompanyWithStructure(CompanyWithPopulatedStructureRequest companySpec) throws DataException;
+
+    /**
+     * Deletes the Item Groups test data for the given order number.
+     *
+     * @param orderNumber the order number generated while creating Item groups
+     * @throws DataException if there is an error during user deletion
+     */
+    boolean deleteItemGroupsData(String orderNumber) throws DataException;
+
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/ItemGroupsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/ItemGroupsServiceImpl.java
@@ -6,7 +6,7 @@ import uk.gov.companieshouse.api.testdata.repository.ItemGroupsRepository;
 import uk.gov.companieshouse.api.testdata.service.ItemGroupsService;
 
 @Service
-public class ItemGroupsServiceImpl implements ItemGroupsService { // Add the interface here
+public class ItemGroupsServiceImpl implements ItemGroupsService {
 
     private final ItemGroupsRepository itemGroupsRepository;
 
@@ -15,7 +15,7 @@ public class ItemGroupsServiceImpl implements ItemGroupsService { // Add the int
         this.itemGroupsRepository = itemGroupsRepository;
     }
 
-    @Override // Good practice to add this
+    @Override
     public boolean deleteItemGroups(String orderNumber) {
         var itemGroups = itemGroupsRepository.findByDataOrderNumber(orderNumber);
         if (itemGroups.isPresent()) {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/ItemGroupsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/ItemGroupsServiceImpl.java
@@ -8,8 +8,12 @@ import uk.gov.companieshouse.api.testdata.service.ItemGroupsService;
 @Service
 public class ItemGroupsServiceImpl implements ItemGroupsService { // Add the interface here
 
+    private final ItemGroupsRepository itemGroupsRepository;
+
     @Autowired
-    public ItemGroupsRepository itemGroupsRepository;
+    public ItemGroupsServiceImpl(ItemGroupsRepository itemGroupsRepository) {
+        this.itemGroupsRepository = itemGroupsRepository;
+    }
 
     @Override // Good practice to add this
     public boolean deleteItemGroups(String orderNumber) {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/ItemGroupsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/ItemGroupsServiceImpl.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.api.testdata.service.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.testdata.repository.ItemGroupsRepository;
+import uk.gov.companieshouse.api.testdata.service.ItemGroupsService;
+
+@Service
+public class ItemGroupsServiceImpl implements ItemGroupsService { // Add the interface here
+
+    @Autowired
+    public ItemGroupsRepository itemGroupsRepository;
+
+    @Override // Good practice to add this
+    public boolean deleteItemGroups(String orderNumber) {
+        var itemGroups = itemGroupsRepository.findByDataOrderNumber(orderNumber);
+        if (itemGroups.isPresent()) {
+            itemGroupsRepository.deleteByDataOrderNumber(orderNumber);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -87,6 +87,7 @@ public class TestDataServiceImpl implements TestDataService {
 
     private static final Logger LOG = LoggerFactory.getLogger(Application.APPLICATION_NAME);
     private static final int COMPANY_NUMBER_LENGTH = 8;
+    private final ItemGroupsService itemGroupsService;
 
     @Autowired
     private CompanyProfileService companyProfileService;
@@ -157,8 +158,7 @@ public class TestDataServiceImpl implements TestDataService {
             UserCompanyAssociationRequest> userCompanyAssociationService;
     @Autowired
     private DataService<AdminPermissionsResponse, AdminPermissionsRequest> adminPermissionsService;
-    @Autowired
-    private ItemGroupsService itemGroupsService;
+
 
     private final CompanyWithPopulatedStructureService companyWithPopulatedStructureService;
 
@@ -177,7 +177,8 @@ public class TestDataServiceImpl implements TestDataService {
     }
 
     public TestDataServiceImpl(
-            CompanyWithPopulatedStructureService companyWithPopulatedStructureService) {
+            ItemGroupsService itemGroupsService, CompanyWithPopulatedStructureService companyWithPopulatedStructureService) {
+        this.itemGroupsService = itemGroupsService;
         this.companyWithPopulatedStructureService = companyWithPopulatedStructureService;
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -73,6 +73,7 @@ import uk.gov.companieshouse.api.testdata.service.CompanyPscService;
 import uk.gov.companieshouse.api.testdata.service.CompanySearchService;
 import uk.gov.companieshouse.api.testdata.service.CompanyWithPopulatedStructureService;
 import uk.gov.companieshouse.api.testdata.service.DataService;
+import uk.gov.companieshouse.api.testdata.service.ItemGroupsService;
 import uk.gov.companieshouse.api.testdata.service.PostcodeService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 import uk.gov.companieshouse.api.testdata.service.TestDataService;
@@ -156,6 +157,8 @@ public class TestDataServiceImpl implements TestDataService {
             UserCompanyAssociationRequest> userCompanyAssociationService;
     @Autowired
     private DataService<AdminPermissionsResponse, AdminPermissionsRequest> adminPermissionsService;
+    @Autowired
+    private ItemGroupsService itemGroupsService;
 
     private final CompanyWithPopulatedStructureService companyWithPopulatedStructureService;
 
@@ -1005,6 +1008,15 @@ public class TestDataServiceImpl implements TestDataService {
         String companyUri = this.apiUrl + "/company/" + companyNumber;
         return new CompanyProfileResponse(companyNumber,
                 authCode, companyUri);
+    }
+
+    @Override
+    public boolean deleteItemGroupsData(String orderNumber) throws DataException {
+        try {
+            return itemGroupsService.deleteItemGroups(orderNumber);
+        } catch (Exception ex) {
+            throw new DataException("Error deleting Item Groups", ex);
+        }
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -159,7 +159,6 @@ public class TestDataServiceImpl implements TestDataService {
     @Autowired
     private DataService<AdminPermissionsResponse, AdminPermissionsRequest> adminPermissionsService;
 
-
     private final CompanyWithPopulatedStructureService companyWithPopulatedStructureService;
 
     @Value("${api.url}")

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -87,7 +87,6 @@ public class TestDataServiceImpl implements TestDataService {
 
     private static final Logger LOG = LoggerFactory.getLogger(Application.APPLICATION_NAME);
     private static final int COMPANY_NUMBER_LENGTH = 8;
-    private final ItemGroupsService itemGroupsService;
 
     @Autowired
     private CompanyProfileService companyProfileService;
@@ -158,6 +157,8 @@ public class TestDataServiceImpl implements TestDataService {
             UserCompanyAssociationRequest> userCompanyAssociationService;
     @Autowired
     private DataService<AdminPermissionsResponse, AdminPermissionsRequest> adminPermissionsService;
+    @Autowired
+    private ItemGroupsService itemGroupsService;
 
     private final CompanyWithPopulatedStructureService companyWithPopulatedStructureService;
 
@@ -176,8 +177,7 @@ public class TestDataServiceImpl implements TestDataService {
     }
 
     public TestDataServiceImpl(
-            ItemGroupsService itemGroupsService, CompanyWithPopulatedStructureService companyWithPopulatedStructureService) {
-        this.itemGroupsService = itemGroupsService;
+            CompanyWithPopulatedStructureService companyWithPopulatedStructureService) {
         this.companyWithPopulatedStructureService = companyWithPopulatedStructureService;
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -157,6 +157,7 @@ public class TestDataServiceImpl implements TestDataService {
             UserCompanyAssociationRequest> userCompanyAssociationService;
     @Autowired
     private DataService<AdminPermissionsResponse, AdminPermissionsRequest> adminPermissionsService;
+    @SuppressWarnings("java:S6813") // legacy service – constructor injection not feasible
     @Autowired
     private ItemGroupsService itemGroupsService;
 

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1612,5 +1613,37 @@ class TestDataControllerTest {
 
         verify(testDataService, times(1)).getAcspProfileData(acspNumber);
     }
+
+    @Test
+    void deleteItemGroups() throws Exception {
+        final String orderNumber = "ORD-1776329853";
+        when(this.testDataService.deleteItemGroupsData(orderNumber)).thenReturn(true);
+        ResponseEntity<Map<String, Object>> response
+                = this.testDataController.deleteItemGroups(orderNumber);
+
+        assertNull(response.getBody());
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(testDataService).deleteItemGroupsData(orderNumber);
+    }
+
+
+    @Test
+    void deleteItemGroupsNoData() throws Exception {
+        final String orderNumber = "ORD-1776329853";
+
+        when(this.testDataService.deleteItemGroupsData(orderNumber)).thenReturn(false);
+        ResponseEntity<Map<String, Object>> response
+                = this.testDataController.deleteItemGroups(orderNumber);
+
+        Map<String, Object> expectedBody = new HashMap<>();
+        expectedBody.put("orderNumber", orderNumber);
+        expectedBody.put("message", "Item Groups Not Found");
+        expectedBody.put("status", HttpStatus.NOT_FOUND);
+
+        assertEquals(expectedBody, response.getBody());
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        verify(testDataService).deleteItemGroupsData(orderNumber);
+    }
+
 
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/ItemGroupsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/ItemGroupsServiceImplTest.java
@@ -1,0 +1,66 @@
+package uk.gov.companieshouse.api.testdata.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.api.testdata.model.entity.ItemGroups;
+import uk.gov.companieshouse.api.testdata.repository.ItemGroupsRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ItemGroupsServiceImplTest {
+
+    @Mock
+    private ItemGroupsRepository repository;
+
+    @InjectMocks
+    private ItemGroupsServiceImpl service;
+
+    private static final String ORDER_NUMBER = "ORD-123456-789012";
+
+    @Test
+    void deleteItemGroupsFound() {
+        ItemGroups itemGroups = new ItemGroups();
+        when(repository.findByDataOrderNumber(ORDER_NUMBER)).thenReturn(Optional.of(itemGroups));
+
+        boolean result = service.deleteItemGroups(ORDER_NUMBER);
+
+        assertTrue(result);
+        verify(repository).deleteByDataOrderNumber(ORDER_NUMBER);
+    }
+
+    @Test
+    void deleteItemGroupsNotFound() {
+        when(repository.findByDataOrderNumber(ORDER_NUMBER)).thenReturn(Optional.empty());
+
+        boolean result = service.deleteItemGroups(ORDER_NUMBER);
+
+        assertFalse(result);
+        verify(repository, never()).deleteByDataOrderNumber(anyString());
+    }
+
+    @Test
+    void deleteItemGroupsThrowsException() {
+        when(repository.findByDataOrderNumber(ORDER_NUMBER))
+                .thenThrow(new RuntimeException("Database connection failure"));
+
+        try {
+            service.deleteItemGroups(ORDER_NUMBER);
+        } catch (Exception e) {
+            assertTrue(e instanceof RuntimeException);
+        }
+
+        verify(repository, never()).deleteByDataOrderNumber(anyString());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
@@ -52,7 +52,6 @@ import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscs;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyRegisters;
 import uk.gov.companieshouse.api.testdata.model.entity.Disqualifications;
 import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
-import uk.gov.companieshouse.api.testdata.model.entity.ItemGroups;
 import uk.gov.companieshouse.api.testdata.model.entity.MissingImageDeliveries;
 import uk.gov.companieshouse.api.testdata.model.entity.Postcodes;
 import uk.gov.companieshouse.api.testdata.model.entity.User;

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
@@ -2523,20 +2523,20 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void deleteItemGroupsData() throws DataException {
-        final String orderNumber = "ORD-123456-789012";
+    void deleteItemGroupsDataSuccess() throws DataException {
+        String orderNumber = "ORD-1234-5678";
 
         when(itemGroupsService.deleteItemGroups(orderNumber)).thenReturn(true);
 
         boolean result = testDataService.deleteItemGroupsData(orderNumber);
 
         assertTrue(result);
-        verify(itemGroupsService).deleteItemGroups(orderNumber);
+        verify(itemGroupsService, times(1)).deleteItemGroups(orderNumber);
     }
 
     @Test
-    void deleteItemGroupsDataFailure() throws DataException {
-        final String orderNumber = "ORD-123456-789012";
+    void deleteItemGroupsDataReturnsFalse() throws DataException {
+        String orderNumber = "ORD-0000-0000";
 
         when(itemGroupsService.deleteItemGroups(orderNumber)).thenReturn(false);
 
@@ -2547,16 +2547,19 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void deleteItemGroupsThrowsException() {
-        final String orderNumber = "ORD-123456-789012";
-        RuntimeException ex = new RuntimeException("Internal Database Error");
+    void deleteItemGroupsDataThrowsException() {
+        String orderNumber = "ORD-ERROR-1234";
+        RuntimeException cause = new RuntimeException("Mongo failure");
 
-        when(itemGroupsService.deleteItemGroups(orderNumber)).thenThrow(ex);
-        DataException exception = assertThrows(DataException.class, () ->
-                testDataService.deleteItemGroupsData(orderNumber));
+        when(itemGroupsService.deleteItemGroups(orderNumber)).thenThrow(cause);
+
+        DataException exception = assertThrows(
+                DataException.class,
+                () -> testDataService.deleteItemGroupsData(orderNumber)
+        );
 
         assertEquals("Error deleting Item Groups", exception.getMessage());
-        assertEquals(ex, exception.getCause());
+        assertSame(cause, exception.getCause());
         verify(itemGroupsService, times(1)).deleteItemGroups(orderNumber);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
@@ -52,6 +52,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscs;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyRegisters;
 import uk.gov.companieshouse.api.testdata.model.entity.Disqualifications;
 import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
+import uk.gov.companieshouse.api.testdata.model.entity.ItemGroups;
 import uk.gov.companieshouse.api.testdata.model.entity.MissingImageDeliveries;
 import uk.gov.companieshouse.api.testdata.model.entity.Postcodes;
 import uk.gov.companieshouse.api.testdata.model.entity.User;
@@ -101,6 +102,7 @@ import uk.gov.companieshouse.api.testdata.service.CompanyAuthCodeService;
 import uk.gov.companieshouse.api.testdata.service.CompanyProfileService;
 import uk.gov.companieshouse.api.testdata.service.CompanyPscService;
 import uk.gov.companieshouse.api.testdata.service.DataService;
+import uk.gov.companieshouse.api.testdata.service.ItemGroupsService;
 import uk.gov.companieshouse.api.testdata.service.PostcodeService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 import uk.gov.companieshouse.api.testdata.service.UserService;
@@ -196,6 +198,8 @@ class TestDataServiceImplTest {
             UserCompanyAssociationRequest> userCompanyAssociationService;
     @Mock
     private UserCompanyAssociationRepository userCompanyAssociationRepository;
+    @Mock
+    private ItemGroupsService itemGroupsService;
 
     @InjectMocks
     private TestDataServiceImpl testDataService;
@@ -2483,20 +2487,16 @@ class TestDataServiceImplTest {
     void getAcspProfileDataReturnsProfile() throws NoDataFoundException {
         String acspNumber = "AP000036";
 
-        // Prepare the mock AcspProfile
         AcspProfile profile = new AcspProfile();
         profile.setId(acspNumber);
         profile.setAcspNumber(acspNumber);
         profile.setName("Test ACSP Company");
         profile.setStatus("active");
 
-        // Mock the acspProfileService
         when(acspProfileService.getAcspProfile(acspNumber)).thenReturn(Optional.of(profile));
 
-        // Call the service method
         Optional<AcspProfile> result = testDataService.getAcspProfileData(acspNumber);
 
-        // Verify results
         assertNotNull(result);
         assertTrue(result.isPresent());
 
@@ -2506,7 +2506,6 @@ class TestDataServiceImplTest {
         assertEquals("Test ACSP Company", returnedProfile.getName());
         assertEquals("active", returnedProfile.getStatus());
 
-        // Verify interaction with the mock
         verify(acspProfileService, times(1)).getAcspProfile(acspNumber);
     }
 
@@ -2514,19 +2513,51 @@ class TestDataServiceImplTest {
     void getAcspProfileDataReturnsEmpty() throws NoDataFoundException {
         String acspNumber = "NON_EXISTENT";
 
-        // Mock empty response
         when(acspProfileService.getAcspProfile(acspNumber)).thenReturn(Optional.empty());
 
-        // Call the service method
         Optional<AcspProfile> result = testDataService.getAcspProfileData(acspNumber);
 
-        // Verify results
         assertNotNull(result);
         assertTrue(result.isEmpty());
 
-        // Verify interaction with the mock
         verify(acspProfileService, times(1)).getAcspProfile(acspNumber);
     }
 
+    @Test
+    void deleteItemGroupsData() throws DataException {
+        final String orderNumber = "ORD-123456-789012";
 
+        when(itemGroupsService.deleteItemGroups(orderNumber)).thenReturn(true);
+
+        boolean result = testDataService.deleteItemGroupsData(orderNumber);
+
+        assertTrue(result);
+        verify(itemGroupsService).deleteItemGroups(orderNumber);
+    }
+
+    @Test
+    void deleteItemGroupsDataFailure() throws DataException {
+        final String orderNumber = "ORD-123456-789012";
+
+        when(itemGroupsService.deleteItemGroups(orderNumber)).thenReturn(false);
+
+        boolean result = testDataService.deleteItemGroupsData(orderNumber);
+
+        assertFalse(result);
+        verify(itemGroupsService, times(1)).deleteItemGroups(orderNumber);
+    }
+
+    @Test
+    void deleteItemGroupsThrowsException() {
+        final String orderNumber = "ORD-123456-789012";
+        RuntimeException ex = new RuntimeException("Internal Database Error");
+
+        when(itemGroupsService.deleteItemGroups(orderNumber)).thenThrow(ex);
+        DataException exception = assertThrows(DataException.class, () ->
+                testDataService.deleteItemGroupsData(orderNumber));
+
+        assertEquals("Error deleting Item Groups", exception.getMessage());
+        assertEquals(ex, exception.getCause());
+        verify(itemGroupsService, times(1)).deleteItemGroups(orderNumber);
+    }
 }


### PR DESCRIPTION
# ItemGroups – Test Data Generator
## Change Description
This PR implements the Item Groups functionality within the Test Data Generator. It enables the deletion of Item Groups from the database to support clean Db after testing.

## Key Changes
### API Layer
     DELETE endpoint to clean up item groups

### Service Layer

1. Implemented ItemGroupsService to handle business logic
2. Maps ItemGroupsRequest DTOs to domain entities
3. Integrated with TestDataService to orchestrate data removal across related collections

### Persistence Layer

Created ItemGroupsRepository with custom query support for orderNumber

### Testing

Added comprehensive unit tests for:

-   Controller layer
-    Service layer
-    Repository layer

Implemented mock‑based verification for:
-   Error handling (404 Not Found)
-   Data consistency

Documentation

Updated README.md with usage examples for the new endpoints

Endpoints Added

DELETE | /test-data/internal/item-groups/{orderNumber}
