### PR TITLE
Improve handling of InvalidFormatException for CompanyRequest and PublicCompanyRequest deserialization errors

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
@@ -61,16 +61,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         String message = "invalid request";
         Throwable cause = ex.getCause();
-        LOG.error("Cause " + cause);
-
 
         if (cause instanceof tools.jackson.databind.exc.InvalidFormatException ife) {
 
             List<JacksonException.Reference> path = ife.getPath();
 
             if (!path.isEmpty()) {
-
-                // ✅ Always take LAST element → actual field
                 Reference lastRef = path.get(path.size() - 1);
 
                 String desc = lastRef.getDescription();

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
@@ -13,14 +13,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
-
 import uk.gov.companieshouse.api.testdata.Application;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.InvalidAuthCodeException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
-import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
-import uk.gov.companieshouse.api.testdata.model.rest.request.PublicCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.validation.ValidationError;
 import uk.gov.companieshouse.api.testdata.model.rest.validation.ValidationErrors;
 import uk.gov.companieshouse.logging.Logger;
@@ -60,16 +56,19 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         String message = "invalid request";
         Throwable cause = ex.getCause();
-        if (cause instanceof InvalidFormatException) {
-            InvalidFormatException ife = (InvalidFormatException) cause;
-            String pathReference = ife.getPathReference();
-            if (pathReference != null
-                    && (pathReference.startsWith(CompanyRequest.class.getName())
-                    || pathReference.startsWith(PublicCompanyRequest.class.getName()))) {
-                // Handle invalid format in CompanyRequest (failed to deserialize enum)
-                String invalidField = pathReference.substring(pathReference.indexOf("[\"") + 2,
-                        pathReference.indexOf("\"]"));
-                message = "invalid " + invalidField;
+        if (cause != null && cause.getClass().getName().contains("InvalidFormatException")) {
+            String errorMessage = cause.getMessage();
+
+            if (errorMessage != null && errorMessage.contains("CompanyRequest[\"")) {
+                int start = errorMessage.indexOf("[\"") + 2;
+                int end = errorMessage.indexOf("\"]");
+
+                if (start > 1 && end > start) {
+
+                    String invalidField = errorMessage.substring(start, end);
+
+                    message = "invalid " + invalidField;
+                }
             }
         }
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.api.testdata.controller;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import java.util.List;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -25,7 +24,6 @@ import uk.gov.companieshouse.api.testdata.model.rest.validation.ValidationError;
 import uk.gov.companieshouse.api.testdata.model.rest.validation.ValidationErrors;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
-import tools.jackson.databind.exc.InvalidFormatException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.api.testdata.controller;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
+import java.util.List;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JacksonException.Reference;
 import uk.gov.companieshouse.api.testdata.Application;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.InvalidAuthCodeException;
@@ -21,6 +25,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.validation.ValidationError;
 import uk.gov.companieshouse.api.testdata.model.rest.validation.ValidationErrors;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
+import tools.jackson.databind.exc.InvalidFormatException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
@@ -56,26 +61,39 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         String message = "invalid request";
         Throwable cause = ex.getCause();
-        if (cause != null && cause.getClass().getName().contains("InvalidFormatException")) {
-            String errorMessage = cause.getMessage();
+        LOG.error("Cause " + cause);
 
-            if (errorMessage != null && errorMessage.contains("CompanyRequest[\"")) {
-                int start = errorMessage.indexOf("[\"") + 2;
-                int end = errorMessage.indexOf("\"]");
 
-                if (start > 1 && end > start) {
+        if (cause instanceof tools.jackson.databind.exc.InvalidFormatException ife) {
 
-                    String invalidField = errorMessage.substring(start, end);
+            List<JacksonException.Reference> path = ife.getPath();
 
-                    message = "invalid " + invalidField;
+            if (!path.isEmpty()) {
+
+                // ✅ Always take LAST element → actual field
+                Reference lastRef = path.get(path.size() - 1);
+
+                String desc = lastRef.getDescription();
+
+                if (desc != null && desc.contains("[\"")) {
+
+                    int start = desc.indexOf("[\"") + 2;
+                    int end = desc.indexOf("\"]");
+
+                    if (start > 1 && end > start) {
+                        String fieldName = desc.substring(start, end);
+                        message = "invalid " + fieldName;
+                    }
                 }
             }
         }
 
         ValidationErrors errors = new ValidationErrors();
         errors.addError(createValidationError(message));
+
         return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
+
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
@@ -27,6 +27,7 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 @ControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     private static final Logger LOG = LoggerFactory.getLogger(Application.APPLICATION_NAME);
+    private static final String invalidRequest = "invalid request";
 
     @ExceptionHandler(value = {DataException.class})
     @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
@@ -71,7 +72,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         Throwable cause = ex.getCause();
 
         if (!(cause instanceof tools.jackson.databind.exc.InvalidFormatException ife)) {
-            return "invalid request";
+            return invalidRequest;
         }
 
         return extractFieldMessage(ife.getPath());
@@ -79,7 +80,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private String extractFieldMessage(List<JacksonException.Reference> path) {
         if (path == null || path.isEmpty()) {
-            return "invalid request";
+            return invalidRequest;
         }
 
         for (JacksonException.Reference ref : path) {
@@ -90,6 +91,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 return "invalid " + fieldName;
             }
         }
+
         return "invalid request";
     }
 
@@ -107,7 +109,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         return null;
     }
-
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
@@ -65,19 +65,29 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             List<JacksonException.Reference> path = ife.getPath();
 
             if (!path.isEmpty()) {
-                Reference lastRef = path.get(path.size() - 1);
 
-                String desc = lastRef.getDescription();
+                String fieldName = null;
 
-                if (desc != null && desc.contains("[\"")) {
+                for (JacksonException.Reference ref : path) {
 
-                    int start = desc.indexOf("[\"") + 2;
-                    int end = desc.indexOf("\"]");
+                    String desc = ref.getDescription();
 
-                    if (start > 1 && end > start) {
-                        String fieldName = desc.substring(start, end);
-                        message = "invalid " + fieldName;
+                    if (desc != null && desc.contains("[\"")) {
+
+                        int start = desc.indexOf("[\"") + 2;
+                        int end = desc.indexOf("\"]");
+
+                        if (start > 1 && end > start) {
+                            fieldName = desc.substring(start, end);
+                            if (fieldName != null) {
+                                break;
+                            }
+                        }
                     }
+                }
+
+                if (fieldName != null) {
+                    message = "invalid " + fieldName;
                 }
             }
         }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
@@ -15,7 +15,6 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import tools.jackson.core.JacksonException;
-import tools.jackson.core.JacksonException.Reference;
 import uk.gov.companieshouse.api.testdata.Application;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.InvalidAuthCodeException;
@@ -53,49 +52,60 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override
     protected ResponseEntity<Object> handleHttpMessageNotReadable(
-            HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status,
+            HttpMessageNotReadableException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
             WebRequest request) {
+
         logException(ex);
 
-        String message = "invalid request";
-        Throwable cause = ex.getCause();
-
-        if (cause instanceof tools.jackson.databind.exc.InvalidFormatException ife) {
-
-            List<JacksonException.Reference> path = ife.getPath();
-
-            if (!path.isEmpty()) {
-
-                String fieldName = null;
-
-                for (JacksonException.Reference ref : path) {
-
-                    String desc = ref.getDescription();
-
-                    if (desc != null && desc.contains("[\"")) {
-
-                        int start = desc.indexOf("[\"") + 2;
-                        int end = desc.indexOf("\"]");
-
-                        if (start > 1 && end > start) {
-                            fieldName = desc.substring(start, end);
-                            if (fieldName != null) {
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                if (fieldName != null) {
-                    message = "invalid " + fieldName;
-                }
-            }
-        }
+        String message = resolveMessage(ex);
 
         ValidationErrors errors = new ValidationErrors();
         errors.addError(createValidationError(message));
 
         return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+    }
+
+    private String resolveMessage(HttpMessageNotReadableException ex) {
+        Throwable cause = ex.getCause();
+
+        if (!(cause instanceof tools.jackson.databind.exc.InvalidFormatException ife)) {
+            return "invalid request";
+        }
+
+        return extractFieldMessage(ife.getPath());
+    }
+
+    private String extractFieldMessage(List<JacksonException.Reference> path) {
+        if (path == null || path.isEmpty()) {
+            return "invalid request";
+        }
+
+        for (JacksonException.Reference ref : path) {
+
+            String fieldName = extractFieldName(ref.getDescription());
+
+            if (fieldName != null) {
+                return "invalid " + fieldName;
+            }
+        }
+        return "invalid request";
+    }
+
+    private String extractFieldName(String desc) {
+        if (desc == null || !desc.contains("[\"")) {
+            return null;
+        }
+
+        int start = desc.indexOf("[\"") + 2;
+        int end = desc.indexOf("\"]");
+
+        if (start > 1 && end > start) {
+            return desc.substring(start, end);
+        }
+
+        return null;
     }
 
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandler.java
@@ -27,7 +27,7 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 @ControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     private static final Logger LOG = LoggerFactory.getLogger(Application.APPLICATION_NAME);
-    private static final String invalidRequest = "invalid request";
+    private static final String INVALID_REQUEST = "invalid request";
 
     @ExceptionHandler(value = {DataException.class})
     @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
@@ -72,7 +72,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         Throwable cause = ex.getCause();
 
         if (!(cause instanceof tools.jackson.databind.exc.InvalidFormatException ife)) {
-            return invalidRequest;
+            return INVALID_REQUEST;
         }
 
         return extractFieldMessage(ife.getPath());
@@ -80,7 +80,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private String extractFieldMessage(List<JacksonException.Reference> path) {
         if (path == null || path.isEmpty()) {
-            return invalidRequest;
+            return INVALID_REQUEST;
         }
 
         for (JacksonException.Reference ref : path) {
@@ -92,7 +92,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             }
         }
 
-        return "invalid request";
+        return INVALID_REQUEST;
     }
 
     private String extractFieldName(String desc) {

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
@@ -11,6 +11,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;
@@ -30,6 +32,7 @@ import uk.gov.companieshouse.api.testdata.exception.InvalidAuthCodeException;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.validation.ValidationError;
 import uk.gov.companieshouse.api.testdata.model.rest.validation.ValidationErrors;
+
 
 @ExtendWith(MockitoExtension.class)
 public class GlobalExceptionHandlerTest {
@@ -122,23 +125,20 @@ public class GlobalExceptionHandlerTest {
         assertEquals("invalid jurisdiction", actual.getError());
     }
 
-    @Test
-    void extractFieldMessageNullPathReturnsInvalidRequest() throws Exception {
-        HttpMessageNotReadableException ex =
-                new HttpMessageNotReadableException("ex", (Throwable) null, null);
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "no-field-info",
+            "[\"field\""
+    })
+    void extractFieldName_invalidDescriptions_returnsInvalidRequest(String description) throws Exception {
 
-        WebRequest request = Mockito.mock(WebRequest.class);
+        InvalidFormatException cause =
+                new InvalidFormatException(null, "msg", "value", String.class);
 
-        ResponseEntity<Object> response = handler.handleException(ex, request);
+        Reference ref = Mockito.mock(Reference.class);
+        when(ref.getDescription()).thenReturn(description);
 
-        ValidationErrors errors = (ValidationErrors) response.getBody();
-        assertEquals("invalid request", errors.getErrors().iterator().next().getError());
-    }
-
-    @Test
-    void extractFieldMessageEmptyPathReturnsInvalidRequest() throws Exception {
-        InvalidFormatException cause = new InvalidFormatException(
-                null, "msg", "value", String.class);
+        cause.prependPath(ref);
 
         HttpMessageNotReadableException ex =
                 new HttpMessageNotReadableException("ex", cause, null);
@@ -148,13 +148,16 @@ public class GlobalExceptionHandlerTest {
         ResponseEntity<Object> response = handler.handleException(ex, request);
 
         ValidationErrors errors = (ValidationErrors) response.getBody();
-        assertEquals("invalid request", errors.getErrors().iterator().next().getError());
+
+        assertEquals("invalid request",
+                errors.getErrors().iterator().next().getError());
     }
 
     @Test
-    void extractFieldNameNullDescriptionReturnsInvalidRequest() throws Exception {
-        InvalidFormatException cause = new InvalidFormatException(
-                null, "msg", "value", String.class);
+    void extractFieldName_nullDescription_returnsInvalidRequest() throws Exception {
+
+        InvalidFormatException cause =
+                new InvalidFormatException(null, "msg", "value", String.class);
 
         Reference ref = Mockito.mock(Reference.class);
         when(ref.getDescription()).thenReturn(null);
@@ -169,7 +172,9 @@ public class GlobalExceptionHandlerTest {
         ResponseEntity<Object> response = handler.handleException(ex, request);
 
         ValidationErrors errors = (ValidationErrors) response.getBody();
-        assertEquals("invalid request", errors.getErrors().iterator().next().getError());
+
+        assertEquals("invalid request",
+                errors.getErrors().iterator().next().getError());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,9 +23,11 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.context.request.WebRequest;
 
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import tools.jackson.databind.exc.InvalidFormatException;
+import tools.jackson.core.JacksonException.Reference;
 
 import uk.gov.companieshouse.api.testdata.exception.InvalidAuthCodeException;
+import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.validation.ValidationError;
 import uk.gov.companieshouse.api.testdata.model.rest.validation.ValidationErrors;
 
@@ -94,55 +97,30 @@ public class GlobalExceptionHandlerTest {
         assertTrue(errors.containsError(expectedError));
     }
 
+
     @Test
     void handleHttpMessageNotReadableInvalidFormatExceptionWithFieldName() throws Exception {
-        String errorMessage = "CompanyRequest[\"jurisdiction\"]";
-
         InvalidFormatException cause = new InvalidFormatException(
                 null,
-                errorMessage,
+                "error",
                 "invalid-value",
                 String.class
         );
+        Reference ref = new Reference(CompanyRequest.class, "jurisdiction");
 
-        HttpInputMessage httpInputMessage = null;
-        Exception ex = new HttpMessageNotReadableException("ex", cause, httpInputMessage);
+        cause.prependPath(ref);
+
+        HttpMessageNotReadableException ex =
+                new HttpMessageNotReadableException("ex", cause, null);
+
         WebRequest request = Mockito.mock(WebRequest.class);
-
-        final ValidationError expectedError =
-                new ValidationError("invalid jurisdiction", null, null, "ch:validation");
 
         ResponseEntity<Object> response = handler.handleException(ex, request);
 
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertTrue(response.getBody() instanceof ValidationErrors);
-
         ValidationErrors errors = (ValidationErrors) response.getBody();
-        assertEquals(1, errors.getErrorCount());
-        assertTrue(errors.containsError(expectedError));
-    }
+        ValidationError actual = errors.getErrors().iterator().next();
 
-    @Test
-    void handleHttpMessageNotReadableOtherInvalidFormatException() throws Exception {
-        InvalidFormatException cause = new InvalidFormatException(
-                null,
-                "invalid value",
-                "INVALID",
-                String.class
-        );
-        HttpInputMessage httpInputMessage = null;
-        Exception ex = new HttpMessageNotReadableException("ex", cause, httpInputMessage);
-        WebRequest request = Mockito.mock(WebRequest.class);
-
-        final ValidationError expectedError = new ValidationError("invalid request", null, null, "ch:validation");
-
-        ResponseEntity<Object> response = handler.handleException(ex, request);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertTrue(response.getBody() instanceof ValidationErrors);
-        ValidationErrors errors = (ValidationErrors) response.getBody();
-        assertEquals(1, errors.getErrorCount());
-        assertTrue(errors.containsError(expectedError));
+        assertEquals("invalid jurisdiction", actual.getError());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
@@ -9,9 +9,11 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -38,6 +40,13 @@ import uk.gov.companieshouse.api.testdata.model.rest.validation.ValidationErrors
 public class GlobalExceptionHandlerTest {
 
     private GlobalExceptionHandler handler = new GlobalExceptionHandler();
+    private static Stream<String> invalidDescriptions() {
+        return Stream.of(
+                null,                 // null case
+                "no-field-info",      // no [" pattern
+                "[\"field\""          // bad index (missing closing "])
+        );
+    }
 
     @Test
     void handleHttpMessageNotReadableNullCause() throws Exception {
@@ -126,11 +135,8 @@ public class GlobalExceptionHandlerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {
-            "no-field-info",
-            "[\"field\""
-    })
-    void extractFieldName_invalidDescriptions_returnsInvalidRequest(String description) throws Exception {
+    @MethodSource("invalidDescriptions")
+    void extractFieldNameInvalidDescriptionsReturnsInvalidRequest(String description) throws Exception {
 
         InvalidFormatException cause =
                 new InvalidFormatException(null, "msg", "value", String.class);
@@ -151,72 +157,6 @@ public class GlobalExceptionHandlerTest {
 
         assertEquals("invalid request",
                 errors.getErrors().iterator().next().getError());
-    }
-
-    @Test
-    void extractFieldName_nullDescription_returnsInvalidRequest() throws Exception {
-
-        InvalidFormatException cause =
-                new InvalidFormatException(null, "msg", "value", String.class);
-
-        Reference ref = Mockito.mock(Reference.class);
-        when(ref.getDescription()).thenReturn(null);
-
-        cause.prependPath(ref);
-
-        HttpMessageNotReadableException ex =
-                new HttpMessageNotReadableException("ex", cause, null);
-
-        WebRequest request = Mockito.mock(WebRequest.class);
-
-        ResponseEntity<Object> response = handler.handleException(ex, request);
-
-        ValidationErrors errors = (ValidationErrors) response.getBody();
-
-        assertEquals("invalid request",
-                errors.getErrors().iterator().next().getError());
-    }
-
-    @Test
-    void extractFieldNameInvalidFormatDescriptionReturnsInvalidRequest() throws Exception {
-        InvalidFormatException cause = new InvalidFormatException(
-                null, "msg", "value", String.class);
-
-        Reference ref = Mockito.mock(Reference.class);
-        when(ref.getDescription()).thenReturn("no-field-info");
-
-        cause.prependPath(ref);
-
-        HttpMessageNotReadableException ex =
-                new HttpMessageNotReadableException("ex", cause, null);
-
-        WebRequest request = Mockito.mock(WebRequest.class);
-
-        ResponseEntity<Object> response = handler.handleException(ex, request);
-
-        ValidationErrors errors = (ValidationErrors) response.getBody();
-        assertEquals("invalid request", errors.getErrors().iterator().next().getError());
-    }
-
-    @Test
-    void extractFieldNameBadIndexesReturnsInvalidRequest() throws Exception {
-        InvalidFormatException cause = new InvalidFormatException(
-                null, "msg", "value", String.class);
-
-        Reference ref = Mockito.mock(Reference.class);
-        when(ref.getDescription()).thenReturn("[\"field\""); // missing closing "]
-
-        cause.prependPath(ref);
-
-        HttpMessageNotReadableException ex =
-                new HttpMessageNotReadableException("ex", cause, null);
-
-        WebRequest request = Mockito.mock(WebRequest.class);
-
-        ResponseEntity<Object> response = handler.handleException(ex, request);
-
-        ValidationErrors errors = (ValidationErrors) response.getBody();
-        assertEquals("invalid request", errors.getErrors().iterator().next().getError());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
@@ -71,25 +71,24 @@ public class GlobalExceptionHandlerTest {
 
     @Test
     void handleHttpMessageNotReadableCompanySpecInvalidFormatException() throws Exception {
-        InvalidFormatException cause = Mockito.mock(InvalidFormatException.class);
+        InvalidFormatException cause = new InvalidFormatException(
+                null,
+                "error",
+                "input",
+                String.class
+        );
         HttpInputMessage httpInputMessage = null;
         Exception ex = new HttpMessageNotReadableException("ex", cause, httpInputMessage);
         WebRequest request = Mockito.mock(WebRequest.class);
 
-        when(cause.getPathReference())
-                .thenReturn("uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest[\"jurisdiction\"]");
-
-        StackTraceElement[] stackTrace = new StackTraceElement[] {
-            new StackTraceElement("CompanyRequest", "getJurisdiction", "CompanyRequest.java", 123)
-        };
-        when(cause.getStackTrace()).thenReturn(stackTrace);
-
-        final ValidationError expectedError = new ValidationError("invalid jurisdiction", null, null, "ch:validation");
+        final ValidationError expectedError =
+                new ValidationError("invalid request", null, null, "ch:validation");
 
         ResponseEntity<Object> response = handler.handleException(ex, request);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertTrue(response.getBody() instanceof ValidationErrors);
+
         ValidationErrors errors = (ValidationErrors) response.getBody();
         assertEquals(1, errors.getErrorCount());
         assertTrue(errors.containsError(expectedError));
@@ -97,17 +96,19 @@ public class GlobalExceptionHandlerTest {
 
     @Test
     void handleHttpMessageNotReadableOtherInvalidFormatException() throws Exception {
-        InvalidFormatException cause = Mockito.mock(InvalidFormatException.class);
+        InvalidFormatException cause = new InvalidFormatException(
+                null,
+                "invalid value",
+                "INVALID",
+                String.class
+        );
         HttpInputMessage httpInputMessage = null;
         Exception ex = new HttpMessageNotReadableException("ex", cause, httpInputMessage);
         WebRequest request = Mockito.mock(WebRequest.class);
 
-        when(cause.getPathReference()).thenReturn("unrecognised path reference");
-
         StackTraceElement[] stackTrace = new StackTraceElement[] {
             new StackTraceElement("CompanyRequest", "getJurisdiction", "CompanyRequest.java", 123)
         };
-        when(cause.getStackTrace()).thenReturn(stackTrace);
 
         final ValidationError expectedError = new ValidationError("invalid request", null, null, "ch:validation");
 

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
@@ -95,61 +95,22 @@ public class GlobalExceptionHandlerTest {
     }
 
     @Test
-    void handleHttpMessageNotReadableInvalidFormatExceptionNullMessage() throws Exception {
+    void handleHttpMessageNotReadableInvalidFormatExceptionWithFieldName() throws Exception {
+        String errorMessage = "CompanyRequest[\"jurisdiction\"]";
 
         InvalidFormatException cause = new InvalidFormatException(
-                (String) null,
                 null,
-                "input",
+                errorMessage,
+                "invalid-value",
                 String.class
         );
 
-        StackTraceElement[] stackTrace = new StackTraceElement[] {
-                new StackTraceElement(
-                        "CompanyRequest",
-                        "getJurisdiction",
-                        "CompanyRequest.java",
-                        123)
-        };
-        cause.setStackTrace(stackTrace);
-
         HttpInputMessage httpInputMessage = null;
-
-        Exception ex = new HttpMessageNotReadableException(
-                "ex",
-                cause,
-                httpInputMessage
-        );
-
+        Exception ex = new HttpMessageNotReadableException("ex", cause, httpInputMessage);
         WebRequest request = Mockito.mock(WebRequest.class);
 
-        ResponseEntity<Object> response = handler.handleException(ex, request);
-
-        ValidationErrors errors = (ValidationErrors) response.getBody();
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertEquals(1, errors.getErrorCount());
-
-        ValidationError actual = errors.getErrors()
-                .stream()
-                .findFirst()
-                .orElseThrow();
-
-        assertEquals("invalid request", actual.getError());
-    }
-
-    @Test
-    void handleHttpMessageNotReadableInvalidFormatExceptionIrrelevantMessage() throws Exception {
-
-        HttpInputMessage httpInputMessage = null;
-
-        Exception ex = new HttpMessageNotReadableException(
-                "ex",
-                new RuntimeException("cause"),
-                httpInputMessage
-        );
-
-        WebRequest request = Mockito.mock(WebRequest.class);
+        final ValidationError expectedError =
+                new ValidationError("invalid jurisdiction", null, null, "ch:validation");
 
         ResponseEntity<Object> response = handler.handleException(ex, request);
 
@@ -157,45 +118,8 @@ public class GlobalExceptionHandlerTest {
         assertTrue(response.getBody() instanceof ValidationErrors);
 
         ValidationErrors errors = (ValidationErrors) response.getBody();
-
         assertEquals(1, errors.getErrorCount());
-
-        ValidationError actual = errors.getErrors()
-                .stream()
-                .findFirst()
-                .orElseThrow();
-
-        assertEquals("invalid request", actual.getError());
-    }
-
-    @Test
-    void handleHttpMessageNotReadableInvalidFormatExceptionBadBracketIndexes() throws Exception {
-
-        HttpInputMessage httpInputMessage = null;
-
-        Exception ex = new HttpMessageNotReadableException(
-                "ex",
-                new RuntimeException("cause"),
-                httpInputMessage
-        );
-
-        WebRequest request = Mockito.mock(WebRequest.class);
-
-        ResponseEntity<Object> response = handler.handleException(ex, request);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertTrue(response.getBody() instanceof ValidationErrors);
-
-        ValidationErrors errors = (ValidationErrors) response.getBody();
-
-        assertEquals(1, errors.getErrorCount());
-
-        ValidationError actual = errors.getErrors()
-                .stream()
-                .findFirst()
-                .orElseThrow();
-
-        assertEquals("invalid request", actual.getError());
+        assertTrue(errors.containsError(expectedError));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
@@ -70,7 +70,7 @@ public class GlobalExceptionHandlerTest {
     }
 
     @Test
-    void handleHttpMessageNotReadableCompanySpecInvalidFormatException() throws Exception {
+    void handleHttpMessageNotReadableReturnsGenericInvalidRequest() throws Exception {
         InvalidFormatException cause = new InvalidFormatException(
                 null,
                 "error",
@@ -133,10 +133,6 @@ public class GlobalExceptionHandlerTest {
         HttpInputMessage httpInputMessage = null;
         Exception ex = new HttpMessageNotReadableException("ex", cause, httpInputMessage);
         WebRequest request = Mockito.mock(WebRequest.class);
-
-        StackTraceElement[] stackTrace = new StackTraceElement[] {
-            new StackTraceElement("CompanyRequest", "getJurisdiction", "CompanyRequest.java", 123)
-        };
 
         final ValidationError expectedError = new ValidationError("invalid request", null, null, "ch:validation");
 

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
@@ -97,7 +97,6 @@ public class GlobalExceptionHandlerTest {
         assertTrue(errors.containsError(expectedError));
     }
 
-
     @Test
     void handleHttpMessageNotReadableInvalidFormatExceptionWithFieldName() throws Exception {
         InvalidFormatException cause = new InvalidFormatException(
@@ -121,6 +120,98 @@ public class GlobalExceptionHandlerTest {
         ValidationError actual = errors.getErrors().iterator().next();
 
         assertEquals("invalid jurisdiction", actual.getError());
+    }
+
+    @Test
+    void extractFieldMessageNullPathReturnsInvalidRequest() throws Exception {
+        HttpMessageNotReadableException ex =
+                new HttpMessageNotReadableException("ex", (Throwable) null, null);
+
+        WebRequest request = Mockito.mock(WebRequest.class);
+
+        ResponseEntity<Object> response = handler.handleException(ex, request);
+
+        ValidationErrors errors = (ValidationErrors) response.getBody();
+        assertEquals("invalid request", errors.getErrors().iterator().next().getError());
+    }
+
+    @Test
+    void extractFieldMessageEmptyPathReturnsInvalidRequest() throws Exception {
+        InvalidFormatException cause = new InvalidFormatException(
+                null, "msg", "value", String.class);
+
+        HttpMessageNotReadableException ex =
+                new HttpMessageNotReadableException("ex", cause, null);
+
+        WebRequest request = Mockito.mock(WebRequest.class);
+
+        ResponseEntity<Object> response = handler.handleException(ex, request);
+
+        ValidationErrors errors = (ValidationErrors) response.getBody();
+        assertEquals("invalid request", errors.getErrors().iterator().next().getError());
+    }
+
+    @Test
+    void extractFieldNameNullDescriptionReturnsInvalidRequest() throws Exception {
+        InvalidFormatException cause = new InvalidFormatException(
+                null, "msg", "value", String.class);
+
+        Reference ref = Mockito.mock(Reference.class);
+        when(ref.getDescription()).thenReturn(null);
+
+        cause.prependPath(ref);
+
+        HttpMessageNotReadableException ex =
+                new HttpMessageNotReadableException("ex", cause, null);
+
+        WebRequest request = Mockito.mock(WebRequest.class);
+
+        ResponseEntity<Object> response = handler.handleException(ex, request);
+
+        ValidationErrors errors = (ValidationErrors) response.getBody();
+        assertEquals("invalid request", errors.getErrors().iterator().next().getError());
+    }
+
+    @Test
+    void extractFieldNameInvalidFormatDescriptionReturnsInvalidRequest() throws Exception {
+        InvalidFormatException cause = new InvalidFormatException(
+                null, "msg", "value", String.class);
+
+        Reference ref = Mockito.mock(Reference.class);
+        when(ref.getDescription()).thenReturn("no-field-info");
+
+        cause.prependPath(ref);
+
+        HttpMessageNotReadableException ex =
+                new HttpMessageNotReadableException("ex", cause, null);
+
+        WebRequest request = Mockito.mock(WebRequest.class);
+
+        ResponseEntity<Object> response = handler.handleException(ex, request);
+
+        ValidationErrors errors = (ValidationErrors) response.getBody();
+        assertEquals("invalid request", errors.getErrors().iterator().next().getError());
+    }
+
+    @Test
+    void extractFieldNameBadIndexesReturnsInvalidRequest() throws Exception {
+        InvalidFormatException cause = new InvalidFormatException(
+                null, "msg", "value", String.class);
+
+        Reference ref = Mockito.mock(Reference.class);
+        when(ref.getDescription()).thenReturn("[\"field\""); // missing closing "]
+
+        cause.prependPath(ref);
+
+        HttpMessageNotReadableException ex =
+                new HttpMessageNotReadableException("ex", cause, null);
+
+        WebRequest request = Mockito.mock(WebRequest.class);
+
+        ResponseEntity<Object> response = handler.handleException(ex, request);
+
+        ValidationErrors errors = (ValidationErrors) response.getBody();
+        assertEquals("invalid request", errors.getErrors().iterator().next().getError());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/GlobalExceptionHandlerTest.java
@@ -95,6 +95,110 @@ public class GlobalExceptionHandlerTest {
     }
 
     @Test
+    void handleHttpMessageNotReadableInvalidFormatExceptionNullMessage() throws Exception {
+
+        InvalidFormatException cause = new InvalidFormatException(
+                (String) null,
+                null,
+                "input",
+                String.class
+        );
+
+        StackTraceElement[] stackTrace = new StackTraceElement[] {
+                new StackTraceElement(
+                        "CompanyRequest",
+                        "getJurisdiction",
+                        "CompanyRequest.java",
+                        123)
+        };
+        cause.setStackTrace(stackTrace);
+
+        HttpInputMessage httpInputMessage = null;
+
+        Exception ex = new HttpMessageNotReadableException(
+                "ex",
+                cause,
+                httpInputMessage
+        );
+
+        WebRequest request = Mockito.mock(WebRequest.class);
+
+        ResponseEntity<Object> response = handler.handleException(ex, request);
+
+        ValidationErrors errors = (ValidationErrors) response.getBody();
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals(1, errors.getErrorCount());
+
+        ValidationError actual = errors.getErrors()
+                .stream()
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals("invalid request", actual.getError());
+    }
+
+    @Test
+    void handleHttpMessageNotReadableInvalidFormatExceptionIrrelevantMessage() throws Exception {
+
+        HttpInputMessage httpInputMessage = null;
+
+        Exception ex = new HttpMessageNotReadableException(
+                "ex",
+                new RuntimeException("cause"),
+                httpInputMessage
+        );
+
+        WebRequest request = Mockito.mock(WebRequest.class);
+
+        ResponseEntity<Object> response = handler.handleException(ex, request);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertTrue(response.getBody() instanceof ValidationErrors);
+
+        ValidationErrors errors = (ValidationErrors) response.getBody();
+
+        assertEquals(1, errors.getErrorCount());
+
+        ValidationError actual = errors.getErrors()
+                .stream()
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals("invalid request", actual.getError());
+    }
+
+    @Test
+    void handleHttpMessageNotReadableInvalidFormatExceptionBadBracketIndexes() throws Exception {
+
+        HttpInputMessage httpInputMessage = null;
+
+        Exception ex = new HttpMessageNotReadableException(
+                "ex",
+                new RuntimeException("cause"),
+                httpInputMessage
+        );
+
+        WebRequest request = Mockito.mock(WebRequest.class);
+
+        ResponseEntity<Object> response = handler.handleException(ex, request);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertTrue(response.getBody() instanceof ValidationErrors);
+
+        ValidationErrors errors = (ValidationErrors) response.getBody();
+
+        assertEquals(1, errors.getErrorCount());
+
+        ValidationError actual = errors.getErrors()
+                .stream()
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals("invalid request", actual.getError());
+    }
+
+    @Test
     void handleHttpMessageNotReadableOtherInvalidFormatException() throws Exception {
         InvalidFormatException cause = new InvalidFormatException(
                 null,


### PR DESCRIPTION
### Summary

Improves error handling in handleHttpMessageNotReadable to correctly process Jackson InvalidFormatException during enum deserialization failures for both CompanyRequest and PublicCompanyRequest.

### Changes Made

- Added explicit handling for InvalidFormatException cause type
- Improved parsing of invalid enum field from exception message/path reference
- Ensured support for both:
- CompanyRequest
- PublicCompanyRequest
- Replaced unreliable string-only detection with safer null checks and structured validation
- Improved robustness of error message extraction for invalid request payloads
