### PR TITLE
add company name endings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>4.0.416</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.14</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.16</test-data-generator-library.version>
 
         <!-- Sonar config -->
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -24,6 +24,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.OverseasEntity;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
+import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyNameEnding;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.JurisdictionType;
 import uk.gov.companieshouse.api.testdata.repository.CompanyProfileRepository;
 import uk.gov.companieshouse.api.testdata.service.AddressService;
@@ -47,7 +48,6 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
     private static final String OVERSEA_COMPANY_TYPE = "oversea-company";
     private static final String EXT_REGISTRATION_NUMBER = "124234R34";
     private static final String COMPANY_NAME_PREFIX = "COMPANY ";
-    private static final String COMPANY_NAME_SUFFIX = " LIMITED";
     private static final String FCD_COUNTRY = "Barbados";
     private static final String LEGAL_FORM = "Plc";
     private static final String BUSINESS_ACTIVITY = "Trading";
@@ -373,12 +373,12 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         var branchDetails = new CompanyProfile.BranchCompanyDetails();
         branchDetails.setBusinessActivity(BUSINESS_ACTIVITY);
         branchDetails.setParentCompanyName(COMPANY_NAME_PREFIX
-                + parentCompanyNumber + COMPANY_NAME_SUFFIX);
+                + parentCompanyNumber + getCompanyNameEnding(CompanyType.UK_ESTABLISHMENT));
         branchDetails.setParentCompanyNumber(parentCompanyNumber);
         ukEstablishment.setBranchCompanyDetails(branchDetails);
 
         ukEstablishment.setCompanyName(COMPANY_NAME_PREFIX
-                + ukEstablishmentNumber + COMPANY_NAME_SUFFIX);
+                + ukEstablishmentNumber + getCompanyNameEnding(CompanyType.UK_ESTABLISHMENT));
         ukEstablishment.setDateOfCreation(dateNow(accountingReferenceDate));
         ukEstablishment.setRegisteredOfficeAddress(addressService.getAddress(jurisdiction));
 
@@ -548,7 +548,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         if (companyType.equals(CompanyType.UNITED_KINGDOM_SOCIETAS.getValue())) {
             profile.setCompanyName(COMPANY_NAME_PREFIX + companyNumber + " UK SOCIETAS");
         } else {
-            profile.setCompanyName(COMPANY_NAME_PREFIX + companyNumber + COMPANY_NAME_SUFFIX);
+            profile.setCompanyName(COMPANY_NAME_PREFIX + companyNumber + getCompanyNameEnding(CompanyType.fromValue(companyType)));
         }
     }
 
@@ -673,4 +673,19 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         private Boolean registeredOfficeIsInDispute;
         private String accountsDueStatus;
     }
+
+    private String getCompanyNameEnding(CompanyType companyType) {
+        if (companyType == null) {
+            LOG.info("getCompanyNameEnding called with null companyType");
+            return "";
+        }
+        try {
+            String ending = CompanyNameEnding.fromTypeEnum(companyType).getEnding();
+            return ending.isEmpty() ? "" : " " + ending;
+        } catch (IllegalArgumentException ex) {
+            LOG.error("No CompanyNameEnding mapping for CompanyType:}" + companyType, ex);
+            return "";
+        }
+    }
+    
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -41,6 +42,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
 import uk.gov.companieshouse.api.testdata.model.entity.OverseasEntity;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyNameEnding;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.JurisdictionType;
 import uk.gov.companieshouse.api.testdata.model.rest.request.RegistersRequest;
