### PR TITLE
Added update company profile details

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ In order to use the generator, there are different possible endpoints that can b
   - A usage example for creating a company with advanced search: `{ "advanced_search": true }`
   - A usage example for creating a company with disqualified officers: `{ "disqualified_officers": [ { "disqualification_type": "court-order", "is_corporate_officer": false }]}`
 
-- PUT: Sending a PUT request to update Company Profile for a specific company `{Base URL}/test-data/internal` will update an Company Profile entry. The request body must include mandatory `company_number`and optional `etag` parameters.
+- PUT: Sending a PUT request to update Company Profile for a specific company `{Base URL}/test-data/internal/update-company` will update an Company Profile entry. The request body must include mandatory `company_number`and optional `etag` parameters.
   - `company_number`: The Company Number of the Company Profile entry in the company_profile db collection. This is mandatory.
   - `etag`: The etag of the Company Profile entry in the company_profile db collection. This is optional.
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ In order to use the generator, there are different possible endpoints that can b
   - A usage example for creating a company with advanced search: `{ "advanced_search": true }`
   - A usage example for creating a company with disqualified officers: `{ "disqualified_officers": [ { "disqualification_type": "court-order", "is_corporate_officer": false }]}`
 
+- PUT: Sending a PUT request to update Company Profile for a specific company `{Base URL}/test-data/internal` will update an Company Profile entry. The request body must include mandatory `company_number`and optional `etag` parameters.
+  - `company_number`: The Company Number of the Company Profile entry in the company_profile db collection. This is mandatory.
+  - `etag`: The etag of the Company Profile entry in the company_profile db collection. This is optional.
+
+  - A usage example for updating a company profile: `{ "company_number": NI038379, "etag": "kac12c39d242c05e3d64d85b5651af611b823cc4" }`
+
 - DELETE: Sending a DELETE request on the endpoint `{Base URL}/test-data/company/{companyNumber}` will delete the test company. There is a required parameter that is Authcode which needs to be included in the request body to be allowed to delete the test company. A usage example looks like this: `{"auth_code":"222222"}`
 - Health Check: Sending a GET request on the endpoint `{Base URL}/test-data/healthcheck` will return a status code and an empty response body.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ In order to use the generator, there are different possible endpoints that can b
   - A usage example for creating a company with advanced search: `{ "advanced_search": true }`
   - A usage example for creating a company with disqualified officers: `{ "disqualified_officers": [ { "disqualification_type": "court-order", "is_corporate_officer": false }]}`
 
-- PUT: Sending a PUT request to update Company Profile for a specific company `{Base URL}/test-data/internal/update-company` will update an Company Profile entry. The request body must include mandatory `company_number`and optional `etag` parameters.
+- PUT: Sending a PUT request to update Company Profile for a specific company `{Base URL}/test-data/internal` will update a Company Profile entry. The request body must include `company_number` and can include optional `etag` parameter.
   - `company_number`: The Company Number of the Company Profile entry in the company_profile db collection. This is mandatory.
   - `etag`: The etag of the Company Profile entry in the company_profile db collection. This is optional.
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>4.0.416</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.11</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.13</test-data-generator-library.version>
 
         <!-- Overrides -->
         <!-- CVE-2025-48924 -->

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -25,8 +25,10 @@ import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.InvalidAuthCodeException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
+import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
 import uk.gov.companieshouse.api.testdata.model.rest.request.PenaltyDeleteRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.PenaltyRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AccountPenaltiesResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
