### PR TITLE
Add backlog deletion functionality to user cleanup process

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ In order to use the generator, there are different possible endpoints that can b
   - A usage example for creating a company with advanced search: `{ "advanced_search": true }`
   - A usage example for creating a company with disqualified officers: `{ "disqualified_officers": [ { "disqualification_type": "court-order", "is_corporate_officer": false }]}`
 
-- PUT: Sending a PUT request to update Company Profile for a specific company `{Base URL}/test-data/internal` will update a Company Profile entry. The request body must include `company_number` and can include optional `etag` parameter.
+- PUT: Sending a PUT request to update Company Profile for a specific company `{Base URL}/test-data/internal/update-company` will update a Company Profile entry. The request body must include `company_number` and can include optional `etag` parameter.
   - `company_number`: The Company Number of the Company Profile entry in the company_profile db collection. This is mandatory.
   - `etag`: The etag of the Company Profile entry in the company_profile db collection. This is optional.
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>4.0.416</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.16</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.17</test-data-generator-library.version>
 
         <!-- Sonar config -->
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>

--- a/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
@@ -20,6 +20,7 @@ import uk.gov.companieshouse.api.testdata.repository.AcspMembersRepository;
 import uk.gov.companieshouse.api.testdata.repository.AcspProfileRepository;
 import uk.gov.companieshouse.api.testdata.repository.AppealsRepository;
 import uk.gov.companieshouse.api.testdata.repository.AppointmentsRepository;
+import uk.gov.companieshouse.api.testdata.repository.BacklogRepository;
 import uk.gov.companieshouse.api.testdata.repository.BasketRepository;
 import uk.gov.companieshouse.api.testdata.repository.CertificatesRepository;
 import uk.gov.companieshouse.api.testdata.repository.CertifiedCopiesRepository;