@@ -1013,6 +1015,44 @@ class CompanyProfileServiceImplTest {
         CompanyProfile profile = captor.getValue();
 
         assertEquals("COMPANY " + COMPANY_NUMBER, profile.getCompanyName());
+    }
+
+    @Test
+    void getCompanyNameEndingWithNullCompanyTypeReturnsEmptyString() throws Exception {
+        var method = CompanyProfileServiceImpl.class.getDeclaredMethod(
+                "getCompanyNameEnding", CompanyType.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(companyProfileService, new Object[]{null});
+
+        assertEquals("", result);
+    }
+
+    @Test
+    void getCompanyNameEndingWhenMappingLookupThrowsReturnsEmptyString() throws Exception {
+        var method = CompanyProfileServiceImpl.class.getDeclaredMethod(
+                "getCompanyNameEnding", CompanyType.class);
+        method.setAccessible(true);
+
+        try (MockedStatic<CompanyNameEnding> mocked = Mockito.mockStatic(CompanyNameEnding.class)) {
+            mocked.when(() -> CompanyNameEnding.fromTypeEnum(CompanyType.PLC))
+                    .thenThrow(new IllegalArgumentException("No mapping"));
+
+            String result = (String) method.invoke(companyProfileService, CompanyType.PLC);
+
+            assertEquals("", result);
+        }
+    }
+
+    @Test
+    void getCompanyNameEndingWithMappedCompanyTypeReturnsPrefixedEnding() throws Exception {
+        var method = CompanyProfileServiceImpl.class.getDeclaredMethod(
+                "getCompanyNameEnding", CompanyType.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(companyProfileService, CompanyType.PLC);
+
+        assertEquals(" PLC", result);
     }
 
      static Stream<Arguments> companyTypeAndExpectedNameEnding() {

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -69,6 +69,8 @@ class CompanyProfileServiceImplTest {
     public static final String FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY_MUTUALS_PUBLIC_REGISTER = "full-data-available-from-financial-conduct-authority-mutuals-public-register";
     private static final String OVERSEA_COMPANY_NUMBER = "FC001234";
     private static final CompanyType OVERSEA_COMPANY_TYPE = CompanyType.OVERSEA_COMPANY;
+    private static final CompanyType CONVERTED_OR_CLOSED_TYPE = CompanyType.CONVERTED_OR_CLOSED;
+    private static final CompanyType PLC_TYPE = CompanyType.PLC;
 
 
 
@@ -955,4 +957,76 @@ class CompanyProfileServiceImplTest {
                 Arguments.of("GmbH", "GmbH")
         );
     }
+
+    @ParameterizedTest
+    @MethodSource("companyTypeAndExpectedNameEnding")
+    void createSetsExpectedCompanyNameEndingFromCompanyType(CompanyType companyType,
+                                                            String expectedEnding) {
+        spec.setCompanyType(companyType);
+        spec.setCompanyNumber(COMPANY_NUMBER);
+
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(savedProfile);
+
+        companyProfileService.create(spec);
+
+        ArgumentCaptor<CompanyProfile> captor = ArgumentCaptor.forClass(CompanyProfile.class);
+        verify(repository).save(captor.capture());
+        CompanyProfile profile = captor.getValue();
+
+        String expectedName = expectedEnding.isEmpty()
+                ? "COMPANY " + COMPANY_NUMBER
+                : "COMPANY " + COMPANY_NUMBER + " " + expectedEnding;
+
+        assertEquals(expectedName, profile.getCompanyName());
+    }
+
+    @Test
+    void createCompanyTypeWithPlcNameEnding() {
+        spec.setCompanyType(PLC_TYPE);
+        spec.setCompanyNumber(COMPANY_NUMBER);
+
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(savedProfile);
+
+        companyProfileService.create(spec);
+
+        ArgumentCaptor<CompanyProfile> captor = ArgumentCaptor.forClass(CompanyProfile.class);
+        verify(repository).save(captor.capture());
+        CompanyProfile profile = captor.getValue();
+
+        assertEquals("COMPANY " + COMPANY_NUMBER + " PLC", profile.getCompanyName());
+    }
+
+    @Test
+    void createCompanyTypeWithoutNameEnding() {
+        spec.setCompanyType(CONVERTED_OR_CLOSED_TYPE);
+        spec.setCompanyNumber(COMPANY_NUMBER);
+
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(savedProfile);
+
+        companyProfileService.create(spec);
+
+        ArgumentCaptor<CompanyProfile> captor = ArgumentCaptor.forClass(CompanyProfile.class);
+        verify(repository).save(captor.capture());
+        CompanyProfile profile = captor.getValue();
+
+        assertEquals("COMPANY " + COMPANY_NUMBER, profile.getCompanyName());
+    }
+
+     static Stream<Arguments> companyTypeAndExpectedNameEnding() {
+        return Stream.of(
+                Arguments.of(CompanyType.EEIG, "EEIG"),
+                Arguments.of(CompanyType.EUROPEAN_PUBLIC_LIMITED_LIABILITY_COMPANY_SE, "SE"),
+                Arguments.of(CompanyType.ICVC_SECURITIES, "ICVC"),
+                Arguments.of(CompanyType.LIMITED_PARTNERSHIP, "LIMITED PARTNERSHIP"),
+                Arguments.of(CompanyType.LLP, "LIMITED LIABILITY PARTNERSHIP"),
+                Arguments.of(CompanyType.PRIVATE_UNLIMITED, "UNLIMITED"),
+                Arguments.of(CompanyType.PROTECTED_CELL_COMPANY, "PCC LIMITED"),
+                Arguments.of(CompanyType.UKEIG, "UKEIG"),
+                Arguments.of(CompanyType.UNITED_KINGDOM_SOCIETAS, "UK SOCIETAS")
+        );
+    }
+
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -124,7 +124,11 @@ class CompanyProfileServiceImplTest {
                                       String companyType, Boolean hasInsolvencyHistory) {
         assertEquals(COMPANY_NUMBER, profile.getId());
         assertEquals(COMPANY_NUMBER, profile.getCompanyNumber());
-        assertEquals("COMPANY " + COMPANY_NUMBER + " LIMITED", profile.getCompanyName());
+        // Dynamically determine the expected company name ending
+        CompanyType typeEnum = CompanyType.valueOf(companyType.toUpperCase().replace("-", "_"));
+        String ending = uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyNameEnding.fromTypeEnum(typeEnum).getEnding();
+        String expectedCompanyName = "COMPANY " + COMPANY_NUMBER + (ending.isEmpty() ? "" : " " + ending);
+        assertEquals(expectedCompanyName, profile.getCompanyName());
         assertEquals(companyStatus, profile.getCompanyStatus());
         assertEquals(jurisdiction, profile.getJurisdiction());
         assertEquals(companyType.toLowerCase(), profile.getType());
@@ -788,7 +792,7 @@ class CompanyProfileServiceImplTest {
         CompanyProfile savedProfile = captor.getValue();
 
         assertEquals(expectedUkEstablishmentNumber, savedProfile.getCompanyNumber());
-        assertEquals("COMPANY BR123456 LIMITED", savedProfile.getCompanyName());
+        assertEquals("COMPANY BR123456", savedProfile.getCompanyName());
         assertEquals("open", savedProfile.getCompanyStatus());
         assertEquals(CompanyType.UK_ESTABLISHMENT.getValue(), savedProfile.getType());
         assertEquals("/company/" + expectedUkEstablishmentNumber, savedProfile.getLinks().getSelf());


### PR DESCRIPTION
This pull request updates how company name endings are determined and applied throughout the codebase. Instead of using a static " LIMITED" suffix, the company name ending is now dynamically resolved based on the `CompanyType`, improving flexibility and correctness for different company types. The update also includes a version bump for the test data generator library and adjusts related tests to account for the new logic.

**Dynamic company name ending logic:**

* Added a new `getCompanyNameEnding` method in `CompanyProfileServiceImpl` to determine the appropriate company name ending based on the `CompanyType`, using the `CompanyNameEnding` enum. This replaces the previous static suffix approach.
* Updated company name construction in methods such as `createUkEstablishment` and `setCompanyName` to use the new dynamic ending logic instead of the fixed " LIMITED" suffix. [[1]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086L376-R381) [[2]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086L551-R551)
* Removed the static `COMPANY_NAME_SUFFIX` constant from `CompanyProfileServiceImpl` as it is no longer needed.

**Test updates:**

* Modified unit tests in `CompanyProfileServiceImplTest` to dynamically determine the expected company name ending using the same logic as production code, ensuring tests remain accurate and robust. [[1]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3L127-R131) [[2]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3L791-R795)

**Dependency update:**

* Bumped the `test-data-generator-library` version from `1.0.14` to `1.0.16` in `pom.xml`.