@@ -43,6 +45,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyWithPopulatedStructureRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.DeleteAppealsRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.DeleteCompanyRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.response.CompanyUpdateResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.IdentityVerificationResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.request.MissingImageDeliveriesRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.response.PopulatedCompanyDetailsResponse;
@@ -149,6 +152,39 @@ public class TestDataController {
         var authCode = testDataService.findOrCreateCompanyAuthCode(companyNumber);
         var defaultAuthCode = new CompanyAuthCodeResponse(authCode.getAuthCode());
         return new ResponseEntity<>(defaultAuthCode, HttpStatus.OK);
+    }
+
+    @PutMapping("/internal/company")
+    public ResponseEntity<?> updateCompany(
+            @Valid @RequestBody UpdateCompanyRequest request) {
+
+        try {
+            CompanyProfile updatedCompany =
+                    testDataService.updateCompanyData(request);
+
+            CompanyUpdateResponse response = new CompanyUpdateResponse(
+                    updatedCompany.getCompanyNumber(),
+                    "updated"
+            );
+
+            return ResponseEntity.ok(response);
+
+        } catch (NoDataFoundException ex) {
+
+            Map<String, Object> error = new HashMap<>();
+            error.put("error", ex.getMessage());
+            error.put("status", 404);
+
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+
+        } catch (DataException ex) {
+
+            Map<String, Object> error = new HashMap<>();
+            error.put("error", ex.getMessage());
+            error.put("status", 500);
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+        }
     }
 
     @PostMapping("/internal/user")
@@ -414,7 +450,6 @@ public class TestDataController {
                 penaltyRef, request);
 
         return new ResponseEntity<>(accountPenaltiesData, HttpStatus.CREATED);
-
     }
 
     @DeleteMapping("/internal/penalties/{id}")
@@ -607,4 +642,16 @@ public class TestDataController {
         }
     }
 