@@ -135,6 +136,11 @@ public class MongoConfig {
     @Bean
     public UvidRepository uvidRepository() {
         return getMongoRepositoryBean(UvidRepository.class, IDENTITY_VERIFICATION);
+    }
+
+    @Bean
+    public BacklogRepository backlogRepository() {
+        return getMongoRepositoryBean(BacklogRepository.class, IDENTITY_VERIFICATION);
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/api/testdata/repository/BacklogRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/repository/BacklogRepository.java
@@ -1,0 +1,13 @@
+package uk.gov.companieshouse.api.testdata.repository;
+
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+import uk.gov.companieshouse.api.testdata.model.entity.Backlog;
+
+@NoRepositoryBean
+public interface BacklogRepository extends MongoRepository<Backlog, String> {
+    Optional<Backlog> findByUserId(String userId);
+
+    long deleteByUserId(String userId);
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
@@ -20,9 +20,11 @@ import uk.gov.companieshouse.api.testdata.model.rest.response.UserResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.UserRoles;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UserRequest;
 import uk.gov.companieshouse.api.testdata.repository.AdminPermissionsRepository;
+import uk.gov.companieshouse.api.testdata.repository.BacklogRepository;
 import uk.gov.companieshouse.api.testdata.repository.IdentityRepository;
 import uk.gov.companieshouse.api.testdata.repository.UserRepository;
 import uk.gov.companieshouse.api.testdata.repository.UvidRepository;
+import uk.gov.companieshouse.api.testdata.repository.BacklogRepository;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 import uk.gov.companieshouse.api.testdata.service.UserService;
 import uk.gov.companieshouse.logging.Logger;
@@ -38,17 +40,20 @@ public class UserServiceImpl implements UserService {
     private final RandomService randomService;
     private final IdentityRepository identityRepository;
     private final UvidRepository uvidRepository;
+    private final BacklogRepository backlogRepository;
 
     public UserServiceImpl(UserRepository repository,
                            AdminPermissionsRepository adminPermissionsRepository,
                            RandomService randomService,
                            IdentityRepository identityRepository,
-                           UvidRepository uvidRepository) {
+                           UvidRepository uvidRepository,
+                           BacklogRepository backlogRepository) {
         this.repository = repository;
         this.adminPermissionsRepository = adminPermissionsRepository;
         this.randomService = randomService;
         this.identityRepository = identityRepository;
         this.uvidRepository = uvidRepository;
+        this.backlogRepository = backlogRepository;
     }
 
     @Override
@@ -217,6 +222,16 @@ public class UserServiceImpl implements UserService {
                         + identity.getId() +  ex.getMessage());
                 throw ex;
             }
+
+            try {
+                backlogRepository.deleteByUserId(identity.getUserId());
+                LOG.debug("Deleted backlog for identity id = " + identity.getId());
+            } catch (Exception ex) {
+                LOG.error("Failed to backlog UVIDs for identity id = "
+                        + identity.getId() + ex.getMessage());
+                throw ex;
+            }
+
         } else {
             LOG.debug("No identity associated with userId= " + userId);
         }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
@@ -24,7 +24,6 @@ import uk.gov.companieshouse.api.testdata.repository.BacklogRepository;
 import uk.gov.companieshouse.api.testdata.repository.IdentityRepository;
 import uk.gov.companieshouse.api.testdata.repository.UserRepository;
 import uk.gov.companieshouse.api.testdata.repository.UvidRepository;
-import uk.gov.companieshouse.api.testdata.repository.BacklogRepository;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 import uk.gov.companieshouse.api.testdata.service.UserService;
 import uk.gov.companieshouse.logging.Logger;

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
@@ -226,7 +226,7 @@ public class UserServiceImpl implements UserService {
                 backlogRepository.deleteByUserId(identity.getUserId());
                 LOG.debug("Deleted backlog for identity id = " + identity.getId());
             } catch (Exception ex) {
-                LOG.error("Failed to backlog UVIDs for identity id = "
+                LOG.error("Failed to backlog for identity id = "
                         + identity.getId() + ex.getMessage());
                 throw ex;
             }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImplTest.java
@@ -1092,4 +1092,85 @@ class UserServiceImplTest {
         verify(identityRepository, times(2)).save(any(Identity.class));
         verify(uvidRepository, times(2)).save(any(Uvid.class));
     }
+
+    @Test
+    void testDeleteUser_whenUvidDeletionFails_shouldThrowException() {
+        User mockUser = new User();
+        mockUser.setId(TEST_USER_ID);
+
+        Identity mockIdentity = new Identity();
+        mockIdentity.setId(TEST_IDENTITY_ID);
+        mockIdentity.setUserId(TEST_USER_ID);
+
+        when(userRepository.findById(TEST_USER_ID)).thenReturn(Optional.of(mockUser));
+        when(identityRepository.findByUserId(TEST_USER_ID)).thenReturn(Optional.of(mockIdentity));
+
+        doThrow(new RuntimeException("UVID delete failure"))
+                .when(uvidRepository).deleteByIdentityId(TEST_IDENTITY_ID);
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> userServiceImpl.delete(TEST_USER_ID));
+
+        assertEquals("UVID delete failure", ex.getMessage());
+
+        verify(uvidRepository, times(1)).deleteByIdentityId(TEST_IDENTITY_ID);
+
+        verify(identityRepository, never()).delete(any());
+        verify(backlogRepository, never()).deleteByUserId(anyString());
+        verify(userRepository, never()).delete(any());
+    }
+
+    @Test
+    void testDeleteUser_whenIdentityDeletionFails_shouldThrowException() {
+        User mockUser = new User();
+        mockUser.setId(TEST_USER_ID);
+
+        Identity mockIdentity = new Identity();
+        mockIdentity.setId(TEST_IDENTITY_ID);
+        mockIdentity.setUserId(TEST_USER_ID);
+
+        when(userRepository.findById(TEST_USER_ID)).thenReturn(Optional.of(mockUser));
+        when(identityRepository.findByUserId(TEST_USER_ID)).thenReturn(Optional.of(mockIdentity));
+
+        doThrow(new RuntimeException("Identity delete failure"))
+                .when(identityRepository).delete(mockIdentity);
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> userServiceImpl.delete(TEST_USER_ID));
+
+        assertEquals("Identity delete failure", ex.getMessage());
+
+        verify(uvidRepository, times(1)).deleteByIdentityId(TEST_IDENTITY_ID);
+        verify(identityRepository, times(1)).delete(mockIdentity);
+
+        verify(backlogRepository, never()).deleteByUserId(anyString());
+        verify(userRepository, never()).delete(any());
+    }
+
+    @Test
+    void testDeleteUser_whenBacklogDeletionFails_shouldThrowException() {
+        User mockUser = new User();
+        mockUser.setId(TEST_USER_ID);
+
+        Identity mockIdentity = new Identity();
+        mockIdentity.setId(TEST_IDENTITY_ID);
+        mockIdentity.setUserId(TEST_USER_ID);
+
+        when(userRepository.findById(TEST_USER_ID)).thenReturn(Optional.of(mockUser));
+        when(identityRepository.findByUserId(TEST_USER_ID)).thenReturn(Optional.of(mockIdentity));
+
+        doThrow(new RuntimeException("Backlog delete failure"))
+                .when(backlogRepository).deleteByUserId(TEST_USER_ID);
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> userServiceImpl.delete(TEST_USER_ID));
+
+        assertEquals("Backlog delete failure", ex.getMessage());
+
+        verify(uvidRepository, times(1)).deleteByIdentityId(TEST_IDENTITY_ID);
+        verify(identityRepository, times(1)).delete(mockIdentity);
+        verify(backlogRepository, times(1)).deleteByUserId(TEST_USER_ID);
+
+        verify(userRepository, never()).delete(any());
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImplTest.java
@@ -22,6 +22,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.response.UserResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.UserRoles;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UserRequest;
 import uk.gov.companieshouse.api.testdata.repository.AdminPermissionsRepository;
+import uk.gov.companieshouse.api.testdata.repository.BacklogRepository;
 import uk.gov.companieshouse.api.testdata.repository.IdentityRepository;
 import uk.gov.companieshouse.api.testdata.repository.UserRepository;
 import uk.gov.companieshouse.api.testdata.repository.UvidRepository;
@@ -70,6 +71,9 @@ class UserServiceImplTest {
 
     @Mock
     private UvidRepository uvidRepository;
+
+    @Mock
+    private BacklogRepository backlogRepository;
 
     @Mock
     private RandomService randomService;


### PR DESCRIPTION
## Description
This PR adds functionality to delete backlog records for users when they are removed from the system. It completes the user deletion process by ensuring that backlog identities are properly cleaned up.

## Changes
- **BacklogRepository**: New Spring Data MongoDB repository interface for managing backlog records
  - `findByUserId()`: Retrieve backlog records by user ID
  - `deleteByUserId()`: Delete all backlog records for a given user

- **MongoConfig**: Registered `BacklogRepository` as a MongoDB repository bean for the identity verification database

- **UserServiceImpl**: Enhanced user deletion logic to clean up backlog records during user removal
  - Catches and logs any deletion errors
  - Maintains consistency with existing UVID deletion patterns

- **Documentation**: Updated README.md with correct endpoint path for company profile updates

- **Dependencies**: Bumped `test-data-generator-library` from 1.0.16 to 1.0.17 to support new backlog functionality

## Type of Change
- ✅ New feature (non-breaking)
- Database cleanup/maintenance functionality

## Related
Completes user cleanup by removing all associated backlog records when a user is deleted from the system.