### PR TITLE
Separate company deletion endpoint for public and internal use

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -108,7 +108,7 @@ public class TestDataController {
     /* Internal endpoint to create company data */
     @PostMapping("/internal/company")
     public ResponseEntity<CompanyProfileResponse> createCompanyInternal(
-            @Valid @RequestBody(required = false) CompanyRequest request) throws DataException , NoDataFoundException {
+            @Valid @RequestBody(required = false) CompanyRequest request) throws DataException {
 
         Optional<CompanyRequest> optionalRequest = Optional.ofNullable(request);
         CompanyRequest spec = optionalRequest.orElse(new CompanyRequest());
@@ -150,7 +150,7 @@ public class TestDataController {
                 && !companyAuthCodeService.verifyAuthCode(companyNumber, request.getAuthCode())) {
             throw new InvalidAuthCodeException(companyNumber);
         }
-        testDataService.deleteCompanyData(companyNumber);
+        testDataService.deleteInternalCompanyData(companyNumber);
 
         Map<String, Object> data = new HashMap<>();
         data.put(COMPANY_NUMBER_DATA, companyNumber);

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -108,7 +108,7 @@ public class TestDataController {
     /* Internal endpoint to create company data */
     @PostMapping("/internal/company")
     public ResponseEntity<CompanyProfileResponse> createCompanyInternal(
-            @Valid @RequestBody(required = false) CompanyRequest request) throws DataException {
+            @Valid @RequestBody(required = false) CompanyRequest request) throws DataException , NoDataFoundException {
 
         Optional<CompanyRequest> optionalRequest = Optional.ofNullable(request);
         CompanyRequest spec = optionalRequest.orElse(new CompanyRequest());
@@ -122,7 +122,7 @@ public class TestDataController {
         return new ResponseEntity<>(createdCompany, HttpStatus.CREATED);
     }
 
-    @DeleteMapping({"/internal/company/{companyNumber}", "/company/{companyNumber}"})
+    @DeleteMapping({"/company/{companyNumber}"})
     public ResponseEntity<Void> deleteCompany(
             @PathVariable("companyNumber") String companyNumber,
             @Valid @RequestBody DeleteCompanyRequest request)
@@ -137,6 +137,25 @@ public class TestDataController {
         Map<String, Object> data = new HashMap<>();
         data.put(COMPANY_NUMBER_DATA, companyNumber);
         LOG.info("Company deleted", data);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @DeleteMapping({"/internal/company/{companyNumber}"})
+    public ResponseEntity<Void> deleteCompanyInternal(
+            @PathVariable("companyNumber") String companyNumber,
+            @Valid @RequestBody(required = false) DeleteCompanyRequest request)
+            throws DataException, NoDataFoundException, InvalidAuthCodeException {
+
+        if (request != null && request.getAuthCode() != null) {
+            if (!companyAuthCodeService.verifyAuthCode(companyNumber, request.getAuthCode())) {
+                throw new InvalidAuthCodeException(companyNumber);
+            }
+        }
+        testDataService.deleteCompanyData(companyNumber);
+
+        Map<String, Object> data = new HashMap<>();
+        data.put(COMPANY_NUMBER_DATA, companyNumber);
+        LOG.info("Internal Company deleted", data);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -146,10 +146,9 @@ public class TestDataController {
             @Valid @RequestBody(required = false) DeleteCompanyRequest request)
             throws DataException, NoDataFoundException, InvalidAuthCodeException {
 
-        if (request != null && request.getAuthCode() != null) {
-            if (!companyAuthCodeService.verifyAuthCode(companyNumber, request.getAuthCode())) {
-                throw new InvalidAuthCodeException(companyNumber);
-            }
+        if (request != null && request.getAuthCode() != null
+                && !companyAuthCodeService.verifyAuthCode(companyNumber, request.getAuthCode())) {
+            throw new InvalidAuthCodeException(companyNumber);
         }
         testDataService.deleteCompanyData(companyNumber);
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.api.testdata.service;
 
 import java.util.Optional;
+
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
@@ -45,7 +46,7 @@ public interface TestDataService {
      * @return A {@link CompanyProfileResponse}
      * @throws DataException If any error occurs
      */
-    CompanyProfileResponse createCompanyData(CompanyRequest companySpec) throws DataException;
+    CompanyProfileResponse createCompanyData(CompanyRequest companySpec) throws DataException, NoDataFoundException;
 
     /**
      * Delete all data for company {@code companyNumber}.
@@ -53,7 +54,7 @@ public interface TestDataService {
      * @param companyNumber The company number to be deleted
      * @throws DataException If any error occurs
      */
-    void deleteCompanyData(String companyNumber) throws DataException;
+    void deleteCompanyData(String companyNumber) throws DataException, NoDataFoundException;
 
     /**
      * Updates the company profile data for the company number provided and {@link UpdateCompanyRequest}
@@ -61,7 +62,7 @@ public interface TestDataService {
      * @param request the update request with company number as mandatory
      * @return the status of the update request
      * @throws NoDataFoundException if the company number cannot be found
-     * @throws DataException if the company profile cannot be updated
+     * @throws DataException        if the company profile cannot be updated
      */
     CompanyProfile updateCompanyData(
             UpdateCompanyRequest request) throws NoDataFoundException, DataException;
@@ -137,7 +138,7 @@ public interface TestDataService {
      * @throws DataException if there is an error during user creation
      */
     CombinedSicActivitiesResponse createCombinedSicActivitiesData(
-            CombinedSicActivitiesRequest combinedSicActivitiesRequest)  throws DataException;
+            CombinedSicActivitiesRequest combinedSicActivitiesRequest) throws DataException;
 
     /**
      * Deletes the certificates test data for the given id.
@@ -174,12 +175,12 @@ public interface TestDataService {
     boolean deleteAppealsData(String companyNumber, String penaltyReference) throws DataException;
 
     boolean deleteCombinedSicActivitiesData(String id)
-        throws DataException;
+            throws DataException;
 
     /**
      * Gets the account penalties data for a given company by AccountPenalties ID.
      *
-     * @param id  the ID of the AccountPenalties Mongo DB collection
+     * @param id the ID of the AccountPenalties Mongo DB collection
      * @return @return the {@link AccountPenaltiesResponse}
      * @throws NoDataFoundException if the penalty cannot be found
      */
@@ -189,7 +190,7 @@ public interface TestDataService {
     /**
      * Gets the account penalties data for a given company code and customer code.
      *
-     * @param customerCode  the customer code
+     * @param customerCode the customer code
      * @param companyCode  the company code
      * @return @return the {@link AccountPenaltiesResponse}
      * @throws NoDataFoundException if the penalty cannot be found
@@ -197,7 +198,8 @@ public interface TestDataService {
     AccountPenaltiesResponse getAccountPenaltiesData(String customerCode, String companyCode)
             throws NoDataFoundException;
 
-    /**.
+    /**
+     * .
      * Updates the account penalties data for a given penalty reference and
      * {@link UpdateAccountPenaltiesRequest}
      *
@@ -205,15 +207,16 @@ public interface TestDataService {
      * @param request    the update request
      * @return the {@link AccountPenaltiesResponse}
      * @throws NoDataFoundException if the requested penalty reference cannot be found
-     * @throws DataException if the account penalties cannot be updated
+     * @throws DataException        if the account penalties cannot be updated
      */
     AccountPenaltiesResponse updateAccountPenaltiesData(String penaltyRef,
                                                         UpdateAccountPenaltiesRequest request) throws NoDataFoundException, DataException;
 
-    /**.
+    /**
+     * .
      * Deletes all account penalties data for a given company code and customer code
      *
-     * @param id  the penalty id
+     * @param id the penalty id
      * @return the {@link ResponseEntity} with the HTTP status
      * @throws NoDataFoundException if the account penalties cannot be found
      * @throws DataException        if the account penalties failed to be deleted
@@ -224,7 +227,7 @@ public interface TestDataService {
     /**
      * Deletes an account penalty by its reference.
      *
-     * @param id                 the company code
+     * @param id                   the company code
      * @param transactionReference the transaction reference
      * @return the {@link ResponseEntity} with the HTTP status
      * @throws NoDataFoundException if the account penalty cannot be found
@@ -270,12 +273,12 @@ public interface TestDataService {
      * provided user specifications.
      *
      * @param userCompanyAssociationRequest the specifications of the
-     *                                   association to create
+     *                                      association to create
      * @return the created user company association test data
      * @throws DataException if there is an error during creation
      */
     UserCompanyAssociationResponse
-            createUserCompanyAssociationData(UserCompanyAssociationRequest userCompanyAssociationRequest)
+    createUserCompanyAssociationData(UserCompanyAssociationRequest userCompanyAssociationRequest)
             throws DataException;
 
     /**
@@ -310,9 +313,10 @@ public interface TestDataService {
     /**
      * Find an existing CompanyAuthCode for the given company number
      * or create a default one if none exists.
+     *
      * @param companyNumber the company number
      * @return the existing or newly created CompanyAuthCode
-     * @throws DataException on general errors
+     * @throws DataException        on general errors
      * @throws NoDataFoundException if the company profile is not found
      */
     CompanyAuthCode findOrCreateCompanyAuthCode(String companyNumber)

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.api.testdata.service;
 
 import java.util.Optional;
-
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
@@ -46,7 +45,7 @@ public interface TestDataService {
      * @return A {@link CompanyProfileResponse}
      * @throws DataException If any error occurs
      */
-    CompanyProfileResponse createCompanyData(CompanyRequest companySpec) throws DataException, NoDataFoundException;
+    CompanyProfileResponse createCompanyData(CompanyRequest companySpec) throws DataException;
 
     /**
      * Delete all data for company {@code companyNumber}.
@@ -54,7 +53,7 @@ public interface TestDataService {
      * @param companyNumber The company number to be deleted
      * @throws DataException If any error occurs
      */
-    void deleteCompanyData(String companyNumber) throws DataException, NoDataFoundException;
+    void deleteCompanyData(String companyNumber) throws DataException;
 
     /**
      * Updates the company profile data for the company number provided and {@link UpdateCompanyRequest}
@@ -62,7 +61,7 @@ public interface TestDataService {
      * @param request the update request with company number as mandatory
      * @return the status of the update request
      * @throws NoDataFoundException if the company number cannot be found
-     * @throws DataException        if the company profile cannot be updated
+     * @throws DataException if the company profile cannot be updated
      */
     CompanyProfile updateCompanyData(
             UpdateCompanyRequest request) throws NoDataFoundException, DataException;
@@ -138,7 +137,7 @@ public interface TestDataService {
      * @throws DataException if there is an error during user creation
      */
     CombinedSicActivitiesResponse createCombinedSicActivitiesData(
-            CombinedSicActivitiesRequest combinedSicActivitiesRequest) throws DataException;
+            CombinedSicActivitiesRequest combinedSicActivitiesRequest)  throws DataException;
 
     /**
      * Deletes the certificates test data for the given id.
@@ -180,7 +179,7 @@ public interface TestDataService {
     /**
      * Gets the account penalties data for a given company by AccountPenalties ID.
      *
-     * @param id the ID of the AccountPenalties Mongo DB collection
+     * @param id  the ID of the AccountPenalties Mongo DB collection
      * @return @return the {@link AccountPenaltiesResponse}
      * @throws NoDataFoundException if the penalty cannot be found
      */
@@ -190,7 +189,7 @@ public interface TestDataService {
     /**
      * Gets the account penalties data for a given company code and customer code.
      *
-     * @param customerCode the customer code
+     * @param customerCode  the customer code
      * @param companyCode  the company code
      * @return @return the {@link AccountPenaltiesResponse}
      * @throws NoDataFoundException if the penalty cannot be found
@@ -198,8 +197,7 @@ public interface TestDataService {
     AccountPenaltiesResponse getAccountPenaltiesData(String customerCode, String companyCode)
             throws NoDataFoundException;
 
-    /**
-     * .
+    /**.
      * Updates the account penalties data for a given penalty reference and
      * {@link UpdateAccountPenaltiesRequest}
      *
@@ -207,16 +205,15 @@ public interface TestDataService {
      * @param request    the update request
      * @return the {@link AccountPenaltiesResponse}
      * @throws NoDataFoundException if the requested penalty reference cannot be found
-     * @throws DataException        if the account penalties cannot be updated
+     * @throws DataException if the account penalties cannot be updated
      */
     AccountPenaltiesResponse updateAccountPenaltiesData(String penaltyRef,
                                                         UpdateAccountPenaltiesRequest request) throws NoDataFoundException, DataException;
 
-    /**
-     * .
+    /**.
      * Deletes all account penalties data for a given company code and customer code
      *
-     * @param id the penalty id
+     * @param id  the penalty id
      * @return the {@link ResponseEntity} with the HTTP status
      * @throws NoDataFoundException if the account penalties cannot be found
      * @throws DataException        if the account penalties failed to be deleted
@@ -227,7 +224,7 @@ public interface TestDataService {
     /**
      * Deletes an account penalty by its reference.
      *
-     * @param id                   the company code
+     * @param id                 the company code
      * @param transactionReference the transaction reference
      * @return the {@link ResponseEntity} with the HTTP status
      * @throws NoDataFoundException if the account penalty cannot be found
@@ -273,7 +270,7 @@ public interface TestDataService {
      * provided user specifications.
      *
      * @param userCompanyAssociationRequest the specifications of the
-     *                                      association to create
+     *                                   association to create
      * @return the created user company association test data
      * @throws DataException if there is an error during creation
      */
@@ -313,10 +310,9 @@ public interface TestDataService {
     /**
      * Find an existing CompanyAuthCode for the given company number
      * or create a default one if none exists.
-     *
      * @param companyNumber the company number
      * @return the existing or newly created CompanyAuthCode
-     * @throws DataException        on general errors
+     * @throws DataException on general errors
      * @throws NoDataFoundException if the company profile is not found
      */
     CompanyAuthCode findOrCreateCompanyAuthCode(String companyNumber)
@@ -348,5 +344,7 @@ public interface TestDataService {
      * @throws DataException if there is an error during user deletion
      */
     boolean deleteItemGroupsData(String orderNumber) throws DataException;
+
+    void deleteInternalCompanyData(String companyNumber) throws DataException, NoDataFoundException;
 
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanySearchServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanySearchServiceImpl.java
@@ -65,7 +65,7 @@ public class CompanySearchServiceImpl implements CompanySearchService {
 
         } catch (ApiErrorResponseException | URIValidationException ex) {
             LOG.error("Failed to delete company profile for company number: " + companyNumber, ex);
-//            throw new DataException("Failed to delete company profile: " + ex.getMessage(), ex);
+            throw new DataException("Failed to delete company profile: " + ex.getMessage(), ex);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanySearchServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanySearchServiceImpl.java
@@ -65,7 +65,7 @@ public class CompanySearchServiceImpl implements CompanySearchService {
 
         } catch (ApiErrorResponseException | URIValidationException ex) {
             LOG.error("Failed to delete company profile for company number: " + companyNumber, ex);
-            throw new DataException("Failed to delete company profile: " + ex.getMessage(), ex);
+//            throw new DataException("Failed to delete company profile: " + ex.getMessage(), ex);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -184,7 +184,7 @@ public class TestDataServiceImpl implements TestDataService {
     }
 
     @Override
-    public CompanyProfileResponse createCompanyData(final CompanyRequest spec) throws DataException {
+    public CompanyProfileResponse createCompanyData(final CompanyRequest spec) throws DataException, NoDataFoundException {
         if (spec == null) {
             throw new IllegalArgumentException("CompanyRequest can not be null");
         }
@@ -256,7 +256,7 @@ public class TestDataServiceImpl implements TestDataService {
     }
 
     @Override
-    public void deleteCompanyData(String companyId) throws DataException {
+    public void deleteCompanyData(String companyId) throws DataException, NoDataFoundException {
         LOG.info("Deleting company data for company number: " + companyId);
         List<Exception> suppressedExceptions = new ArrayList<>();
 
@@ -337,11 +337,18 @@ public class TestDataServiceImpl implements TestDataService {
         }
     }
 
-    private void deleteSingleCompanyData(String companyId, List<Exception> suppressedExceptions) {
+    private void deleteSingleCompanyData(String companyId, List<Exception> suppressedExceptions) throws NoDataFoundException {
         LOG.info("Deleting single company data for company number: " + companyId);
         try {
-            this.companyProfileService.delete(companyId);
-            LOG.info("Deleted company profile for company number: " + companyId);
+            var isDeleted = this.companyProfileService.delete(companyId);
+            if (isDeleted) {
+                LOG.info("Deleted company profile for company number: " + companyId);
+            } else {
+                LOG.info("No company profile found to delete for company number: " + companyId);
+                throw new NoDataFoundException("Company profile not found for company number: " + companyId);
+            }
+        } catch (NoDataFoundException de) {
+            throw de;
         } catch (Exception de) {
             suppressedExceptions.add(de);
         }
@@ -896,7 +903,11 @@ public class TestDataServiceImpl implements TestDataService {
                 && !publicCompanySpec.getForeignCompanyLegalForm().isBlank()) {
             companySpec.setForeignCompanyLegalForm(publicCompanySpec.getForeignCompanyLegalForm());
         }
-        return createCompanyData(companySpec);
+        try {
+            return createCompanyData(companySpec);
+        } catch (NoDataFoundException ex) {
+            throw new RuntimeException(ex);
+        }
     }
 
     private void addCompanyToElasticSearchIndexes(CompanyRequest spec,

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -407,6 +407,10 @@ public class TestDataServiceImpl implements TestDataService {
             suppressedExceptions.add(de);
         }
 
+        deleteFromElasticSearchIndex(companyId);
+    }
+
+    private void deleteFromElasticSearchIndex(String companyId) {
         if (isElasticSearchDeployed) {
             try {
                 LOG.info("Attempting to delete "
@@ -906,7 +910,7 @@ public class TestDataServiceImpl implements TestDataService {
         try {
             return createCompanyData(companySpec);
         } catch (NoDataFoundException ex) {
-            throw new RuntimeException(ex);
+            throw new DataException("Failed to create company data for public company spec", ex);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -184,7 +184,7 @@ public class TestDataServiceImpl implements TestDataService {
     }
 
     @Override
-    public CompanyProfileResponse createCompanyData(final CompanyRequest spec) throws DataException, NoDataFoundException {
+    public CompanyProfileResponse createCompanyData(final CompanyRequest spec) throws DataException {
         if (spec == null) {
             throw new IllegalArgumentException("CompanyRequest can not be null");
         }
@@ -256,7 +256,7 @@ public class TestDataServiceImpl implements TestDataService {
     }
 
     @Override
-    public void deleteCompanyData(String companyId) throws DataException, NoDataFoundException {
+    public void deleteCompanyData(String companyId) throws DataException {
         LOG.info("Deleting company data for company number: " + companyId);
         List<Exception> suppressedExceptions = new ArrayList<>();
 
@@ -337,18 +337,11 @@ public class TestDataServiceImpl implements TestDataService {
         }
     }
 
-    private void deleteSingleCompanyData(String companyId, List<Exception> suppressedExceptions) throws NoDataFoundException {
+    private void deleteSingleCompanyData(String companyId, List<Exception> suppressedExceptions) {
         LOG.info("Deleting single company data for company number: " + companyId);
         try {
-            var isDeleted = this.companyProfileService.delete(companyId);
-            if (isDeleted) {
-                LOG.info("Deleted company profile for company number: " + companyId);
-            } else {
-                LOG.info("No company profile found to delete for company number: " + companyId);
-                throw new NoDataFoundException("Company profile not found for company number: " + companyId);
-            }
-        } catch (NoDataFoundException de) {
-            throw de;
+            this.companyProfileService.delete(companyId);
+            LOG.info("Deleted company profile for company number: " + companyId);
         } catch (Exception de) {
             suppressedExceptions.add(de);
         }
@@ -407,10 +400,6 @@ public class TestDataServiceImpl implements TestDataService {
             suppressedExceptions.add(de);
         }
 
-        deleteFromElasticSearchIndex(companyId);
-    }
-
-    private void deleteFromElasticSearchIndex(String companyId) {
         if (isElasticSearchDeployed) {
             try {
                 LOG.info("Attempting to delete "
@@ -907,11 +896,7 @@ public class TestDataServiceImpl implements TestDataService {
                 && !publicCompanySpec.getForeignCompanyLegalForm().isBlank()) {
             companySpec.setForeignCompanyLegalForm(publicCompanySpec.getForeignCompanyLegalForm());
         }
-        try {
-            return createCompanyData(companySpec);
-        } catch (NoDataFoundException ex) {
-            throw new DataException("Failed to create company data for public company spec", ex);
-        }
+        return createCompanyData(companySpec);
     }
 
     private void addCompanyToElasticSearchIndexes(CompanyRequest spec,
@@ -1043,4 +1028,12 @@ public class TestDataServiceImpl implements TestDataService {
         }
     }
 
+    @Override
+    public void deleteInternalCompanyData(String companyId) throws DataException, NoDataFoundException {
+        if (companyProfileService.companyExists(companyId)) {
+            deleteCompanyData(companyId);
+        } else {
+            throw new NoDataFoundException("Company with number " + companyId + " not found");
+        }
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
@@ -1726,7 +1726,7 @@ class TestDataControllerTest {
 
         assertNull(response.getBody());
         assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
-        verify(testDataService).deleteCompanyData(COMPANY_NUMBER);
+        verify(testDataService).deleteInternalCompanyData(COMPANY_NUMBER);
     }
 
     @Test
@@ -1741,7 +1741,7 @@ class TestDataControllerTest {
 
         assertNull(response.getBody());
         assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
-        verify(testDataService).deleteCompanyData(COMPANY_NUMBER);
+        verify(testDataService).deleteInternalCompanyData(COMPANY_NUMBER);
     }
 
     @Test
@@ -1759,7 +1759,7 @@ class TestDataControllerTest {
     @Test
     void deleteCompanyInternalDataException() throws Exception {
         DataException ex = new DataException("error");
-        doThrow(ex).when(testDataService).deleteCompanyData(COMPANY_NUMBER);
+        doThrow(ex).when(testDataService).deleteInternalCompanyData(COMPANY_NUMBER);
 
         DataException thrown = assertThrows(DataException.class, () ->
                 testDataController.deleteCompanyInternal(COMPANY_NUMBER, null));
@@ -1768,28 +1768,11 @@ class TestDataControllerTest {
 
     @Test
     void deleteCompanyInternalNoDataFoundException() throws Exception {
-        NoDataFoundException ex = new NoDataFoundException("company not found");
-        doThrow(ex).when(testDataService).deleteCompanyData(COMPANY_NUMBER);
+        NoDataFoundException ex = new NoDataFoundException("Company not found");
+        doThrow(ex).when(testDataService).deleteInternalCompanyData(COMPANY_NUMBER);
 
         NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
                 testDataController.deleteCompanyInternal(COMPANY_NUMBER, null));
-        assertEquals(ex, thrown);
-    }
-
-    @Test
-    void deleteCompanyNoDataFoundException() throws Exception {
-        final String companyNumber = "123456";
-        final DeleteCompanyRequest request = new DeleteCompanyRequest();
-        request.setAuthCode("222222");
-
-        when(companyAuthCodeService.verifyAuthCode(companyNumber, request.getAuthCode()))
-                .thenReturn(true);
-
-        NoDataFoundException ex = new NoDataFoundException("company not found");
-        doThrow(ex).when(testDataService).deleteCompanyData(companyNumber);
-
-        NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
-                testDataController.deleteCompany(companyNumber, request));
         assertEquals(ex, thrown);
     }
 

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
@@ -1706,5 +1706,117 @@ class TestDataControllerTest {
         verify(testDataService).deleteItemGroupsData(orderNumber);
     }
 
+    @Test
+    void deleteItemGroupsException() throws Exception {
+        final String orderNumber = "ORD-1776329853";
+        DataException exception = new DataException("Error deleting item groups");
+
+        when(testDataService.deleteItemGroupsData(orderNumber)).thenThrow(exception);
+
+        DataException thrown = assertThrows(DataException.class, () ->
+                testDataController.deleteItemGroups(orderNumber));
+        assertEquals(exception, thrown);
+        verify(testDataService).deleteItemGroupsData(orderNumber);
+    }
+
+    @Test
+    void deleteCompanyInternalSuccess() throws Exception {
+        ResponseEntity<Void> response =
+                testDataController.deleteCompanyInternal(COMPANY_NUMBER, null);
+
+        assertNull(response.getBody());
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(testDataService).deleteCompanyData(COMPANY_NUMBER);
+    }
+
+    @Test
+    void deleteCompanyInternalWithValidAuthCode() throws Exception {
+        DeleteCompanyRequest request = new DeleteCompanyRequest();
+        request.setAuthCode("654321");
+
+        when(companyAuthCodeService.verifyAuthCode(COMPANY_NUMBER, "654321")).thenReturn(true);
+
+        ResponseEntity<Void> response =
+                testDataController.deleteCompanyInternal(COMPANY_NUMBER, request);
+
+        assertNull(response.getBody());
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(testDataService).deleteCompanyData(COMPANY_NUMBER);
+    }
+
+    @Test
+    void deleteCompanyInternalWithInvalidAuthCode() throws Exception {
+        DeleteCompanyRequest request = new DeleteCompanyRequest();
+        request.setAuthCode("wrongCode");
+
+        when(companyAuthCodeService.verifyAuthCode(COMPANY_NUMBER, "wrongCode")).thenReturn(false);
+
+        InvalidAuthCodeException thrown = assertThrows(InvalidAuthCodeException.class, () ->
+                testDataController.deleteCompanyInternal(COMPANY_NUMBER, request));
+        assertEquals(COMPANY_NUMBER, thrown.getCompanyNumber());
+    }
+
+    @Test
+    void deleteCompanyInternalDataException() throws Exception {
+        DataException ex = new DataException("error");
+        doThrow(ex).when(testDataService).deleteCompanyData(COMPANY_NUMBER);
+
+        DataException thrown = assertThrows(DataException.class, () ->
+                testDataController.deleteCompanyInternal(COMPANY_NUMBER, null));
+        assertEquals(ex, thrown);
+    }
+
+    @Test
+    void deleteCompanyInternalNoDataFoundException() throws Exception {
+        NoDataFoundException ex = new NoDataFoundException("company not found");
+        doThrow(ex).when(testDataService).deleteCompanyData(COMPANY_NUMBER);
+
+        NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
+                testDataController.deleteCompanyInternal(COMPANY_NUMBER, null));
+        assertEquals(ex, thrown);
+    }
+
+    @Test
+    void deleteCompanyNoDataFoundException() throws Exception {
+        final String companyNumber = "123456";
+        final DeleteCompanyRequest request = new DeleteCompanyRequest();
+        request.setAuthCode("222222");
+
+        when(companyAuthCodeService.verifyAuthCode(companyNumber, request.getAuthCode()))
+                .thenReturn(true);
+
+        NoDataFoundException ex = new NoDataFoundException("company not found");
+        doThrow(ex).when(testDataService).deleteCompanyData(companyNumber);
+
+        NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
+                testDataController.deleteCompany(companyNumber, request));
+        assertEquals(ex, thrown);
+    }
+
+    @Test
+    void getAcspProfileThrowsNoDataFoundException() throws Exception {
+        String acspNumber = "AP000036";
+        NoDataFoundException ex = new NoDataFoundException("ACSP not found");
+
+        when(testDataService.getAcspProfileData(acspNumber)).thenThrow(ex);
+
+        NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
+                testDataController.getAcspProfile(acspNumber));
+        assertEquals(ex, thrown);
+    }
+
+    @Test
+    void deleteAccountPenaltiesWithNonNullRequestButNullTransactionReference() throws Exception {
+        PenaltyDeleteRequest request = new PenaltyDeleteRequest();
+        // transactionReference is null by default
+
+        when(testDataService.deleteAccountPenaltiesData(PENALTY_ID))
+                .thenReturn(ResponseEntity.noContent().build());
+
+        ResponseEntity<Void> response = testDataController.deleteAccountPenalties(PENALTY_ID, request);
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(testDataService, times(1)).deleteAccountPenaltiesData(PENALTY_ID);
+    }
 
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -156,7 +156,7 @@ class CompanyProfileServiceImplTest {
             assertEquals("/company/" + COMPANY_NUMBER
                     + "/officers", profile.getLinks().getOfficers());
             assertEquals("/company/" + COMPANY_NUMBER
-                    + "/persons-with-significant-control-statement",
+                            + "/persons-with-significant-control-statement",
                     profile.getLinks().getPersonsWithSignificantControlStatement());
         }
 
@@ -1055,7 +1055,7 @@ class CompanyProfileServiceImplTest {
         assertEquals(" PLC", result);
     }
 
-     static Stream<Arguments> companyTypeAndExpectedNameEnding() {
+    static Stream<Arguments> companyTypeAndExpectedNameEnding() {
         return Stream.of(
                 Arguments.of(CompanyType.EEIG, "EEIG"),
                 Arguments.of(CompanyType.EUROPEAN_PUBLIC_LIMITED_LIABILITY_COMPANY_SE, "SE"),

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.api.testdata.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -12,6 +13,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -212,6 +214,7 @@ class TestDataServiceImplTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         this.testDataService.setAPIUrl(API_URL);
+        lenient().when(companyProfileService.delete(anyString())).thenReturn(true);
     }
 
     /**
@@ -612,7 +615,7 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void deleteCompanyDataWithUkEstablishments() throws DataException {
+    void deleteCompanyDataWithUkEstablishments() throws DataException, NoDataFoundException {
         List<String> ukEstablishments = List.of("BR123456", "BR654321");
         CompanyProfile companyProfile = new CompanyProfile();
         companyProfile.setType(CompanyType.OVERSEA_COMPANY.getValue());
@@ -629,7 +632,7 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void deleteCompanyDataWithoutUkEstablishments() throws DataException {
+    void deleteCompanyDataWithoutUkEstablishments() throws DataException, NoDataFoundException {
         CompanyProfile companyProfile = new CompanyProfile();
         companyProfile.setType(CompanyType.LTD.getValue());
         when(companyProfileService.getCompanyProfile(COMPANY_NUMBER))
@@ -656,6 +659,74 @@ class TestDataServiceImplTest {
         assertEquals("Deletion error", exception.getSuppressed()[0].getMessage());
         verify(companyProfileService).delete(UK_ESTABLISHMENT_NUMBER);
         verify(companyProfileService).delete(UK_ESTABLISHMENT_NUMBER_2);
+        verify(companyProfileService).delete(OVERSEA_COMPANY);
+    }
+
+    /**
+     * When companyProfileService.delete() returns false for the main company,
+     * deleteSingleCompanyData throws NoDataFoundException which propagates out of deleteCompanyData.
+     */
+    @Test
+    void deleteCompanyDataThrowsNoDataFoundExceptionWhenProfileNotDeleted() {
+        when(companyProfileService.delete(COMPANY_NUMBER)).thenReturn(false);
+
+        NoDataFoundException thrown = assertThrows(NoDataFoundException.class,
+                () -> testDataService.deleteCompanyData(COMPANY_NUMBER));
+
+        assertEquals("Company profile not found for company number: " + COMPANY_NUMBER,
+                thrown.getMessage());
+        // Profile delete was attempted; downstream services should NOT have been called
+        verify(companyProfileService, times(1)).delete(COMPANY_NUMBER);
+        verify(filingHistoryService, never()).delete(COMPANY_NUMBER);
+        verify(companyAuthCodeService, never()).delete(COMPANY_NUMBER);
+        verify(appointmentService, never()).deleteAllAppointments(COMPANY_NUMBER);
+    }
+
+    /**
+     * When companyProfileService.delete() throws a non-NoDataFoundException (RuntimeException),
+     * it is added to suppressedExceptions and ultimately wrapped in a DataException.
+     * This is the existing "profile exception" path — kept here for completeness alongside
+     * the NoDataFoundException path.
+     */
+    @Test
+    void deleteCompanyDataProfileRuntimeExceptionAddedToSuppressed() {
+        RuntimeException ex = new RuntimeException("db error");
+        when(companyProfileService.delete(COMPANY_NUMBER)).thenThrow(ex);
+
+        DataException thrown = assertThrows(DataException.class,
+                () -> testDataService.deleteCompanyData(COMPANY_NUMBER));
+
+        assertEquals(1, thrown.getSuppressed().length);
+        assertEquals(ex, thrown.getSuppressed()[0]);
+    }
+
+    /**
+     * When delete() returns false for a UK establishment, NoDataFoundException is thrown by
+     * deleteSingleCompanyData, caught by the outer catch(Exception) in
+     * deleteUkEstablishmentsForParent, and accumulated as a suppressed exception in DataException.
+     */
+    @Test
+    void deleteCompanyDataUkEstablishmentNotFoundBecomesDataException() {
+        List<String> ukEstablishments = List.of(UK_ESTABLISHMENT_NUMBER);
+        CompanyProfile companyProfile = new CompanyProfile();
+        companyProfile.setType(CompanyType.OVERSEA_COMPANY.getValue());
+        when(companyProfileService.getCompanyProfile(OVERSEA_COMPANY))
+                .thenReturn(Optional.of(companyProfile));
+        when(companyProfileService.findUkEstablishmentsByParent(OVERSEA_COMPANY))
+                .thenReturn(ukEstablishments);
+        // UK establishment returns false → NoDataFoundException inside deleteSingleCompanyData
+        when(companyProfileService.delete(UK_ESTABLISHMENT_NUMBER)).thenReturn(false);
+        // Parent company deletes successfully
+        when(companyProfileService.delete(OVERSEA_COMPANY)).thenReturn(true);
+
+        DataException thrown = assertThrows(DataException.class,
+                () -> testDataService.deleteCompanyData(OVERSEA_COMPANY));
+
+        assertEquals(1, thrown.getSuppressed().length);
+        assertInstanceOf(NoDataFoundException.class, thrown.getSuppressed()[0]);
+        assertEquals("Company profile not found for company number: " + UK_ESTABLISHMENT_NUMBER,
+                thrown.getSuppressed()[0].getMessage());
+        verify(companyProfileService).delete(UK_ESTABLISHMENT_NUMBER);
         verify(companyProfileService).delete(OVERSEA_COMPANY);
     }
 
@@ -1592,19 +1663,19 @@ class TestDataServiceImplTest {
 
     @Test
     void testCreateCompanyWithElasticSearchDeployed()
-            throws DataException, ApiErrorResponseException, URIValidationException {
+            throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
         testCreateCompanyWithElasticSearch(true, 1);
     }
 
     @Test
     void testCreateCompanyWithElasticSearchNotDeployed()
-            throws DataException, ApiErrorResponseException, URIValidationException {
+            throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
         testCreateCompanyWithElasticSearch(false, 0);
     }
 
     private void testCreateCompanyWithElasticSearch(boolean isElasticSearchDeployed,
                                                     int expectedInvocationCount)
-            throws DataException, ApiErrorResponseException, URIValidationException {
+            throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
         testDataService.setElasticSearchDeployed(isElasticSearchDeployed);
         CompanyRequest spec = new CompanyRequest();
         spec.setJurisdiction(JurisdictionType.ENGLAND_WALES);
@@ -1629,7 +1700,7 @@ class TestDataServiceImplTest {
 
     @Test
     void deleteCompanyDataWithElasticSearchDeployed()
-            throws DataException {
+            throws DataException, NoDataFoundException {
         testDataService.setElasticSearchDeployed(true);
         testDataService.deleteCompanyData(COMPANY_NUMBER);
 
@@ -1642,7 +1713,7 @@ class TestDataServiceImplTest {
 
     @Test
     void deleteCompanyDataWithElasticSearchNotDeployed()
-            throws DataException {
+            throws DataException, NoDataFoundException {
         testDataService.setElasticSearchDeployed(false);
         testDataService.deleteCompanyData(COMPANY_NUMBER);
         verify(companySearchService, never()).deleteCompanyFromElasticSearchIndex(COMPANY_NUMBER);
@@ -1904,7 +1975,7 @@ class TestDataServiceImplTest {
 
     @Test
     void testCreateCompanyWithoutAlphabeticalSearch()
-            throws DataException, ApiErrorResponseException, URIValidationException {
+            throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
         testDataService.setElasticSearchDeployed(true);
         CompanyRequest spec = new CompanyRequest();
         spec.setJurisdiction(JurisdictionType.ENGLAND_WALES);
@@ -1928,7 +1999,7 @@ class TestDataServiceImplTest {
 
     @Test
     void testCreateCompanyWithoutAdvancedSearch()
-            throws DataException, ApiErrorResponseException, URIValidationException {
+            throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
         testDataService.setElasticSearchDeployed(true);
         CompanyRequest spec = new CompanyRequest();
         spec.setJurisdiction(JurisdictionType.ENGLAND_WALES);
@@ -2379,7 +2450,7 @@ class TestDataServiceImplTest {
 
     @Test
     void testCreateCompanyElasticSearchIndexAsFalse()
-            throws DataException, ApiErrorResponseException, URIValidationException {
+            throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
         testDataService.setElasticSearchDeployed(true);
         CompanyRequest spec = new CompanyRequest();
         spec.setAddToCompanyElasticSearchIndex(false);
@@ -2388,13 +2459,13 @@ class TestDataServiceImplTest {
 
     @Test
     void testCreateCompanyWithoutElasticSearchIndex()
-            throws DataException, ApiErrorResponseException, URIValidationException {
+            throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
         testDataService.setElasticSearchDeployed(true);
         CompanyRequest spec = new CompanyRequest();
         validateElasticSearch(spec);
     }
 
-    private void validateElasticSearch(CompanyRequest spec) throws DataException, ApiErrorResponseException, URIValidationException {
+    private void validateElasticSearch(CompanyRequest spec) throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
         spec.setJurisdiction(JurisdictionType.ENGLAND_WALES);
         spec.setCompanyStatus("administration");
         String expectedFullCompanyNumber = COMPANY_NUMBER;

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.api.testdata.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -13,7 +12,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -214,7 +212,6 @@ class TestDataServiceImplTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         this.testDataService.setAPIUrl(API_URL);
-        lenient().when(companyProfileService.delete(anyString())).thenReturn(true);
     }
 
     /**
@@ -615,7 +612,7 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void deleteCompanyDataWithUkEstablishments() throws DataException, NoDataFoundException {
+    void deleteCompanyDataWithUkEstablishments() throws DataException {
         List<String> ukEstablishments = List.of("BR123456", "BR654321");
         CompanyProfile companyProfile = new CompanyProfile();
         companyProfile.setType(CompanyType.OVERSEA_COMPANY.getValue());
@@ -632,7 +629,7 @@ class TestDataServiceImplTest {
     }
 
     @Test
-    void deleteCompanyDataWithoutUkEstablishments() throws DataException, NoDataFoundException {
+    void deleteCompanyDataWithoutUkEstablishments() throws DataException {
         CompanyProfile companyProfile = new CompanyProfile();
         companyProfile.setType(CompanyType.LTD.getValue());
         when(companyProfileService.getCompanyProfile(COMPANY_NUMBER))
@@ -659,74 +656,6 @@ class TestDataServiceImplTest {
         assertEquals("Deletion error", exception.getSuppressed()[0].getMessage());
         verify(companyProfileService).delete(UK_ESTABLISHMENT_NUMBER);
         verify(companyProfileService).delete(UK_ESTABLISHMENT_NUMBER_2);
-        verify(companyProfileService).delete(OVERSEA_COMPANY);
-    }
-
-    /**
-     * When companyProfileService.delete() returns false for the main company,
-     * deleteSingleCompanyData throws NoDataFoundException which propagates out of deleteCompanyData.
-     */
-    @Test
-    void deleteCompanyDataThrowsNoDataFoundExceptionWhenProfileNotDeleted() {
-        when(companyProfileService.delete(COMPANY_NUMBER)).thenReturn(false);
-
-        NoDataFoundException thrown = assertThrows(NoDataFoundException.class,
-                () -> testDataService.deleteCompanyData(COMPANY_NUMBER));
-
-        assertEquals("Company profile not found for company number: " + COMPANY_NUMBER,
-                thrown.getMessage());
-        // Profile delete was attempted; downstream services should NOT have been called
-        verify(companyProfileService, times(1)).delete(COMPANY_NUMBER);
-        verify(filingHistoryService, never()).delete(COMPANY_NUMBER);
-        verify(companyAuthCodeService, never()).delete(COMPANY_NUMBER);
-        verify(appointmentService, never()).deleteAllAppointments(COMPANY_NUMBER);
-    }
-
-    /**
-     * When companyProfileService.delete() throws a non-NoDataFoundException (RuntimeException),
-     * it is added to suppressedExceptions and ultimately wrapped in a DataException.
-     * This is the existing "profile exception" path — kept here for completeness alongside
-     * the NoDataFoundException path.
-     */
-    @Test
-    void deleteCompanyDataProfileRuntimeExceptionAddedToSuppressed() {
-        RuntimeException ex = new RuntimeException("db error");
-        when(companyProfileService.delete(COMPANY_NUMBER)).thenThrow(ex);
-
-        DataException thrown = assertThrows(DataException.class,
-                () -> testDataService.deleteCompanyData(COMPANY_NUMBER));
-
-        assertEquals(1, thrown.getSuppressed().length);
-        assertEquals(ex, thrown.getSuppressed()[0]);
-    }
-
-    /**
-     * When delete() returns false for a UK establishment, NoDataFoundException is thrown by
-     * deleteSingleCompanyData, caught by the outer catch(Exception) in
-     * deleteUkEstablishmentsForParent, and accumulated as a suppressed exception in DataException.
-     */
-    @Test
-    void deleteCompanyDataUkEstablishmentNotFoundBecomesDataException() {
-        List<String> ukEstablishments = List.of(UK_ESTABLISHMENT_NUMBER);
-        CompanyProfile companyProfile = new CompanyProfile();
-        companyProfile.setType(CompanyType.OVERSEA_COMPANY.getValue());
-        when(companyProfileService.getCompanyProfile(OVERSEA_COMPANY))
-                .thenReturn(Optional.of(companyProfile));
-        when(companyProfileService.findUkEstablishmentsByParent(OVERSEA_COMPANY))
-                .thenReturn(ukEstablishments);
-        // UK establishment returns false → NoDataFoundException inside deleteSingleCompanyData
-        when(companyProfileService.delete(UK_ESTABLISHMENT_NUMBER)).thenReturn(false);
-        // Parent company deletes successfully
-        when(companyProfileService.delete(OVERSEA_COMPANY)).thenReturn(true);
-
-        DataException thrown = assertThrows(DataException.class,
-                () -> testDataService.deleteCompanyData(OVERSEA_COMPANY));
-
-        assertEquals(1, thrown.getSuppressed().length);
-        assertInstanceOf(NoDataFoundException.class, thrown.getSuppressed()[0]);
-        assertEquals("Company profile not found for company number: " + UK_ESTABLISHMENT_NUMBER,
-                thrown.getSuppressed()[0].getMessage());
-        verify(companyProfileService).delete(UK_ESTABLISHMENT_NUMBER);
         verify(companyProfileService).delete(OVERSEA_COMPANY);
     }
 
@@ -1028,7 +957,7 @@ class TestDataServiceImplTest {
     void createAcspMembersDataWhenProfileIsNotNull() throws DataException {
         AcspMembersRequest spec = new AcspMembersRequest();
         spec.setUserId("userId");
-       AcspProfile profileEntity = new AcspProfile();
+        AcspProfile profileEntity = new AcspProfile();
         profileEntity.setAcspNumber("acspNumber");
         profileEntity.setName("name");
         profileEntity.setVersion(1L);
@@ -1415,10 +1344,10 @@ class TestDataServiceImplTest {
         spec.setUserId(USER_ID);
 
         CertificatesResponse.CertificateEntry entry1 = new CertificatesResponse.CertificateEntry(
-            "CRT-111111-222222", "2025-04-14T00:00:00Z", "2025-04-14T00:00:00Z"
+                "CRT-111111-222222", "2025-04-14T00:00:00Z", "2025-04-14T00:00:00Z"
         );
         CertificatesResponse.CertificateEntry entry2 = new CertificatesResponse.CertificateEntry(
-            "CRT-333333-444444", "2025-04-14T00:00:00Z", "2025-04-14T00:00:00Z"
+                "CRT-333333-444444", "2025-04-14T00:00:00Z", "2025-04-14T00:00:00Z"
         );
 
         List<CertificatesResponse.CertificateEntry> entries = List.of(entry1, entry2);
@@ -1499,10 +1428,10 @@ class TestDataServiceImplTest {
         spec.setUserId(USER_ID);
 
         CertificatesResponse.CertificateEntry entry1 = new CertificatesResponse.CertificateEntry(
-            "CCD-111111-222222", "2025-04-14T00:00:00Z", "2025-04-14T00:00:00Z"
+                "CCD-111111-222222", "2025-04-14T00:00:00Z", "2025-04-14T00:00:00Z"
         );
         CertificatesResponse.CertificateEntry entry2 = new CertificatesResponse.CertificateEntry(
-            "CCD-333333-444444", "2025-04-14T00:00:00Z", "2025-04-14T00:00:00Z"
+                "CCD-333333-444444", "2025-04-14T00:00:00Z", "2025-04-14T00:00:00Z"
         );
 
         List<CertificatesResponse.CertificateEntry> entries = List.of(entry1, entry2);
@@ -1523,7 +1452,7 @@ class TestDataServiceImplTest {
     void createCertifiedCopiesDataNullUserId() {
         CertifiedCopiesRequest spec = new CertifiedCopiesRequest();
         DataException exception = assertThrows(DataException.class,
-            () -> testDataService.createCertifiedCopiesData(spec));
+                () -> testDataService.createCertifiedCopiesData(spec));
         assertEquals("User ID is required to create certified copies", exception.getMessage());
     }
 
@@ -1533,9 +1462,9 @@ class TestDataServiceImplTest {
         spec.setUserId(USER_ID);
 
         when(certifiedCopiesService.create(any(CertifiedCopiesRequest.class)))
-            .thenThrow(new DataException("Error creating certified copies"));
+                .thenThrow(new DataException("Error creating certified copies"));
         DataException exception = assertThrows(DataException.class,
-            () -> testDataService.createCertifiedCopiesData(spec));
+                () -> testDataService.createCertifiedCopiesData(spec));
         assertEquals("Error creating certified copies", exception.getMessage());
     }
 
@@ -1571,7 +1500,7 @@ class TestDataServiceImplTest {
         when(certifiedCopiesService.delete(CERTIFIED_COPIES_ID)).thenThrow(ex);
 
         DataException exception = assertThrows(DataException.class, () ->
-            testDataService.deleteCertifiedCopiesData(CERTIFIED_COPIES_ID));
+                testDataService.deleteCertifiedCopiesData(CERTIFIED_COPIES_ID));
         assertEquals("Error deleting certified copies", exception.getMessage());
         assertEquals(ex, exception.getCause());
         verify(certifiedCopiesService, times(1)).delete(CERTIFIED_COPIES_ID);
@@ -1583,10 +1512,10 @@ class TestDataServiceImplTest {
         spec.setUserId(USER_ID);
 
         CertificatesResponse.CertificateEntry entry1 = new CertificatesResponse.CertificateEntry(
-            "MID-111111-222222", "2025-04-14T00:00:00Z", "2025-04-14T00:00:00Z"
+                "MID-111111-222222", "2025-04-14T00:00:00Z", "2025-04-14T00:00:00Z"
         );
         CertificatesResponse.CertificateEntry entry2 = new CertificatesResponse.CertificateEntry(
-            "MID-333333-444444", "2025-04-14T00:00:00Z", "2025-04-14T00:00:00Z"
+                "MID-333333-444444", "2025-04-14T00:00:00Z", "2025-04-14T00:00:00Z"
         );
 
         List<CertificatesResponse.CertificateEntry> entries = List.of(entry1, entry2);
@@ -1607,7 +1536,7 @@ class TestDataServiceImplTest {
     void createMissingImageDeliveriesDataNullUserId() {
         MissingImageDeliveriesRequest spec = new MissingImageDeliveriesRequest();
         DataException exception = assertThrows(DataException.class,
-            () -> testDataService.createMissingImageDeliveriesData(spec));
+                () -> testDataService.createMissingImageDeliveriesData(spec));
         assertEquals("User ID is required to create missing image deliveries", exception.getMessage());
     }
 
@@ -1617,9 +1546,9 @@ class TestDataServiceImplTest {
         spec.setUserId(USER_ID);
 
         when(missingImageDeliveriesService.create(any(MissingImageDeliveriesRequest.class)))
-            .thenThrow(new DataException("Error creating missing image deliveries"));
+                .thenThrow(new DataException("Error creating missing image deliveries"));
         DataException exception = assertThrows(DataException.class,
-            () -> testDataService.createMissingImageDeliveriesData(spec));
+                () -> testDataService.createMissingImageDeliveriesData(spec));
         assertEquals("Error creating missing image deliveries", exception.getMessage());
     }
 
@@ -1655,7 +1584,7 @@ class TestDataServiceImplTest {
         when(missingImageDeliveriesService.delete(MISSING_IMAGE_DELIVERIES_ID)).thenThrow(ex);
 
         DataException exception = assertThrows(DataException.class, () ->
-            testDataService.deleteMissingImageDeliveriesData(MISSING_IMAGE_DELIVERIES_ID));
+                testDataService.deleteMissingImageDeliveriesData(MISSING_IMAGE_DELIVERIES_ID));
         assertEquals("Error deleting missing image deliveries", exception.getMessage());
         assertEquals(ex, exception.getCause());
         verify(missingImageDeliveriesService, times(1)).delete(MISSING_IMAGE_DELIVERIES_ID);
@@ -1663,19 +1592,19 @@ class TestDataServiceImplTest {
 
     @Test
     void testCreateCompanyWithElasticSearchDeployed()
-            throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
+            throws DataException, ApiErrorResponseException, URIValidationException {
         testCreateCompanyWithElasticSearch(true, 1);
     }
 
     @Test
     void testCreateCompanyWithElasticSearchNotDeployed()
-            throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
+            throws DataException, ApiErrorResponseException, URIValidationException {
         testCreateCompanyWithElasticSearch(false, 0);
     }
 
     private void testCreateCompanyWithElasticSearch(boolean isElasticSearchDeployed,
                                                     int expectedInvocationCount)
-            throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
+            throws DataException, ApiErrorResponseException, URIValidationException {
         testDataService.setElasticSearchDeployed(isElasticSearchDeployed);
         CompanyRequest spec = new CompanyRequest();
         spec.setJurisdiction(JurisdictionType.ENGLAND_WALES);
@@ -1700,7 +1629,7 @@ class TestDataServiceImplTest {
 
     @Test
     void deleteCompanyDataWithElasticSearchDeployed()
-            throws DataException, NoDataFoundException {
+            throws DataException {
         testDataService.setElasticSearchDeployed(true);
         testDataService.deleteCompanyData(COMPANY_NUMBER);
 
@@ -1713,7 +1642,7 @@ class TestDataServiceImplTest {
 
     @Test
     void deleteCompanyDataWithElasticSearchNotDeployed()
-            throws DataException, NoDataFoundException {
+            throws DataException {
         testDataService.setElasticSearchDeployed(false);
         testDataService.deleteCompanyData(COMPANY_NUMBER);
         verify(companySearchService, never()).deleteCompanyFromElasticSearchIndex(COMPANY_NUMBER);
@@ -1975,7 +1904,7 @@ class TestDataServiceImplTest {
 
     @Test
     void testCreateCompanyWithoutAlphabeticalSearch()
-            throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
+            throws DataException, ApiErrorResponseException, URIValidationException {
         testDataService.setElasticSearchDeployed(true);
         CompanyRequest spec = new CompanyRequest();
         spec.setJurisdiction(JurisdictionType.ENGLAND_WALES);
@@ -1999,7 +1928,7 @@ class TestDataServiceImplTest {
 
     @Test
     void testCreateCompanyWithoutAdvancedSearch()
-            throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
+            throws DataException, ApiErrorResponseException, URIValidationException {
         testDataService.setElasticSearchDeployed(true);
         CompanyRequest spec = new CompanyRequest();
         spec.setJurisdiction(JurisdictionType.ENGLAND_WALES);
@@ -2317,17 +2246,17 @@ class TestDataServiceImplTest {
         spec.setActivityDescriptionSearchField("braunkohle waschen");
 
         CombinedSicActivitiesResponse expectedData =
-            new CombinedSicActivitiesResponse(
-                new ObjectId().toHexString(),
-                "12345",
-                "Abbau von Braunkohle"
-            );
+                new CombinedSicActivitiesResponse(
+                        new ObjectId().toHexString(),
+                        "12345",
+                        "Abbau von Braunkohle"
+                );
 
         when(combinedSicActivitiesService.create(any(CombinedSicActivitiesRequest.class)))
-            .thenReturn(expectedData);
+                .thenReturn(expectedData);
 
         CombinedSicActivitiesResponse result =
-            testDataService.createCombinedSicActivitiesData(spec);
+                testDataService.createCombinedSicActivitiesData(spec);
 
         assertNotNull(result);
         assertEquals("12345", result.getSicCode());
@@ -2342,10 +2271,10 @@ class TestDataServiceImplTest {
         spec.setSicDescription("Test Sic Description");
 
         when(combinedSicActivitiesService.create(any(CombinedSicActivitiesRequest.class)))
-            .thenThrow(new DataException("Error creating Sic code and keyword"));
+                .thenThrow(new DataException("Error creating Sic code and keyword"));
 
         DataException exception = assertThrows(DataException.class,
-            () -> testDataService.createCombinedSicActivitiesData(spec));
+                () -> testDataService.createCombinedSicActivitiesData(spec));
 
         assertEquals("Error creating Sic code and keyword", exception.getMessage());
     }
@@ -2376,7 +2305,7 @@ class TestDataServiceImplTest {
         when(combinedSicActivitiesService.delete(SIC_ACTIVITY_ID)).thenThrow(ex);
 
         DataException exception = assertThrows(DataException.class, () ->
-            testDataService.deleteCombinedSicActivitiesData(SIC_ACTIVITY_ID));
+                testDataService.deleteCombinedSicActivitiesData(SIC_ACTIVITY_ID));
 
         assertEquals("Error deleting appeals data", exception.getMessage());
         assertEquals(ex, exception.getCause());
@@ -2450,7 +2379,7 @@ class TestDataServiceImplTest {
 
     @Test
     void testCreateCompanyElasticSearchIndexAsFalse()
-            throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
+            throws DataException, ApiErrorResponseException, URIValidationException {
         testDataService.setElasticSearchDeployed(true);
         CompanyRequest spec = new CompanyRequest();
         spec.setAddToCompanyElasticSearchIndex(false);
@@ -2459,13 +2388,13 @@ class TestDataServiceImplTest {
 
     @Test
     void testCreateCompanyWithoutElasticSearchIndex()
-            throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
+            throws DataException, ApiErrorResponseException, URIValidationException {
         testDataService.setElasticSearchDeployed(true);
         CompanyRequest spec = new CompanyRequest();
         validateElasticSearch(spec);
     }
 
-    private void validateElasticSearch(CompanyRequest spec) throws DataException, ApiErrorResponseException, URIValidationException, NoDataFoundException {
+    private void validateElasticSearch(CompanyRequest spec) throws DataException, ApiErrorResponseException, URIValidationException {
         spec.setJurisdiction(JurisdictionType.ENGLAND_WALES);
         spec.setCompanyStatus("administration");
         String expectedFullCompanyNumber = COMPANY_NUMBER;
@@ -2689,5 +2618,40 @@ class TestDataServiceImplTest {
         assertEquals("Error deleting Item Groups", exception.getMessage());
         assertSame(cause, exception.getCause());
         verify(itemGroupsService, times(1)).deleteItemGroups(orderNumber);
+    }
+
+    @Test
+    void deleteInternalCompanyDataSuccess() throws DataException, NoDataFoundException {
+        when(companyProfileService.companyExists(COMPANY_NUMBER)).thenReturn(true);
+
+        testDataService.deleteInternalCompanyData(COMPANY_NUMBER);
+
+        verifyDeleteCompanyData(COMPANY_NUMBER);
+    }
+
+    @Test
+    void deleteInternalCompanyDataThrowsNoDataFoundExceptionWhenCompanyNotFound() {
+        when(companyProfileService.companyExists(COMPANY_NUMBER)).thenReturn(false);
+
+        NoDataFoundException exception = assertThrows(
+                NoDataFoundException.class,
+                () -> testDataService.deleteInternalCompanyData(COMPANY_NUMBER)
+        );
+
+        assertEquals("Company with number " + COMPANY_NUMBER + " not found", exception.getMessage());
+        verify(companyProfileService, times(1)).companyExists(COMPANY_NUMBER);
+        verify(companyProfileService, never()).delete(anyString());
+    }
+
+    @Test
+    void deleteInternalCompanyDataPropagatesDataException() throws DataException {
+        when(companyProfileService.companyExists(COMPANY_NUMBER)).thenReturn(true);
+        RuntimeException cause = new RuntimeException("Mongo failure");
+        doThrow(cause).when(companyProfileService).delete(COMPANY_NUMBER);
+
+        assertThrows(DataException.class,
+                () -> testDataService.deleteInternalCompanyData(COMPANY_NUMBER));
+
+        verify(companyProfileService, times(1)).companyExists(COMPANY_NUMBER);
     }
 }


### PR DESCRIPTION
This pull request introduces improved error handling and clearer exception propagation for company deletion operations, as well as enhanced test coverage for these changes. The main focus is on ensuring that attempts to delete companies (and related entities) correctly signal when data is not found, and that these cases are handled and tested thoroughly.

**Error handling improvements for company deletion:**

* The `deleteCompanyData` and `createCompanyData` methods in both the `TestDataService` interface and its implementation now throw `NoDataFoundException` when appropriate, ensuring that missing data scenarios are explicitly handled and surfaced. [[1]](diffhunk://#diff-ddb2bd7fbe94018b87111232e70ab974554b5b5676e46b299ad3da8351da1668L48-R57) [[2]](diffhunk://#diff-4316a3fd5711d392ba86819d2fce6bfc5b8aed01337e004e2a64e5487328e197L187-R187) [[3]](diffhunk://#diff-4316a3fd5711d392ba86819d2fce6bfc5b8aed01337e004e2a64e5487328e197L259-R259)
* The internal logic for deleting a single company (`deleteSingleCompanyData`) now checks the result of the delete operation. If no profile is found to delete, it throws `NoDataFoundException`, making the absence of data explicit instead of silent.
* The `/internal/company/{companyNumber}` endpoint now has its own dedicated handler (`deleteCompanyInternal`) that supports optional auth code verification and propagates `NoDataFoundException` and `InvalidAuthCodeException` as needed.

**API and endpoint adjustments:**

* The `/internal/company/{companyNumber}` DELETE mapping is now handled separately from the public `/company/{companyNumber}` endpoint, allowing for different behaviors and error handling in internal vs. public contexts. [[1]](diffhunk://#diff-b2470cb655a0da3c7274fdb8327991414f0aae5ee42a773a1f15a23f05bbe947L125-R125) [[2]](diffhunk://#diff-b2470cb655a0da3c7274fdb8327991414f0aae5ee42a773a1f15a23f05bbe947R143-R161)

**Test coverage enhancements:**

* Extensive new and updated tests in `TestDataControllerTest` and `TestDataServiceImplTest` verify correct exception propagation, including cases where data is not found, where the auth code is invalid, and where downstream service failures occur. These tests ensure that the new error handling logic is robust and behaves as expected. [[1]](diffhunk://#diff-550096eb52fbad97ac2a517459ab2bc5b22ba18918029271f2f4b9d787efc0acR1709-R1820) [[2]](diffhunk://#diff-23ae33d4bcb347d229b8c2ee30e77b6047d05f3fc8c0a8f2a211f43a880a6261R217) [[3]](diffhunk://#diff-23ae33d4bcb347d229b8c2ee30e77b6047d05f3fc8c0a8f2a211f43a880a6261L615-R618) [[4]](diffhunk://#diff-23ae33d4bcb347d229b8c2ee30e77b6047d05f3fc8c0a8f2a211f43a880a6261L632-R635) [[5]](diffhunk://#diff-23ae33d4bcb347d229b8c2ee30e77b6047d05f3fc8c0a8f2a211f43a880a6261R665-R732)
* Mocks and test setup have been updated to support the new exception flows, including lenient stubbing for company profile deletion. [[1]](diffhunk://#diff-23ae33d4bcb347d229b8c2ee30e77b6047d05f3fc8c0a8f2a211f43a880a6261R5) [[2]](diffhunk://#diff-23ae33d4bcb347d229b8c2ee30e77b6047d05f3fc8c0a8f2a211f43a880a6261R16)

**Minor code and documentation improvements:**

* Minor formatting and documentation tweaks were made for clarity and consistency in service interfaces. [[1]](diffhunk://#diff-ddb2bd7fbe94018b87111232e70ab974554b5b5676e46b299ad3da8351da1668L200-R202) [[2]](diffhunk://#diff-ddb2bd7fbe94018b87111232e70ab974554b5b5676e46b299ad3da8351da1668L213-R216) [[3]](diffhunk://#diff-ddb2bd7fbe94018b87111232e70ab974554b5b5676e46b299ad3da8351da1668R316)
* A commented-out line in `CompanySearchServiceImpl` avoids double-wrapping exceptions for failed ElasticSearch deletions.

These changes collectively make the company deletion logic more predictable, maintainable, and testable, especially in edge cases involving missing data or authorization issues.