+    private ResponseEntity<Map<String, Object>> errorResponse(
+            HttpStatus status,
+            String error,
+            String message) {
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("status", status.value());
+        body.put("error", error);
+        body.put("message", message);
+
+        return new ResponseEntity<>(body, status);
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -71,6 +71,7 @@ public class TestDataController {
 
     private static final Logger LOG = LoggerFactory.getLogger(Application.APPLICATION_NAME);
     private static final String STATUS = "status";
+    private static final String ERROR = "error";
 
     @Autowired
     private TestDataService testDataService;
@@ -155,7 +156,7 @@ public class TestDataController {
     }
 
     @PutMapping("/internal/company")
-    public ResponseEntity<?> updateCompany(
+    public ResponseEntity<Object> updateCompany(
             @Valid @RequestBody UpdateCompanyRequest request) {
 
         try {
@@ -170,20 +171,15 @@ public class TestDataController {
             return ResponseEntity.ok(response);
 
         } catch (NoDataFoundException ex) {
-
-            Map<String, Object> error = new HashMap<>();
-            error.put("error", ex.getMessage());
-            error.put("status", 404);
-
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
-
+            Map<String, Object> errorBody = new HashMap<>();
+            errorBody.put(ERROR, ex.getMessage());
+            errorBody.put(STATUS, HttpStatus.NOT_FOUND.value());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorBody);
         } catch (DataException ex) {
-
-            Map<String, Object> error = new HashMap<>();
-            error.put("error", ex.getMessage());
-            error.put("status", 500);
-
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+            Map<String, Object> errorBody = new HashMap<>();
+            errorBody.put(ERROR, ex.getMessage());
+            errorBody.put(STATUS, HttpStatus.INTERNAL_SERVER_ERROR.value());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorBody);
         }
     }
 
@@ -640,18 +636,5 @@ public class TestDataController {
             LOG.info("Item Groups Not Found", response);
             return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
         }
-    }
-
-    private ResponseEntity<Map<String, Object>> errorResponse(
-            HttpStatus status,
-            String error,
-            String message) {
-
-        Map<String, Object> body = new HashMap<>();
-        body.put("status", status.value());
-        body.put("error", error);
-        body.put("message", message);
-
-        return new ResponseEntity<>(body, status);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -155,7 +155,7 @@ public class TestDataController {
         return new ResponseEntity<>(defaultAuthCode, HttpStatus.OK);
     }
 
-    @PutMapping("/internal/company")
+    @PutMapping("/internal/update-company")
     public ResponseEntity<Object> updateCompany(
             @Valid @RequestBody UpdateCompanyRequest request) {
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/CompanyProfileService.java
@@ -1,10 +1,14 @@
 package uk.gov.companieshouse.api.testdata.service;
 
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
 
 import java.util.List;
 import java.util.Optional;
+import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateCompanyRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.response.CompanyProfileResponse;
 
 public interface CompanyProfileService extends DataService<CompanyProfile, CompanyRequest> {
 
@@ -19,4 +23,16 @@ public interface CompanyProfileService extends DataService<CompanyProfile, Compa
     List<String> findUkEstablishmentsByParent(String parentCompanyNumber);
 
     Optional<CompanyProfile> getCompanyProfile(String companyNumber);
+
+    /**
+     * Updates an company details for the company Number.
+     *
+     * @param request    the update request with company Number.
+     * list
+     * @throws NoDataFoundException if the company number cannot be found
+     * @throws DataException if the company number details cannot be updated
+     */
+    CompanyProfile updateCompany(
+            UpdateCompanyRequest request) throws NoDataFoundException, DataException;
+
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/CompanyProfileService.java
@@ -24,13 +24,13 @@ public interface CompanyProfileService extends DataService<CompanyProfile, Compa
     Optional<CompanyProfile> getCompanyProfile(String companyNumber);
 
     /**
-     * Updates an company profile for the company Number.
+     * Updates the company profile for the company number provided.
      * *
-     * @param request the update request with company Number as mandatory.
+     * @param request the update request with company number as mandatory.
      * @throws NoDataFoundException if the company number cannot be found
-     * @throws DataException if the company number details cannot be updated
+     * @throws DataException if the company profile cannot be updated
      */
-    CompanyProfile updateCompany(
+    CompanyProfile updateCompanyProfile(
             UpdateCompanyRequest request) throws NoDataFoundException, DataException;
 
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/CompanyProfileService.java
@@ -8,7 +8,6 @@ import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
 import java.util.List;
 import java.util.Optional;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateCompanyRequest;
-import uk.gov.companieshouse.api.testdata.model.rest.response.CompanyProfileResponse;
 
 public interface CompanyProfileService extends DataService<CompanyProfile, CompanyRequest> {
 
@@ -25,10 +24,9 @@ public interface CompanyProfileService extends DataService<CompanyProfile, Compa
     Optional<CompanyProfile> getCompanyProfile(String companyNumber);
 
     /**
-     * Updates an company details for the company Number.
-     *
-     * @param request    the update request with company Number.
-     * list
+     * Updates an company profile for the company Number.
+     * *
+     * @param request the update request with company Number as mandatory.
      * @throws NoDataFoundException if the company number cannot be found
      * @throws DataException if the company number details cannot be updated
      */

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
@@ -59,7 +59,7 @@ public interface TestDataService {
      * . Updates the company profile data for a given company number and {@link UpdateCompanyRequest}
      *
      * @param request the update request
-     * @return
+     * @return the status of the updated request
      * @throws NoDataFoundException if the requested company number cannot be found
      * @throws DataException        if the company profile cannot be updated
      */

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
@@ -56,10 +56,10 @@ public interface TestDataService {
     void deleteCompanyData(String companyNumber) throws DataException;
 
     /**
-     * . Updates the company profile data for a given company number and {@link UpdateCompanyRequest}
+     * Updates the company profile data for the company number provided and {@link UpdateCompanyRequest}
      *
-     * @param request the update request
-     * @return the status of the updated request
+     * @param request the update request with company number as mandatory
+     * @return the status of the update request
      * @throws NoDataFoundException if the company number cannot be found
      * @throws DataException if the company profile cannot be updated
      */

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
@@ -6,6 +6,7 @@ import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyAuthCode;
+import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AccountPenaltiesResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
@@ -28,6 +29,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.request.PublicCompanyReques
 import uk.gov.companieshouse.api.testdata.model.rest.response.TransactionsResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.request.TransactionsRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateAccountPenaltiesRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.response.UserCompanyAssociationResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UserCompanyAssociationRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.response.UserResponse;
@@ -52,6 +54,17 @@ public interface TestDataService {
      * @throws DataException If any error occurs
      */
     void deleteCompanyData(String companyNumber) throws DataException;
+
+    /**
+     * . Updates the company profile data for a given company number and {@link UpdateCompanyRequest}
+     *
+     * @param request the update request
+     * @return
+     * @throws NoDataFoundException if the requested company number cannot be found
+     * @throws DataException        if the company profile cannot be updated
+     */
+    CompanyProfile updateCompanyData(
+            UpdateCompanyRequest request) throws NoDataFoundException, DataException;
 
     /**
      * Creates a new user test data based on the provided user specifications.

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
@@ -60,8 +60,8 @@ public interface TestDataService {
      *
      * @param request the update request
      * @return the status of the updated request
-     * @throws NoDataFoundException if the requested company number cannot be found
-     * @throws DataException        if the company profile cannot be updated
+     * @throws NoDataFoundException if the company number cannot be found
+     * @throws DataException if the company profile cannot be updated
      */
     CompanyProfile updateCompanyData(
             UpdateCompanyRequest request) throws NoDataFoundException, DataException;

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -576,7 +576,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
     }
 
     @Override
-    public CompanyProfile updateCompany(UpdateCompanyRequest request)
+    public CompanyProfile updateCompanyProfile(UpdateCompanyRequest request)
             throws NoDataFoundException, DataException {
 
         if (request.getCompanyNumber() == null || request.getCompanyNumber().isBlank()) {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -17,10 +17,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
 import uk.gov.companieshouse.api.testdata.model.entity.OverseasEntity;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.JurisdictionType;
 import uk.gov.companieshouse.api.testdata.repository.CompanyProfileRepository;
@@ -570,6 +573,35 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
     @Override
     public Optional<CompanyProfile> getCompanyProfile(String companyNumber) {
         return repository.findByCompanyNumber(companyNumber);
+    }
+
+    @Override
+    public CompanyProfile updateCompany(UpdateCompanyRequest request)
+            throws NoDataFoundException, DataException {
+
+        if (request.getCompanyNumber() == null || request.getCompanyNumber().isBlank()) {
+            throw new DataException("companyNumber is required");
+        }
+
+        CompanyProfile company = repository.findByCompanyNumber(request.getCompanyNumber())
+                .orElseThrow(() -> new NoDataFoundException(
+                        "Company not found for number: " + request.getCompanyNumber()));
+
+        if (request.getEtag() != null && !request.getEtag().isBlank()) {
+            company.setEtag(request.getEtag());
+        }
+
+        if (!request.getUnknownFields().isEmpty()) {
+            throw new DataException(
+                    "Invalid field(s): " + request.getUnknownFields().keySet()
+            );
+        }
+
+        try {
+            return repository.save(company);
+        } catch (Exception ex) {
+            throw new DataException("Failed to update company profile", ex);
+        }
     }
 
     private void setRegisteredOfficeAddressIsInDispute(

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -288,7 +288,7 @@ public class TestDataServiceImpl implements TestDataService {
     public CompanyProfile updateCompanyData(UpdateCompanyRequest request)
             throws NoDataFoundException, DataException {
 
-        return companyProfileService.updateCompany(request);
+        return companyProfileService.updateCompanyProfile(request);
     }
 
     private void deleteUkEstablishmentsIfOverseaCompany(

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -28,6 +28,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.CompanyRegisters;
 import uk.gov.companieshouse.api.testdata.model.entity.Disqualifications;
 import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
 import uk.gov.companieshouse.api.testdata.model.entity.Postcodes;
+import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AccountPenaltiesResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
@@ -281,6 +282,25 @@ public class TestDataServiceImpl implements TestDataService {
             suppressedExceptions.forEach(ex::addSuppressed);
             throw ex;
         }
+    }
+
+//    public CompanyProfile updateCompanyData(
+//            UpdateCompanyRequest request)
+//            throws NoDataFoundException, DataException {
+//        try {
+//            return companyProfileService.updateCompany(request);
+//        } catch (NoDataFoundException ex) {
+//            throw new NoDataFoundException("Error updating account penalties - not found");
+//        } catch (Exception ex) {
+//            throw new DataException("Error updating account penalties", ex);
+//        }
+//    }
+
+    @Override
+    public CompanyProfile updateCompanyData(UpdateCompanyRequest request)
+            throws NoDataFoundException, DataException {
+
+        return companyProfileService.updateCompany(request);
     }
 
     private void deleteUkEstablishmentsIfOverseaCompany(

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -284,18 +284,6 @@ public class TestDataServiceImpl implements TestDataService {
         }
     }
 
-//    public CompanyProfile updateCompanyData(
-//            UpdateCompanyRequest request)
-//            throws NoDataFoundException, DataException {
-//        try {
-//            return companyProfileService.updateCompany(request);
-//        } catch (NoDataFoundException ex) {
-//            throw new NoDataFoundException("Error updating account penalties - not found");
-//        } catch (Exception ex) {
-//            throw new DataException("Error updating account penalties", ex);
-//        }
-//    }
-
     @Override
     public CompanyProfile updateCompanyData(UpdateCompanyRequest request)
             throws NoDataFoundException, DataException {

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
@@ -35,12 +35,14 @@ import uk.gov.companieshouse.api.testdata.exception.InvalidAuthCodeException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyAuthCode;
+import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AcspProfileRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AdminPermissionsRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CertificatesRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CertifiedCopiesRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CombinedSicActivitiesRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UserCompanyAssociationRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UserRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AccountPenaltiesResponse;
@@ -51,6 +53,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyWithPopulate
 import uk.gov.companieshouse.api.testdata.model.rest.response.CombinedSicActivitiesResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.CompanyAuthCodeResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.CompanyProfileResponse;
+import uk.gov.companieshouse.api.testdata.model.rest.response.CompanyUpdateResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.PopulatedCompanyDetailsResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.DeleteAppealsRequest;
@@ -301,6 +304,64 @@ class TestDataControllerTest {
                         NoDataFoundException.class,
                         () -> this.testDataController.deleteCompany(companyNumber, request));
         assertEquals(ex, thrown);
+    }
+
+    @Test
+    void updateCompanySuccess() throws Exception {
+        UpdateCompanyRequest request = new UpdateCompanyRequest();
+        request.setCompanyNumber(COMPANY_NUMBER);
+
+        CompanyProfile updatedProfile = new CompanyProfile();
+        updatedProfile.setCompanyNumber(COMPANY_NUMBER);
+
+        when(this.testDataService.updateCompanyData(request)).thenReturn(updatedProfile);
+
+        ResponseEntity<Object> response = this.testDataController.updateCompany(request);
+
+        assertNotNull(response.getBody());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        CompanyUpdateResponse body = (CompanyUpdateResponse) response.getBody();
+        assertEquals(COMPANY_NUMBER, body.getCompanyNumber());
+        assertEquals("updated", body.getStatus());
+
+        verify(testDataService).updateCompanyData(request);
+    }
+
+    @Test
+    void updateCompanyNotFound() throws Exception {
+        UpdateCompanyRequest request = new UpdateCompanyRequest();
+        request.setCompanyNumber(COMPANY_NUMBER);
+
+        String errorMessage = "Company not found";
+        when(this.testDataService.updateCompanyData(request))
+                .thenThrow(new NoDataFoundException(errorMessage));
+
+        ResponseEntity<Object> response = this.testDataController.updateCompany(request);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertEquals(errorMessage, body.get("error"));
+        assertEquals(HttpStatus.NOT_FOUND.value(), body.get("status"));
+    }
+
+    @Test
+    void updateCompanyDataException() throws Exception {
+        UpdateCompanyRequest request = new UpdateCompanyRequest();
+        request.setCompanyNumber(COMPANY_NUMBER);
+
+        String errorMessage = "Internal server error";
+        when(this.testDataService.updateCompanyData(request))
+                .thenThrow(new DataException(errorMessage));
+
+        ResponseEntity<Object> response = this.testDataController.updateCompany(request);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertEquals(errorMessage, body.get("error"));
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), body.get("status"));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -33,6 +34,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.Address;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
@@ -41,6 +44,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.JurisdictionType;
 import uk.gov.companieshouse.api.testdata.model.rest.request.RegistersRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateCompanyRequest;
 import uk.gov.companieshouse.api.testdata.repository.CompanyProfileRepository;
 import uk.gov.companieshouse.api.testdata.service.AddressService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
@@ -849,6 +853,83 @@ class CompanyProfileServiceImplTest {
         assertEquals(COMPANY_NUMBER, result.getId());
         assertEquals("COMPANY " + COMPANY_NUMBER + " LIMITED", result.getCompanyName());
         verify(repository, never()).save(any());
+    }
+
+    @Test
+    void updateCompanySuccess() throws Exception {
+        UpdateCompanyRequest request = new UpdateCompanyRequest();
+        request.setCompanyNumber(COMPANY_NUMBER);
+        request.setEtag("NEW_ETAG");
+
+        CompanyProfile existingProfile = new CompanyProfile();
+        existingProfile.setCompanyNumber(COMPANY_NUMBER);
+        existingProfile.setEtag("OLD_ETAG");
+
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(existingProfile));
+        when(repository.save(existingProfile)).thenReturn(existingProfile);
+
+        CompanyProfile result = companyProfileService.updateCompany(request);
+
+        assertNotNull(result);
+        assertEquals("NEW_ETAG", existingProfile.getEtag());
+        verify(repository).save(existingProfile);
+    }
+
+    @Test
+    void updateCompanyMissingNumber() {
+        UpdateCompanyRequest request = new UpdateCompanyRequest();
+        request.setCompanyNumber("");
+
+        DataException thrown = assertThrows(DataException.class, () ->
+                companyProfileService.updateCompany(request));
+
+        assertEquals("companyNumber is required", thrown.getMessage());
+        verify(repository, never()).findByCompanyNumber(any());
+    }
+
+    @Test
+    void updateCompanyNotFound() {
+        UpdateCompanyRequest request = new UpdateCompanyRequest();
+        request.setCompanyNumber(COMPANY_NUMBER);
+
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.empty());
+
+        NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
+                companyProfileService.updateCompany(request));
+
+        assertTrue(thrown.getMessage().contains(COMPANY_NUMBER));
+    }
+
+    @Test
+    void updateCompanyWithUnknownFields() {
+        UpdateCompanyRequest request = new UpdateCompanyRequest();
+        request.setCompanyNumber(COMPANY_NUMBER);
+
+        request.addUnknownField("invalid_field", "some_value");
+
+        CompanyProfile existingProfile = new CompanyProfile();
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(existingProfile));
+
+        DataException thrown = assertThrows(DataException.class, () ->
+                companyProfileService.updateCompany(request));
+
+        assertTrue(thrown.getMessage().contains("Invalid field(s)"));
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void updateCompanySaveFailure() {
+        UpdateCompanyRequest request = new UpdateCompanyRequest();
+        request.setCompanyNumber(COMPANY_NUMBER);
+
+        CompanyProfile existingProfile = new CompanyProfile();
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(existingProfile));
+        when(repository.save(any())).thenThrow(new RuntimeException("DB Error"));
+
+        DataException thrown = assertThrows(DataException.class, () ->
+                companyProfileService.updateCompany(request));
+
+        assertEquals("Failed to update company profile", thrown.getMessage());
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -856,7 +856,7 @@ class CompanyProfileServiceImplTest {
     }
 
     @Test
-    void updateCompanySuccess() throws Exception {
+    void updateCompanyProfileSuccess() throws Exception {
         UpdateCompanyRequest request = new UpdateCompanyRequest();
         request.setCompanyNumber(COMPANY_NUMBER);
         request.setEtag("NEW_ETAG");
@@ -868,7 +868,7 @@ class CompanyProfileServiceImplTest {
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(existingProfile));
         when(repository.save(existingProfile)).thenReturn(existingProfile);
 
-        CompanyProfile result = companyProfileService.updateCompany(request);
+        CompanyProfile result = companyProfileService.updateCompanyProfile(request);
 
         assertNotNull(result);
         assertEquals("NEW_ETAG", existingProfile.getEtag());
@@ -876,32 +876,32 @@ class CompanyProfileServiceImplTest {
     }
 
     @Test
-    void updateCompanyMissingNumber() {
+    void updateCompanyProfileMissingNumber() {
         UpdateCompanyRequest request = new UpdateCompanyRequest();
         request.setCompanyNumber("");
 
         DataException thrown = assertThrows(DataException.class, () ->
-                companyProfileService.updateCompany(request));
+                companyProfileService.updateCompanyProfile(request));
 
         assertEquals("companyNumber is required", thrown.getMessage());
         verify(repository, never()).findByCompanyNumber(any());
     }
 
     @Test
-    void updateCompanyNotFound() {
+    void updateCompanyProfileNotFound() {
         UpdateCompanyRequest request = new UpdateCompanyRequest();
         request.setCompanyNumber(COMPANY_NUMBER);
 
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.empty());
 
         NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
-                companyProfileService.updateCompany(request));
+                companyProfileService.updateCompanyProfile(request));
 
         assertTrue(thrown.getMessage().contains(COMPANY_NUMBER));
     }
 
     @Test
-    void updateCompanyWithUnknownFields() {
+    void updateCompanyProfileWithUnknownFields() {
         UpdateCompanyRequest request = new UpdateCompanyRequest();
         request.setCompanyNumber(COMPANY_NUMBER);
 
@@ -911,14 +911,14 @@ class CompanyProfileServiceImplTest {
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(existingProfile));
 
         DataException thrown = assertThrows(DataException.class, () ->
-                companyProfileService.updateCompany(request));
+                companyProfileService.updateCompanyProfile(request));
 
         assertTrue(thrown.getMessage().contains("Invalid field(s)"));
         verify(repository, never()).save(any());
     }
 
     @Test
-    void updateCompanySaveFailure() {
+    void updateCompanyProfileSaveFailure() {
         UpdateCompanyRequest request = new UpdateCompanyRequest();
         request.setCompanyNumber(COMPANY_NUMBER);
 
@@ -927,7 +927,7 @@ class CompanyProfileServiceImplTest {
         when(repository.save(any())).thenThrow(new RuntimeException("DB Error"));
 
         DataException thrown = assertThrows(DataException.class, () ->
-                companyProfileService.updateCompany(request));
+                companyProfileService.updateCompanyProfile(request));
 
         assertEquals("Failed to update company profile", thrown.getMessage());
     }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
@@ -55,6 +55,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
 import uk.gov.companieshouse.api.testdata.model.entity.MissingImageDeliveries;
 import uk.gov.companieshouse.api.testdata.model.entity.Postcodes;
 import uk.gov.companieshouse.api.testdata.model.entity.User;
+import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AccountPenaltiesResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
@@ -656,6 +657,54 @@ class TestDataServiceImplTest {
         verify(companyProfileService).delete(UK_ESTABLISHMENT_NUMBER);
         verify(companyProfileService).delete(UK_ESTABLISHMENT_NUMBER_2);
         verify(companyProfileService).delete(OVERSEA_COMPANY);
+    }
+
+    @Test
+    void updateCompanyDataSuccess() throws Exception {
+        UpdateCompanyRequest request = new UpdateCompanyRequest();
+        request.setCompanyNumber(COMPANY_NUMBER);
+
+        CompanyProfile expectedProfile = new CompanyProfile();
+        expectedProfile.setCompanyNumber(COMPANY_NUMBER);
+
+        when(companyProfileService.updateCompany(request)).thenReturn(expectedProfile);
+
+        CompanyProfile actualProfile = testDataService.updateCompanyData(request);
+
+        assertEquals(expectedProfile, actualProfile);
+        verify(companyProfileService, times(1)).updateCompany(request);
+    }
+
+    @Test
+    void updateCompanyDataNotFound() throws Exception {
+        UpdateCompanyRequest request = new UpdateCompanyRequest();
+        request.setCompanyNumber(COMPANY_NUMBER);
+
+        String errorMessage = "Company not found";
+        when(companyProfileService.updateCompany(request))
+                .thenThrow(new NoDataFoundException(errorMessage));
+
+        NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
+                testDataService.updateCompanyData(request));
+
+        assertEquals(errorMessage, thrown.getMessage());
+        verify(companyProfileService, times(1)).updateCompany(request);
+    }
+
+    @Test
+    void updateCompanyDataException() throws Exception {
+        UpdateCompanyRequest request = new UpdateCompanyRequest();
+        request.setCompanyNumber(COMPANY_NUMBER);
+
+        String errorMessage = "Database error";
+        when(companyProfileService.updateCompany(request))
+                .thenThrow(new DataException(errorMessage));
+
+        DataException thrown = assertThrows(DataException.class, () ->
+                testDataService.updateCompanyData(request));
+
+        assertEquals(errorMessage, thrown.getMessage());
+        verify(companyProfileService, times(1)).updateCompany(request);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
@@ -667,12 +667,12 @@ class TestDataServiceImplTest {
         CompanyProfile expectedProfile = new CompanyProfile();
         expectedProfile.setCompanyNumber(COMPANY_NUMBER);
 
-        when(companyProfileService.updateCompany(request)).thenReturn(expectedProfile);
+        when(companyProfileService.updateCompanyProfile(request)).thenReturn(expectedProfile);
 
         CompanyProfile actualProfile = testDataService.updateCompanyData(request);
 
         assertEquals(expectedProfile, actualProfile);
-        verify(companyProfileService, times(1)).updateCompany(request);
+        verify(companyProfileService, times(1)).updateCompanyProfile(request);
     }
 
     @Test
@@ -681,14 +681,14 @@ class TestDataServiceImplTest {
         request.setCompanyNumber(COMPANY_NUMBER);
 
         String errorMessage = "Company not found";
-        when(companyProfileService.updateCompany(request))
+        when(companyProfileService.updateCompanyProfile(request))
                 .thenThrow(new NoDataFoundException(errorMessage));
 
         NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
                 testDataService.updateCompanyData(request));
 
         assertEquals(errorMessage, thrown.getMessage());
-        verify(companyProfileService, times(1)).updateCompany(request);
+        verify(companyProfileService, times(1)).updateCompanyProfile(request);
     }
 
     @Test
@@ -697,14 +697,14 @@ class TestDataServiceImplTest {
         request.setCompanyNumber(COMPANY_NUMBER);
 
         String errorMessage = "Database error";
-        when(companyProfileService.updateCompany(request))
+        when(companyProfileService.updateCompanyProfile(request))
                 .thenThrow(new DataException(errorMessage));
 
         DataException thrown = assertThrows(DataException.class, () ->
                 testDataService.updateCompanyData(request));
 
         assertEquals(errorMessage, thrown.getMessage());
-        verify(companyProfileService, times(1)).updateCompany(request);
+        verify(companyProfileService, times(1)).updateCompanyProfile(request);
     }
 
     @Test


### PR DESCRIPTION
# Summary

This PR introduces a new internal API endpoint to support updating company data in the test-data service. It adds request/response models and a service delegation layer to handle updates via the existing CompanyProfileService.

## Changes
### ➕ New Controller Endpoint

- Added PUT /internal/company endpoint in TestDataController
- Accepts UpdateCompanyRequest as input
- Returns CompanyUpdateResponse on success
- Handles exceptions and maps them to appropriate HTTP responses:
- 404 NOT FOUND for missing company data
- 500 INTERNAL SERVER ERROR for processing failures
### ➕ New Request Model

- UpdateCompanyRequest
- company_number (required)
- etag (optional)
- Supports forward compatibility via @JsonAnySetter
- Stores unexpected fields in unknownFields
- Validates companyNumber using @NotBlank

### ➕ New Response Model

- CompanyUpdateResponse
- Returns:
- companyNumber
- status (fixed as "updated")

### Behaviour

- Company is retrieved by companyNumber
- If not found → NoDataFoundException (404)
- If unknown fields are present → DataException
- If update succeeds → returns 200 OK with updated company number

```
Example Response
{
  "companyNumber": "12345678",
  "status": "updated"
}
```