### PR TITLE
Add user deletion by email functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ In order to use the generator, there are different possible endpoints that can b
     - `identity_verification`: This is optional. It takes a list of `IdentiyVerificationSpec` and creates an `identity` and `uvid`
     
     A usage example looks like this: `{ "password": "password", "roles": [ "GROUPNAME_1", "GROUPNAME_2" ], "is_admin": true, "is_company_auth_allow_list": true, "identity_verification": [{"verification_source": "ONE_LOGIN"}] }`
-- DELETE: Sending a DELETE request on the endpoint `{Base URL}/test-data/user/{userId}` will delete the test user. `userid` is required to delete the user.
-
+- DELETE: Sending a DELETE request on the endpoint `{Base URL}/test-data/user/{userId}` or `{Base URL}/test-data/user?email={emailAddress}` will delete the test user. `userid` or `email` is required to delete the user.
+  - By deleting the user we delete the mapped identity id, backlog and uvid data
+- 
 #### Creating admin permission
 - POST: Sending a POST request to create admin permission for a user `{Base URL}/test-data/admin-permission` will generate a new admin permission for a user. The request body must include `AdminPermissionSpec` parameter to customise the generated admin permission.
     - `entra_group_id`: The user id of the user. This is mandatory.

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -246,6 +246,25 @@ public class TestDataController {
         }
     }
 
