### PR TITLE
exclude spring-boot-devtools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,14 +75,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-        <!--    This optional dependency contains vulnerabilities with no newer version
-                     available. To be re-enabled if spring-boot > 4.0.5 fixed the vulnerabilities -->
-        <!--       <dependency>-->
-        <!--            <groupId>org.springframework.boot</groupId>-->
-        <!--            <artifactId>spring-boot-devtools</artifactId>-->
-        <!--            <scope>runtime</scope>-->
-        <!--            <optional>true</optional>-->
-        <!--        </dependency>-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>test-data-generator</artifactId>
@@ -75,12 +75,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <scope>runtime</scope>
-            <optional>true</optional>
-        </dependency>
+        <!--    This optional dependency contains vulnerabilities with no newer version
+                     available. To be re-enabled if spring-boot > 4.0.5 fixed the vulnerabilities -->
+        <!--       <dependency>-->
+        <!--            <groupId>org.springframework.boot</groupId>-->
+        <!--            <artifactId>spring-boot-devtools</artifactId>-->
+        <!--            <scope>runtime</scope>-->
+        <!--            <optional>true</optional>-->
+        <!--        </dependency>-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
@@ -181,9 +183,9 @@
                 <configuration>
                     <source>21</source>
                     <target>21</target>
-                        <compilerArgs>
-                            <arg>-parameters</arg>
-                        </compilerArgs>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This pull request makes a minor but important change to the `pom.xml` file by commenting out the `spring-boot-devtools` dependency due to unresolved security vulnerabilities. The change includes a note explaining that the dependency can be re-enabled once the vulnerabilities are fixed in a future version of Spring Boot.

Dependency management and security:

* Commented out the `spring-boot-devtools` dependency in `pom.xml` due to known vulnerabilities, with a note to revisit once Spring Boot releases a fixed version.