### PR TITLE
Add filing history get and delete API endpoints

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -644,7 +644,7 @@ public class TestDataController {
     }
 
     @GetMapping("/internal/company-filing-history")
-    public ResponseEntity<?> getCompanyFilingHistory(
+    public ResponseEntity<Object> getCompanyFilingHistory(
             @RequestParam(value = "companyNumber", required = false) String companyNumber,
             @RequestParam(value = "id", required = false) String companyFilingHistoryId) {
 
@@ -652,8 +652,8 @@ public class TestDataController {
                 (companyFilingHistoryId == null || companyFilingHistoryId.isEmpty())) {
 
             Map<String, Object> error = new HashMap<>();
-            error.put("error", "Either companyNumber or transactionId must be provided");
-            error.put("status", HttpStatus.BAD_REQUEST.value());
+            error.put(ERROR, "Either companyNumber or id must be provided");
+            error.put(STATUS, HttpStatus.BAD_REQUEST.value());
             return ResponseEntity.badRequest().body(error);
         }
 
@@ -683,7 +683,7 @@ public class TestDataController {
     }
 
     @DeleteMapping("/internal/company-filing-history/{companyNumber}")
-    public ResponseEntity<?> deleteCompanyFilingHistory(
+    public ResponseEntity<Object> deleteCompanyFilingHistory(
             @PathVariable String companyNumber) throws NoDataFoundException {
 
         boolean deleted = filingHistoryService.deleteCompanyFilingHistory(companyNumber);
@@ -693,7 +693,7 @@ public class TestDataController {
         } else {
             Map<String, Object> response = new HashMap<>();
             response.put("companyNumber", companyNumber);
-            response.put("status", HttpStatus.NOT_FOUND.value());
+            response.put(STATUS, HttpStatus.NOT_FOUND.value());
 
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
         }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.api.testdata.controller;
 import jakarta.validation.Valid;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -24,6 +25,7 @@ import uk.gov.companieshouse.api.testdata.exception.InvalidAuthCodeException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
+import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
 import uk.gov.companieshouse.api.testdata.model.rest.request.PenaltyDeleteRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.PenaltyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateCompanyRequest;
@@ -57,6 +59,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.request.UserCompanyAssociat
 import uk.gov.companieshouse.api.testdata.model.rest.response.UserResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UserRequest;
 import uk.gov.companieshouse.api.testdata.service.CompanyAuthCodeService;
+import uk.gov.companieshouse.api.testdata.service.FilingHistoryService;
 import uk.gov.companieshouse.api.testdata.service.TestDataService;
 import uk.gov.companieshouse.api.testdata.service.VerifiedIdentityService;
 import uk.gov.companieshouse.logging.Logger;
@@ -78,14 +81,17 @@ public class TestDataController {
     private static final String NEW_COMPANY_CREATED = "New company created";
 
     private final VerifiedIdentityService<IdentityVerificationResponse> verifiedIdentityService;
+    private final FilingHistoryService filingHistoryService;
 
     public TestDataController(
             TestDataService testDataService,
             CompanyAuthCodeService companyAuthCodeService,
-            VerifiedIdentityService<IdentityVerificationResponse> verifiedIdentityService) {
+            VerifiedIdentityService<IdentityVerificationResponse> verifiedIdentityService,
+            FilingHistoryService filingHistoryService) {
         this.testDataService = testDataService;
         this.companyAuthCodeService = companyAuthCodeService;
         this.verifiedIdentityService = verifiedIdentityService;
+        this.filingHistoryService = filingHistoryService;
     }
 
     /* Public endpoint to create company data */
@@ -634,6 +640,62 @@ public class TestDataController {
             response.put(STATUS, HttpStatus.NOT_FOUND);
             LOG.info("Item Groups Not Found", response);
             return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @GetMapping("/internal/company-filing-history")
+    public ResponseEntity<?> getCompanyFilingHistory(
+            @RequestParam(value = "companyNumber", required = false) String companyNumber,
+            @RequestParam(value = "id", required = false) String companyFilingHistoryId) {
+
+        if ((companyNumber == null || companyNumber.isEmpty()) &&
+                (companyFilingHistoryId == null || companyFilingHistoryId.isEmpty())) {
+
+            Map<String, Object> error = new HashMap<>();
+            error.put("error", "Either companyNumber or transactionId must be provided");
+            error.put("status", HttpStatus.BAD_REQUEST.value());
+            return ResponseEntity.badRequest().body(error);
+        }
+
+        if (companyNumber != null && !companyNumber.isEmpty()) {
+
+            List<FilingHistory> results =
+                    filingHistoryService.getCompanyFilingHistoryByCompanyNumber(companyNumber);
+
+            if (results.isEmpty()) {
+                return ResponseEntity.notFound().build();
+            }
+
+            return ResponseEntity.ok(results);
+
+        } else {
+
+            Optional<FilingHistory> result =
+                    filingHistoryService.getCompanyFilingHistoryById(companyFilingHistoryId);
+
+            if (result.isEmpty()) {
+                return ResponseEntity.notFound().build();
+            }
+
+            return ResponseEntity.ok(result.get());
+        }
+
+    }
+
+    @DeleteMapping("/internal/company-filing-history/{companyNumber}")
+    public ResponseEntity<?> deleteCompanyFilingHistory(
+            @PathVariable String companyNumber) throws NoDataFoundException {
+
+        boolean deleted = filingHistoryService.deleteCompanyFilingHistory(companyNumber);
+
+        if (deleted) {
+            return ResponseEntity.noContent().build();
+        } else {
+            Map<String, Object> response = new HashMap<>();
+            response.put("companyNumber", companyNumber);
+            response.put("status", HttpStatus.NOT_FOUND.value());
+
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/FilingHistoryService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/FilingHistoryService.java
@@ -1,0 +1,37 @@
+package uk.gov.companieshouse.api.testdata.service;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
+import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
+
+public interface FilingHistoryService {
+    /**
+     * Retrieves company filing histories for a given company number.
+     *
+     * @param companyNumber the company number which to retrieve filing histories for
+     * @return FilingHistory object containing the filing histories for the specified company number
+     */
+    List<FilingHistory> getCompanyFilingHistoryByCompanyNumber(String companyNumber);
+
+    /**
+     * Retrieves company filing history for a given id.
+     *
+     * @param id the id which to retrieve filing historu for
+     * @return FilingHistory object containing the filing history for the specified id
+     */
+    Optional<FilingHistory> getCompanyFilingHistoryById(String id);
+
+    /**
+     * Deletes a filing history by its company number.
+     *
+     * @param companyNumber the company number
+     * @return the {@link ResponseEntity} with the HTTP status
+     * @throws NoDataFoundException if the filing history cannot be found
+     * @throws DataException        if the filing history failed to be deleted
+     */
+    boolean deleteCompanyFilingHistory(String companyNumber)
+            throws NoDataFoundException;
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImpl.java
@@ -38,12 +38,13 @@ import uk.gov.companieshouse.api.testdata.model.rest.request.ResolutionsRequest;
 import uk.gov.companieshouse.api.testdata.repository.FilingHistoryRepository;
 import uk.gov.companieshouse.api.testdata.service.BarcodeService;
 import uk.gov.companieshouse.api.testdata.service.DataService;
+import uk.gov.companieshouse.api.testdata.service.FilingHistoryService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Service
-public class FilingHistoryServiceImpl implements DataService<FilingHistory, CompanyRequest> {
+public class FilingHistoryServiceImpl implements FilingHistoryService, DataService<FilingHistory, CompanyRequest> {
     private static final int SALT_LENGTH = 8;
     private static final int ENTITY_ID_LENGTH = 9;
     private static final String ENTITY_ID_PREFIX = "8";
@@ -310,5 +311,24 @@ public class FilingHistoryServiceImpl implements DataService<FilingHistory, Comp
         } else {
             return Collections.emptyList();
         }
+    }
+
+    public Optional<FilingHistory> getFilingHistoryById(String id) {
+        return filingHistoryRepository.findById(id);
+    }
+
+    @Override
+    public List<FilingHistory> getCompanyFilingHistoryByCompanyNumber(String companyNumber) {
+        return getFilingHistories(companyNumber);
+    }
+
+    @Override
+    public Optional<FilingHistory> getCompanyFilingHistoryById(String id) {
+        return getFilingHistoryById(id);
+    }
+
+    @Override
+    public boolean deleteCompanyFilingHistory(String companyNumber) {
+        return delete(companyNumber);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
@@ -36,6 +36,7 @@ import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyAuthCode;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
+import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AcspProfileRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AdminPermissionsRequest;
@@ -74,6 +75,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.response.UserCompanyAssocia
 import uk.gov.companieshouse.api.testdata.model.rest.response.UserResponse;
 import uk.gov.companieshouse.api.testdata.service.AccountPenaltiesService;
 import uk.gov.companieshouse.api.testdata.service.CompanyAuthCodeService;
+import uk.gov.companieshouse.api.testdata.service.FilingHistoryService;
 import uk.gov.companieshouse.api.testdata.service.TestDataService;
 import uk.gov.companieshouse.api.testdata.service.VerifiedIdentityService;
 
@@ -103,7 +105,7 @@ class TestDataControllerTest {
     private TestDataController testDataController;
 
     @Mock
-    private AccountPenaltiesService accountPenaltiesService;
+    private FilingHistoryService filingHistoryService;
 
     @Mock
     private VerifiedIdentityService<IdentityVerificationResponse> verifiedIdentityService;
@@ -1706,5 +1708,127 @@ class TestDataControllerTest {
         verify(testDataService).deleteItemGroupsData(orderNumber);
     }
 
+    @Test
+    void getCompanyFilingHistoryNoParamsReturnsBadRequest() {
+        ResponseEntity<Object> response =
+                testDataController.getCompanyFilingHistory(null, null);
 
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertNotNull(body);
+        assertEquals("Either companyNumber or id must be provided", body.get("error"));
+        assertEquals(HttpStatus.BAD_REQUEST.value(), body.get("status"));
+    }
+
+    @Test
+    void getCompanyFilingHistoryByCompanyNumberFound() {
+        String companyNumber = "12345678";
+
+        FilingHistory filingHistory = new FilingHistory();
+        List<FilingHistory> results = List.of(filingHistory);
+
+        when(filingHistoryService.getCompanyFilingHistoryByCompanyNumber(companyNumber))
+                .thenReturn(results);
+
+        ResponseEntity<?> response =
+                testDataController.getCompanyFilingHistory(companyNumber, null);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(results, response.getBody());
+
+        verify(filingHistoryService, times(1))
+                .getCompanyFilingHistoryByCompanyNumber(companyNumber);
+    }
+
+    @Test
+    void getCompanyFilingHistoryByCompanyNumberNotFound() {
+        String companyNumber = "12345678";
+
+        when(filingHistoryService.getCompanyFilingHistoryByCompanyNumber(companyNumber))
+                .thenReturn(Collections.emptyList());
+
+        ResponseEntity<?> response =
+                testDataController.getCompanyFilingHistory(companyNumber, null);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertNull(response.getBody());
+
+        verify(filingHistoryService, times(1))
+                .getCompanyFilingHistoryByCompanyNumber(companyNumber);
+    }
+
+    @Test
+    void getCompanyFilingHistoryByIdFound() {
+        String filingHistoryId = "FH123";
+
+        FilingHistory fh = new FilingHistory();
+
+        when(filingHistoryService.getCompanyFilingHistoryById(filingHistoryId))
+                .thenReturn(Optional.of(fh));
+
+        ResponseEntity<?> response =
+                testDataController.getCompanyFilingHistory(null, filingHistoryId);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(fh, response.getBody());
+
+        verify(filingHistoryService, times(1))
+                .getCompanyFilingHistoryById(filingHistoryId);
+    }
+
+    @Test
+    void getCompanyFilingHistoryByIdNotFound() {
+        String filingHistoryId = "FH123";
+
+        when(filingHistoryService.getCompanyFilingHistoryById(filingHistoryId))
+                .thenReturn(Optional.empty());
+
+        ResponseEntity<?> response =
+                testDataController.getCompanyFilingHistory(null, filingHistoryId);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertNull(response.getBody());
+
+        verify(filingHistoryService, times(1))
+                .getCompanyFilingHistoryById(filingHistoryId);
+    }
+
+    @Test
+    void deleteCompanyFilingHistorySuccess() throws Exception {
+        String companyNumber = "12345678";
+
+        when(filingHistoryService.deleteCompanyFilingHistory(companyNumber))
+                .thenReturn(true);
+
+        ResponseEntity<?> response =
+                testDataController.deleteCompanyFilingHistory(companyNumber);
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        assertNull(response.getBody());
+
+        verify(filingHistoryService, times(1))
+                .deleteCompanyFilingHistory(companyNumber);
+    }
+
+    @Test
+    void deleteCompanyFilingHistoryNotFound() throws Exception {
+        String companyNumber = "12345678";
+
+        when(filingHistoryService.deleteCompanyFilingHistory(companyNumber))
+                .thenReturn(false);
+
+        ResponseEntity<?> response =
+                testDataController.deleteCompanyFilingHistory(companyNumber);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertNotNull(body);
+        assertEquals(companyNumber, body.get("companyNumber"));
+        assertEquals(HttpStatus.NOT_FOUND.value(), body.get("status"));
+
+        verify(filingHistoryService, times(1))
+                .deleteCompanyFilingHistory(companyNumber);
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/FilingHistoryServiceImplTest.java
@@ -839,4 +839,60 @@ class FilingHistoryServiceImplTest {
         assertEquals(BARCODE, result.getBarcode());
         verify(filingHistoryRepository, never()).save(any());
     }
+
+    @Test
+    void getCompanyFilingHistoryByCompanyNumberDelegatesToGetFilingHistories() {
+        FilingHistory filingHistory = new FilingHistory();
+        List<FilingHistory> expected = List.of(filingHistory);
+
+        when(filingHistoryRepository.findAllByCompanyNumber(COMPANY_NUMBER))
+                .thenReturn(Optional.of(expected));
+
+        List<FilingHistory> result =
+                filingHistoryService.getCompanyFilingHistoryByCompanyNumber(COMPANY_NUMBER);
+
+        assertEquals(expected, result);
+        verify(filingHistoryRepository).findAllByCompanyNumber(COMPANY_NUMBER);
+    }
+
+    @Test
+    void getCompanyFilingHistoryByIdDelegatesToGetFilingHistoryById() {
+        FilingHistory filingHistory = new FilingHistory();
+
+        when(filingHistoryRepository.findById(TEST_ID))
+                .thenReturn(Optional.of(filingHistory));
+
+        Optional<FilingHistory> result =
+                filingHistoryService.getCompanyFilingHistoryById(TEST_ID);
+
+        assertTrue(result.isPresent());
+        assertEquals(filingHistory, result.get());
+        verify(filingHistoryRepository).findById(TEST_ID);
+    }
+
+    @Test
+    void deleteCompanyFilingHistoryDelegatesToDeleteAndReturnsTrue() {
+        FilingHistory filingHistory = new FilingHistory();
+
+        when(filingHistoryRepository.findAllByCompanyNumber(COMPANY_NUMBER))
+                .thenReturn(Optional.of(List.of(filingHistory)));
+
+        boolean result =
+                filingHistoryService.deleteCompanyFilingHistory(COMPANY_NUMBER);
+
+        assertTrue(result);
+        verify(filingHistoryRepository).delete(filingHistory);
+    }
+
+    @Test
+    void deleteCompanyFilingHistoryDelegatesToDeleteAndReturnsFalse() {
+        when(filingHistoryRepository.findAllByCompanyNumber(COMPANY_NUMBER))
+                .thenReturn(Optional.empty());
+
+        boolean result =
+                filingHistoryService.deleteCompanyFilingHistory(COMPANY_NUMBER);
+
+        assertFalse(result);
+        verify(filingHistoryRepository, never()).delete(any());
+    }
 }


### PR DESCRIPTION
## Summary
Adds support for getting and deleting filing history through test data generator APIs.

## Changes
- Implements GET endpoint for filing history retrieval
- Implements DELETE endpoint for filing history removal
- Adds corresponding test cases

## Related Issues
https://companieshouse.atlassian.net/browse/TDG-38