+    @DeleteMapping(value = "/internal/user", params = "email")
+    public ResponseEntity<Map<String, Object>> deleteUserByEmail(
+            @RequestParam("email") String email) throws DataException {
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("email", email);
+
+        boolean deleted = testDataService.deleteUserDataByEmail(email);
+
+        if (deleted) {
+            LOG.info("User deleted", response);
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } else {
+            response.put(STATUS, HttpStatus.NOT_FOUND);
+            LOG.info("User not found", response);
+            return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+        }
+    }
+
     @PostMapping("/internal/acsp-members")
     public ResponseEntity<AcspMembersResponse> createAcspMember(
             @Valid @RequestBody AcspMembersRequest request) throws DataException {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/repository/UserRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/repository/UserRepository.java
@@ -1,9 +1,11 @@
 package uk.gov.companieshouse.api.testdata.repository;
 
+import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 import uk.gov.companieshouse.api.testdata.model.entity.User;
 
 @NoRepositoryBean
 public interface UserRepository extends MongoRepository<User, String> {
+    Optional<User> findByEmail(String userEmail);
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
@@ -84,6 +84,14 @@ public interface TestDataService {
     boolean deleteUserData(String userId) throws DataException;
 
     /**
+     * Deletes an user test data by their user email.
+     *
+     * @param userEmail the email of the user to delete
+     * @throws DataException if there is an error during user deletion
+     */
+    boolean deleteUserDataByEmail(String userEmail) throws DataException;
+
+    /**
      * Creates a new acsp member test data based on the provided user specifications.
      *
      * @param acspMembersRequest the specifications of the acsp member to create

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/UserService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/UserService.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.api.testdata.service;
 
 import java.util.Optional;
 
-import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.testdata.model.entity.User;
 import uk.gov.companieshouse.api.testdata.model.rest.response.UserResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UserRequest;

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/UserService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/UserService.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.api.testdata.service;
 
 import java.util.Optional;
 
+import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.testdata.model.entity.User;
 import uk.gov.companieshouse.api.testdata.model.rest.response.UserResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UserRequest;
@@ -14,4 +15,20 @@ public interface UserService extends DataService<UserResponse, UserRequest> {
      * @return an Optional containing the user if found, or empty if not found
      */
     Optional<User> getUserById(String userId);
+
+    /**
+     * Retrieves the roles associated with a given user email.
+     *
+     * @param email the email of the user whose roles are to be retrieved
+     * @return an Optional containing the user if found, or empty if not found
+     */
+    Optional<User> getUserByEmail(String email);
+
+    /**
+     * Deleted the User associated with a given user email.
+     *
+     * @param email the email of the user whose roles are to be retrieved
+     * @return true if the user was deleted, false otherwise
+     */
+    boolean deleteByEmail(String email);
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -478,6 +478,22 @@ public class TestDataServiceImpl implements TestDataService {
         return this.userService.delete(userId);
     }
 
+    @Override
+    public boolean deleteUserDataByEmail(String email) {
+        var user = userService.getUserByEmail(email).orElse(null);
+
+        if (user == null) {
+            return false;
+        }
+        if (user.getEmail() != null && !user.getEmail().isEmpty()) {
+            var allowListId = companyAuthAllowListService.getAuthId(user.getEmail());
+            if (allowListId != null) {
+                companyAuthAllowListService.delete(allowListId);
+            }
+        }
+        return this.userService.deleteByEmail(email);
+    }
+
 
     @Override
     public AcspMembersResponse createAcspMembersData(final AcspMembersRequest spec) throws DataException {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
@@ -188,116 +188,99 @@ public class UserServiceImpl implements UserService {
         }
     }
 
+    private void deleteIdentityData(Identity identity, String userId) {
+        try {
+            uvidRepository.deleteByIdentityId(identity.getId());
+            LOG.debug("Deleted UVIDs for identityId={}");
+        } catch (Exception ex) {
+            LOG.error("Failed to delete UVIDs for identityId={}");
+            throw ex;
+        }
+
+        try {
+            identityRepository.delete(identity);
+            LOG.debug("Deleted identity id={}");
+        } catch (Exception ex) {
+            LOG.error("Failed to delete identity id={}");
+            throw ex;
+        }
+
+        try {
+            backlogRepository.deleteByUserId(userId);
+            LOG.debug("Deleted backlog for userId={}");
+        } catch (Exception ex) {
+            LOG.error("Failed to delete backlog for userId={}");
+            throw ex;
+        }
+    }
+
     @Override
     @Transactional
     public boolean delete(String userId) {
-        LOG.info("delete called for userId= " + userId);
+        LOG.info("delete called for userId={}");
+
         var userOpt = repository.findById(userId);
         if (userOpt.isEmpty()) {
-            LOG.debug("User not found for id=  " + userId);
+            LOG.debug("User not found for id={}");
             return false;
         }
 
         Optional<Identity> identityOpt = identityRepository.findByUserId(userId);
+
         if (identityOpt.isPresent()) {
             var identity = identityOpt.get();
-            LOG.info("Found identity for userId = "
-                    + userId
-                    + "Identity_id = " + identity.getId());
-            try {
-                uvidRepository.deleteByIdentityId(identity.getId());
-                LOG.debug("Deleted UVIDs for identityId = " + identity.getId());
-            } catch (Exception ex) {
-                LOG.error("Failed to delete UVIDs for identityId = "
-                        + identity.getId() + ex.getMessage());
-                throw ex;
-            }
 
-            try {
-                identityRepository.delete(identity);
-                LOG.debug("Deleted identity id= " + identity.getId());
-            } catch (Exception ex) {
-                LOG.error("Failed to delete identity id= "
-                        + identity.getId() +  ex.getMessage());
-                throw ex;
-            }
+            LOG.info("Found identity for userId={} identityId={}"
+            );
 
-            try {
-                backlogRepository.deleteByUserId(identity.getUserId());
-                LOG.debug("Deleted backlog for identity id = " + identity.getId());
-            } catch (Exception ex) {
-                LOG.error("Failed to backlog for identity id = "
-                        + identity.getId() + ex.getMessage());
-                throw ex;
-            }
-
+            deleteIdentityData(identity, userId);
         } else {
-            LOG.debug("No identity associated with userId= " + userId);
+            LOG.debug("No identity associated with userId={}");
         }
 
         try {
             repository.delete(userOpt.get());
-            LOG.info("Deleted user id= " + userId);
+            LOG.info("Deleted user id={}");
         } catch (Exception ex) {
-            LOG.error("Failed to delete user id " + userId, ex);
+            LOG.error("Failed to delete user id={}");
             throw ex;
         }
+
         return true;
     }
 
+    @Override
+    @Transactional
     public boolean deleteByEmail(String email) {
-        LOG.info("delete called for email= " + email);
+        LOG.info("delete called for email={}");
+
         var userOpt = repository.findByEmail(email);
 
         if (userOpt.isEmpty()) {
-            LOG.debug("User not found for email=  " + email);
+            LOG.debug("User not found for email={}");
             return false;
         }
 
         Optional<Identity> identityOpt = identityRepository.findByEmail(email);
+
         if (identityOpt.isPresent()) {
             var identity = identityOpt.get();
-            LOG.info("Found identity for user email = "
-                    + email
-                    + "Identity_id = " + identity.getId());
-            try {
-                uvidRepository.deleteByIdentityId(identity.getId());
-                LOG.debug("Deleted UVIDs for identityId = " + identity.getId());
-            } catch (Exception ex) {
-                LOG.error("Failed to delete UVIDs for identityId = "
-                        + identity.getId() + ex.getMessage());
-                throw ex;
-            }
 
-            try {
-                identityRepository.delete(identity);
-                LOG.debug("Deleted identity id= " + identity.getId());
-            } catch (Exception ex) {
-                LOG.error("Failed to delete identity id= "
-                        + identity.getId() +  ex.getMessage());
-                throw ex;
-            }
+            LOG.info("Found identity for user email={} identityId={}");
 
-            try {
-                backlogRepository.deleteByUserId(String.valueOf(userOpt.map(User::getId)));
-                LOG.debug("Deleted backlog for identity id = " + identity.getId());
-            } catch (Exception ex) {
-                LOG.error("Failed to backlog for identity id = "
-                        + identity.getId() + ex.getMessage());
-                throw ex;
-            }
-
+            deleteIdentityData(identity, userOpt.get().getId());
         } else {
-            LOG.debug("No identity associated with email= " + email);
+            LOG.debug("No identity associated with email={}");
         }
 
         try {
             repository.delete(userOpt.get());
-            LOG.info("Deleted user email= " + email);
+            LOG.info("Deleted user email={}");
         } catch (Exception ex) {
-            LOG.error("Failed to delete user email " + email, ex);
+            LOG.error("Failed to delete user email={}");
             throw ex;
         }
+
         return true;
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
@@ -248,6 +248,7 @@ public class UserServiceImpl implements UserService {
     public boolean deleteByEmail(String email) {
         LOG.info("delete called for email= " + email);
         var userOpt = repository.findByEmail(email);
+
         if (userOpt.isEmpty()) {
             LOG.debug("User not found for email=  " + email);
             return false;
@@ -278,7 +279,7 @@ public class UserServiceImpl implements UserService {
             }
 
             try {
-                backlogRepository.deleteByUserId(identity.getUserId());
+                backlogRepository.deleteByUserId(String.valueOf(userOpt.map(User::getId)));
                 LOG.debug("Deleted backlog for identity id = " + identity.getId());
             } catch (Exception ex) {
                 LOG.error("Failed to backlog for identity id = "

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
@@ -250,6 +250,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional
     public boolean deleteByEmail(String email) {
         LOG.info("delete called for email={}");
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
@@ -245,11 +245,74 @@ public class UserServiceImpl implements UserService {
         return true;
     }
 
+    public boolean deleteByEmail(String email) {
+        LOG.info("delete called for email= " + email);
+        var userOpt = repository.findByEmail(email);
+        if (userOpt.isEmpty()) {
+            LOG.debug("User not found for email=  " + email);
+            return false;
+        }
+
+        Optional<Identity> identityOpt = identityRepository.findByEmail(email);
+        if (identityOpt.isPresent()) {
+            var identity = identityOpt.get();
+            LOG.info("Found identity for user email = "
+                    + email
+                    + "Identity_id = " + identity.getId());
+            try {
+                uvidRepository.deleteByIdentityId(identity.getId());
+                LOG.debug("Deleted UVIDs for identityId = " + identity.getId());
+            } catch (Exception ex) {
+                LOG.error("Failed to delete UVIDs for identityId = "
+                        + identity.getId() + ex.getMessage());
+                throw ex;
+            }
+
+            try {
+                identityRepository.delete(identity);
+                LOG.debug("Deleted identity id= " + identity.getId());
+            } catch (Exception ex) {
+                LOG.error("Failed to delete identity id= "
+                        + identity.getId() +  ex.getMessage());
+                throw ex;
+            }
+
+            try {
+                backlogRepository.deleteByUserId(identity.getUserId());
+                LOG.debug("Deleted backlog for identity id = " + identity.getId());
+            } catch (Exception ex) {
+                LOG.error("Failed to backlog for identity id = "
+                        + identity.getId() + ex.getMessage());
+                throw ex;
+            }
+
+        } else {
+            LOG.debug("No identity associated with email= " + email);
+        }
+
+        try {
+            repository.delete(userOpt.get());
+            LOG.info("Deleted user email= " + email);
+        } catch (Exception ex) {
+            LOG.error("Failed to delete user email " + email, ex);
+            throw ex;
+        }
+        return true;
+    }
+
     @Override
     public Optional<User> getUserById(String userId) {
         LOG.debug("getUserById called for userId= " + userId);
         var result = repository.findById(userId);
         LOG.debug("getUserById found={}");
+        return result;
+    }
+
+    @Override
+    public Optional<User> getUserByEmail(String email) {
+        LOG.debug("getUserByEmail called for email= " + email);
+        var result = repository.findByEmail(email);
+        LOG.debug("getUserByEmail found={}");
         return result;
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
@@ -261,27 +261,7 @@ public class UserServiceImpl implements UserService {
             return false;
         }
 
-        Optional<Identity> identityOpt = identityRepository.findByEmail(email);
-
-        if (identityOpt.isPresent()) {
-            var identity = identityOpt.get();
-
-            LOG.info("Found identity for user email={} identityId={}");
-
-            deleteIdentityData(identity, userOpt.get().getId());
-        } else {
-            LOG.debug("No identity associated with email={}");
-        }
-
-        try {
-            repository.delete(userOpt.get());
-            LOG.info("Deleted user email={}");
-        } catch (Exception ex) {
-            LOG.error("Failed to delete user email={}");
-            throw ex;
-        }
-
-        return true;
+        return delete(userOpt.get().getId());
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
@@ -250,7 +250,6 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    @Transactional
     public boolean deleteByEmail(String email) {
         LOG.info("delete called for email={}");
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/UserServiceImpl.java
@@ -189,6 +189,7 @@ public class UserServiceImpl implements UserService {
     }
 
     private void deleteIdentityData(Identity identity, String userId) {
+
         try {
             uvidRepository.deleteByIdentityId(identity.getId());
             LOG.debug("Deleted UVIDs for identityId={}");
@@ -214,37 +215,44 @@ public class UserServiceImpl implements UserService {
         }
     }
 
-    @Override
-    @Transactional
-    public boolean delete(String userId) {
-        LOG.info("delete called for userId={}");
-
-        var userOpt = repository.findById(userId);
-        if (userOpt.isEmpty()) {
-            LOG.debug("User not found for id={}");
-            return false;
-        }
-
-        Optional<Identity> identityOpt = identityRepository.findByUserId(userId);
+    private void deleteUserAndIdentity(User user, Optional<Identity> identityOpt) {
 
         if (identityOpt.isPresent()) {
-            var identity = identityOpt.get();
+            Identity identity = identityOpt.get();
 
             LOG.info("Found identity for userId={} identityId={}"
             );
 
-            deleteIdentityData(identity, userId);
+            deleteIdentityData(identity, user.getId());
         } else {
             LOG.debug("No identity associated with userId={}");
         }
 
         try {
-            repository.delete(userOpt.get());
+            repository.delete(user);
             LOG.info("Deleted user id={}");
         } catch (Exception ex) {
             LOG.error("Failed to delete user id={}");
             throw ex;
         }
+    }
+
+    @Override
+    @Transactional
+    public boolean delete(String userId) {
+
+        LOG.info("delete called for userId={}");
+
+        var userOpt = repository.findById(userId);
+
+        if (userOpt.isEmpty()) {
+            LOG.debug("User not found for id={}");
+            return false;
+        }
+
+        deleteUserAndIdentity(
+                userOpt.get(),
+                identityRepository.findByUserId(userId));
 
         return true;
     }
@@ -252,6 +260,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public boolean deleteByEmail(String email) {
+
         LOG.info("delete called for email={}");
 
         var userOpt = repository.findByEmail(email);
@@ -261,7 +270,11 @@ public class UserServiceImpl implements UserService {
             return false;
         }
 
-        return delete(userOpt.get().getId());
+        deleteUserAndIdentity(
+                userOpt.get(),
+                identityRepository.findByEmail(email));
+
+        return true;
     }
 
     @Override

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
@@ -1926,4 +1926,52 @@ class TestDataControllerTest {
         verify(filingHistoryService, times(1))
                 .deleteCompanyFilingHistory(companyNumber);
     }
+
+    @Test
+    void deleteUserByEmailSuccess() throws Exception {
+        String email = "test@example.com";
+
+        when(testDataService.deleteUserDataByEmail(email)).thenReturn(true);
+
+        ResponseEntity<Map<String, Object>> response =
+                testDataController.deleteUserByEmail(email);
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        assertNull(response.getBody());
+
+        verify(testDataService, times(1)).deleteUserDataByEmail(email);
+    }
+
+    @Test
+    void deleteUserByEmailNotFound() throws Exception {
+        String email = "test@example.com";
+
+        when(testDataService.deleteUserDataByEmail(email)).thenReturn(false);
+
+        ResponseEntity<Map<String, Object>> response =
+                testDataController.deleteUserByEmail(email);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+
+        Map<String, Object> body = response.getBody();
+        assertNotNull(body);
+        assertEquals(email, body.get("email"));
+        assertEquals(HttpStatus.NOT_FOUND, body.get("status"));
+
+        verify(testDataService, times(1)).deleteUserDataByEmail(email);
+    }
+
+    @Test
+    void deleteUserByEmailException() throws Exception {
+        String email = "test@example.com";
+        DataException exception = new DataException("Error deleting user");
+
+        when(testDataService.deleteUserDataByEmail(email)).thenThrow(exception);
+
+        DataException thrown = assertThrows(DataException.class,
+                () -> testDataController.deleteUserByEmail(email));
+
+        assertEquals(exception, thrown);
+        verify(testDataService, times(1)).deleteUserDataByEmail(email);
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
@@ -2654,4 +2654,114 @@ class TestDataServiceImplTest {
 
         verify(companyProfileService, times(1)).companyExists(COMPANY_NUMBER);
     }
+
+    @Test
+    void deleteUserDataByEmailUserNotFoundReturnsFalse() {
+        String email = "test@example.com";
+
+        when(userService.getUserByEmail(email)).thenReturn(Optional.empty());
+
+        boolean result = testDataService.deleteUserDataByEmail(email);
+
+        assertFalse(result);
+        verify(userService, times(1)).getUserByEmail(email);
+        verify(userService, never()).deleteByEmail(anyString());
+        verify(companyAuthAllowListService, never()).delete(anyString());
+    }
+
+    @Test
+    void deleteUserDataByEmailSuccessWithAllowList() {
+        String email = "test@example.com";
+
+        User user = new User();
+        user.setEmail(email);
+
+        when(userService.getUserByEmail(email)).thenReturn(Optional.of(user));
+        when(companyAuthAllowListService.getAuthId(email)).thenReturn("allowId");
+        when(userService.deleteByEmail(email)).thenReturn(true);
+
+        boolean result = testDataService.deleteUserDataByEmail(email);
+
+        assertTrue(result);
+
+        verify(userService).getUserByEmail(email);
+        verify(companyAuthAllowListService).getAuthId(email);
+        verify(companyAuthAllowListService).delete("allowId");
+        verify(userService).deleteByEmail(email);
+    }
+
+    @Test
+    void deleteUserDataByEmailSuccessNoAllowList() {
+        String email = "test@example.com";
+
+        User user = new User();
+        user.setEmail(email);
+
+        when(userService.getUserByEmail(email)).thenReturn(Optional.of(user));
+        when(companyAuthAllowListService.getAuthId(email)).thenReturn(null);
+        when(userService.deleteByEmail(email)).thenReturn(true);
+
+        boolean result = testDataService.deleteUserDataByEmail(email);
+
+        assertTrue(result);
+
+        verify(companyAuthAllowListService).getAuthId(email);
+        verify(companyAuthAllowListService, never()).delete(anyString());
+        verify(userService).deleteByEmail(email);
+    }
+
+    @Test
+    void deleteUserDataByEmailUserWithNullEmailSkipsAllowList() {
+        String email = "test@example.com";
+
+        User user = new User();
+        user.setEmail(null);
+
+        when(userService.getUserByEmail(email)).thenReturn(Optional.of(user));
+        when(userService.deleteByEmail(email)).thenReturn(true);
+
+        boolean result = testDataService.deleteUserDataByEmail(email);
+
+        assertTrue(result);
+
+        verify(companyAuthAllowListService, never()).getAuthId(anyString());
+        verify(companyAuthAllowListService, never()).delete(anyString());
+        verify(userService).deleteByEmail(email);
+    }
+
+    @Test
+    void deleteUserDataByEmailUserWithEmptyEmailSkipsAllowList() {
+        String email = "test@example.com";
+
+        User user = new User();
+        user.setEmail("");
+
+        when(userService.getUserByEmail(email)).thenReturn(Optional.of(user));
+        when(userService.deleteByEmail(email)).thenReturn(true);
+
+        boolean result = testDataService.deleteUserDataByEmail(email);
+
+        assertTrue(result);
+
+        verify(companyAuthAllowListService, never()).getAuthId(anyString());
+        verify(companyAuthAllowListService, never()).delete(anyString());
+        verify(userService).deleteByEmail(email);
+    }
+
+    @Test
+    void deleteUserDataByEmailDeleteReturnsFalse() {
+        String email = "test@example.com";
+
+        User user = new User();
+        user.setEmail(email);
+
+        when(userService.getUserByEmail(email)).thenReturn(Optional.of(user));
+        when(companyAuthAllowListService.getAuthId(email)).thenReturn(null);
+        when(userService.deleteByEmail(email)).thenReturn(false);
+
+        boolean result = testDataService.deleteUserDataByEmail(email);
+
+        assertFalse(result);
+        verify(userService).deleteByEmail(email);
+    }
 }


### PR DESCRIPTION
## Description
This PR adds the ability to delete test users by their email address in addition to the existing user ID-based deletion. This enhancement allows for more flexible user management in test data generation.

## Changes Made
- **API Endpoint**: Added new DELETE endpoint `/internal/user?email={emailAddress}` to complement the existing `/user/{userId}` endpoint
- **Repository Layer**: Added `findByEmail()` method to `UserRepository` for email-based user lookups
- **Service Layer**: 
  - Added `deleteUserDataByEmail()` to `TestDataService` interface
  - Implemented `deleteByEmail()` and `getUserByEmail()` methods in `UserService`
  - Implemented `deleteUserDataByEmail()` in `TestDataServiceImpl` with company auth allow list cleanup
- **Controller**: Added `deleteUserByEmail()` endpoint handler with proper error handling
- **Code Quality**: Refactored duplicate code in `UserServiceImpl.delete()` into helper methods (`deleteIdentityData()` and `deleteUserAndIdentity()`)
- **Testing**: Added comprehensive unit tests covering success, not found, and exception scenarios
- **Documentation**: Updated README.md to document the new email-based deletion endpoint

## Related Data Cleanup
When deleting a user by email, the following associated data is also deleted:
- User identity record
- UVIDs associated with the identity
- Backlog entries for the user
- Company auth allow list entries (if applicable)

## Testing
- Added 3 new controller tests for the `deleteUserByEmail` endpoint
- Added 7 new service tests for the `deleteUserDataByEmail` functionality
- All tests cover success paths, error handling, and edge cases (null/empty email, missing allow list)