### PR TITLE
refactoring acsp structure

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/AcspMemberController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/AcspMemberController.java
@@ -1,0 +1,68 @@
+package uk.gov.companieshouse.api.testdata.controller;
+
+import jakarta.validation.Valid;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.testdata.Application;
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
+import uk.gov.companieshouse.api.testdata.service.AcspWorkflowService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+
+@RestController
+@RequestMapping(value = "${api.endpoint}/internal", produces = MediaType.APPLICATION_JSON_VALUE)
+public class AcspMemberController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Application.APPLICATION_NAME);
+    private static final String STATUS = "status";
+
+    private final AcspWorkflowService acspWorkflowService;
+
+    public AcspMemberController(AcspWorkflowService acspWorkflowService) {
+        this.acspWorkflowService = acspWorkflowService;
+    }
+
+    @PostMapping("/acsp-members")
+    public ResponseEntity<AcspMembersResponse> createAcspMember(
+            @Valid @RequestBody AcspMembersRequest request) throws DataException {
+
+        var createdAcspMember = acspWorkflowService.createAcspMembersData(request);
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("acsp-member-id", createdAcspMember.getAcspMemberId());
+        LOG.info("New acsp member created", data);
+        return new ResponseEntity<>(createdAcspMember, HttpStatus.CREATED);
+    }
+
+    @DeleteMapping("/acsp-members/{acspMemberId}")
+    public ResponseEntity<Map<String, Object>> deleteAcspMember(@PathVariable("acspMemberId")
+                                                                String acspMemberId)
+            throws DataException {
+        Map<String, Object> response = new HashMap<>();
+        response.put("acsp-member-id", acspMemberId);
+        boolean deleteAcspMember = acspWorkflowService.deleteAcspMembersData(acspMemberId);
+
+        if (deleteAcspMember) {
+            LOG.info("Acsp Member Deleted", response);
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } else {
+            response.put(STATUS, HttpStatus.NOT_FOUND);
+            LOG.info("Acsp Member Not Found", response);
+            return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/AcspProfileController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/AcspProfileController.java
@@ -1,0 +1,40 @@
+package uk.gov.companieshouse.api.testdata.controller;
+
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.testdata.Application;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
+import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
+import uk.gov.companieshouse.api.testdata.service.AcspWorkflowService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@RestController
+@RequestMapping(value = "${api.endpoint}/internal", produces = MediaType.APPLICATION_JSON_VALUE)
+public class AcspProfileController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Application.APPLICATION_NAME);
+    private static final String STATUS = "status";
+
+    private final AcspWorkflowService acspWorkflowService;
+
+    public AcspProfileController(AcspWorkflowService acspWorkflowService) {
+        this.acspWorkflowService = acspWorkflowService;
+    }
+
+    @GetMapping("/acsp-profile/{acspNumber}")
+    public ResponseEntity<Optional<AcspProfile>> getAcspProfile(
+            @PathVariable String acspNumber) throws NoDataFoundException {
+
+        Optional<AcspProfile> acspProfile =
+                acspWorkflowService.getAcspProfileData(acspNumber);
+
+        return new ResponseEntity<>(acspProfile, HttpStatus.OK);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/AcspProfileController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/AcspProfileController.java
@@ -10,16 +10,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
-import uk.gov.companieshouse.api.testdata.service.AcspWorkflowService;
+import uk.gov.companieshouse.api.testdata.service.AcspProfileService;
 
 @RestController
 @RequestMapping(value = "${api.endpoint}/internal", produces = MediaType.APPLICATION_JSON_VALUE)
 public class AcspProfileController {
 
-    private final AcspWorkflowService acspWorkflowService;
+    private final AcspProfileService acspProfileService;
 
-    public AcspProfileController(AcspWorkflowService acspWorkflowService) {
-        this.acspWorkflowService = acspWorkflowService;
+    public AcspProfileController(AcspProfileService acspProfileService) {
+        this.acspProfileService = acspProfileService;
     }
 
     @GetMapping("/acsp-profile/{acspNumber}")
@@ -27,7 +27,7 @@ public class AcspProfileController {
             @PathVariable String acspNumber) throws NoDataFoundException {
 
         Optional<AcspProfile> acspProfile =
-                acspWorkflowService.getAcspProfileData(acspNumber);
+                acspProfileService.getAcspProfile(acspNumber);
 
         return new ResponseEntity<>(acspProfile, HttpStatus.OK);
     }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/AcspProfileController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/AcspProfileController.java
@@ -8,12 +8,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.companieshouse.api.testdata.Application;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
 import uk.gov.companieshouse.api.testdata.service.AcspWorkflowService;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 @RestController
 @RequestMapping(value = "${api.endpoint}/internal", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/AcspProfileController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/AcspProfileController.java
@@ -19,9 +19,6 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 @RequestMapping(value = "${api.endpoint}/internal", produces = MediaType.APPLICATION_JSON_VALUE)
 public class AcspProfileController {
 
-    private static final Logger LOG = LoggerFactory.getLogger(Application.APPLICATION_NAME);
-    private static final String STATUS = "status";
-
     private final AcspWorkflowService acspWorkflowService;
 
     public AcspProfileController(AcspWorkflowService acspWorkflowService) {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/TestDataController.java
@@ -101,18 +101,6 @@ public class TestDataController {
         }
     }
 
-    @PostMapping("/internal/acsp-members")
-    public ResponseEntity<AcspMembersResponse> createAcspMember(
-            @Valid @RequestBody AcspMembersRequest request) throws DataException {
-
-        var createdAcspMember = testDataService.createAcspMembersData(request);
-
-        Map<String, Object> data = new HashMap<>();
-        data.put("acsp-member-id", createdAcspMember.getAcspMemberId());
-        LOG.info("New acsp member created", data);
-        return new ResponseEntity<>(createdAcspMember, HttpStatus.CREATED);
-    }
-
     @PostMapping("/internal/certificates")
     public ResponseEntity<CertificatesResponse> createCertificates(
             @Valid @RequestBody CertificatesRequest request) throws DataException {
@@ -150,24 +138,6 @@ public class TestDataController {
                 createdMissingImageDeliveries.getCertificates().getFirst().getId());
         LOG.info("New missing image deliveries added", data);
         return new ResponseEntity<>(createdMissingImageDeliveries, HttpStatus.CREATED);
-    }
-
-    @DeleteMapping("/internal/acsp-members/{acspMemberId}")
-    public ResponseEntity<Map<String, Object>> deleteAcspMember(@PathVariable("acspMemberId")
-                                                                String acspMemberId)
-            throws DataException {
-        Map<String, Object> response = new HashMap<>();
-        response.put("acsp-member-id", acspMemberId);
-        boolean deleteAcspMember = testDataService.deleteAcspMembersData(acspMemberId);
-
-        if (deleteAcspMember) {
-            LOG.info("Acsp Member Deleted", response);
-            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-        } else {
-            response.put(STATUS, HttpStatus.NOT_FOUND);
-            LOG.info("Acsp Member Not Found", response);
-            return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
-        }
     }
 
     @DeleteMapping("/internal/certificates/{id}")
@@ -332,16 +302,6 @@ public class TestDataController {
         }
         LOG.info("Retrieved postcode for country: " + country + " " + postcode.getPostcode());
         return new ResponseEntity<>(postcode, HttpStatus.OK);
-    }
-
-    @GetMapping("/internal/acsp-profile/{acspNumber}")
-    public ResponseEntity<Optional<AcspProfile>> getAcspProfile(
-            @PathVariable String acspNumber) throws NoDataFoundException {
-
-        Optional<AcspProfile> acspProfile =
-                testDataService.getAcspProfileData(acspNumber);
-
-        return new ResponseEntity<>(acspProfile, HttpStatus.OK);
     }
 
     @PostMapping("/internal/transactions")

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/AcspWorkflowService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/AcspWorkflowService.java
@@ -1,12 +1,8 @@
 package uk.gov.companieshouse.api.testdata.service;
 
-import java.util.Optional;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
-import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
-import uk.gov.companieshouse.api.testdata.model.rest.response.AcspProfileResponse;
 
 public interface AcspWorkflowService {
     /**

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/AcspWorkflowService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/AcspWorkflowService.java
@@ -25,23 +25,4 @@ public interface AcspWorkflowService {
      * @throws DataException if there is an error during user deletion
      */
     boolean deleteAcspMembersData(String acspMemberId) throws DataException;
-
-    /**
-     * Adds a new certificate test data based on the provided user specifications.
-     *
-     * @param certificatesRequest the specifications of the certificates to order
-     * @return the created certificates test data
-     * @throws DataException if there is an error during user creation
-     */
-
-    /**
-     * Gets the ACSP profile data for a given ACSP number.
-     *
-     * @param acspNumber the ACSP number
-     * @return the {@link AcspProfileResponse}
-     * @throws NoDataFoundException if the profile cannot be found
-     */
-    Optional<AcspProfile> getAcspProfileData(String acspNumber)
-            throws NoDataFoundException;
-
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/AcspWorkflowService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/AcspWorkflowService.java
@@ -1,0 +1,47 @@
+package uk.gov.companieshouse.api.testdata.service;
+
+import java.util.Optional;
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
+import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
+import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
+import uk.gov.companieshouse.api.testdata.model.rest.response.AcspProfileResponse;
+
+public interface AcspWorkflowService {
+    /**
+     * Creates a new acsp member test data based on the provided user specifications.
+     *
+     * @param acspMembersRequest the specifications of the acsp member to create
+     * @return the created acsp members' test data
+     * @throws DataException if there is an error during user creation
+     */
+    AcspMembersResponse createAcspMembersData(AcspMembersRequest acspMembersRequest) throws DataException;
+
+    /**
+     * Deletes an acsp members' test data by their membership id.
+     *
+     * @param acspMemberId the ID of the membership to delete
+     * @throws DataException if there is an error during user deletion
+     */
+    boolean deleteAcspMembersData(String acspMemberId) throws DataException;
+
+    /**
+     * Adds a new certificate test data based on the provided user specifications.
+     *
+     * @param certificatesRequest the specifications of the certificates to order
+     * @return the created certificates test data
+     * @throws DataException if there is an error during user creation
+     */
+
+    /**
+     * Gets the ACSP profile data for a given ACSP number.
+     *
+     * @param acspNumber the ACSP number
+     * @return the {@link AcspProfileResponse}
+     * @throws NoDataFoundException if the profile cannot be found
+     */
+    Optional<AcspProfile> getAcspProfileData(String acspNumber)
+            throws NoDataFoundException;
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/TestDataService.java
@@ -27,30 +27,6 @@ import java.util.Optional;
 
 public interface TestDataService {
 
-    /**
-     * Creates a new acsp member test data based on the provided user specifications.
-     *
-     * @param acspMembersRequest the specifications of the acsp member to create
-     * @return the created acsp members' test data
-     * @throws DataException if there is an error during user creation
-     */
-    AcspMembersResponse createAcspMembersData(AcspMembersRequest acspMembersRequest) throws DataException;
-
-    /**
-     * Deletes an acsp members' test data by their membership id.
-     *
-     * @param acspMemberId the ID of the membership to delete
-     * @throws DataException if there is an error during user deletion
-     */
-    boolean deleteAcspMembersData(String acspMemberId) throws DataException;
-
-    /**
-     * Adds a new certificate test data based on the provided user specifications.
-     *
-     * @param certificatesRequest the specifications of the certificates to order
-     * @return the created certificates test data
-     * @throws DataException if there is an error during user creation
-     */
     CertificatesResponse createCertificatesData(CertificatesRequest certificatesRequest) throws DataException;
 
     /**
@@ -188,15 +164,6 @@ public interface TestDataService {
      */
     PostcodesResponse getPostcodes(String country) throws DataException;
 
-    /**
-     * Gets the ACSP profile data for a given ACSP number.
-     *
-     * @param acspNumber the ACSP number
-     * @return the {@link AcspProfileResponse}
-     * @throws NoDataFoundException if the profile cannot be found
-     */
-    Optional<AcspProfile> getAcspProfileData(String acspNumber)
-            throws NoDataFoundException;
 
     /**
      * Adds a new transaction and acsp application test data based on the provided specifications.

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AcspMembersServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/AcspMembersServiceImpl.java
@@ -9,14 +9,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.model.entity.AcspMembers;
-import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
 import uk.gov.companieshouse.api.testdata.repository.AcspMembersRepository;
 import uk.gov.companieshouse.api.testdata.service.DataService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 
 @Service
-public class AcspMembersServiceImpl implements DataService<AcspMembersResponse, AcspMembersRequest> {
+public class AcspMembersServiceImpl implements
+        DataService<AcspMembersResponse, AcspMembersRequest> {
 
     @Autowired
     private AcspMembersRepository repository;

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImpl.java
@@ -1,16 +1,12 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
-import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.testdata.Application;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
-import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.Postcodes;
-import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
-import uk.gov.companieshouse.api.testdata.model.rest.request.AcspProfileRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AdminPermissionsRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CertificatesRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CertifiedCopiesRequest;
@@ -20,16 +16,12 @@ import uk.gov.companieshouse.api.testdata.model.rest.request.PenaltyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.TransactionsRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateAccountPenaltiesRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AccountPenaltiesResponse;
-import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
-import uk.gov.companieshouse.api.testdata.model.rest.response.AcspProfileResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AdminPermissionsResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.CertificatesResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.CombinedSicActivitiesResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.PostcodesResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.TransactionsResponse;
-import uk.gov.companieshouse.api.testdata.repository.AcspMembersRepository;
 import uk.gov.companieshouse.api.testdata.service.AccountPenaltiesService;
-import uk.gov.companieshouse.api.testdata.service.AcspProfileService;
 import uk.gov.companieshouse.api.testdata.service.AppealsService;
 import uk.gov.companieshouse.api.testdata.service.DataService;
 import uk.gov.companieshouse.api.testdata.service.ItemGroupsService;
@@ -41,15 +33,12 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 public class TestDataServiceImpl implements TestDataService {
 
     private static final Logger LOG = LoggerFactory.getLogger(Application.APPLICATION_NAME);
 
-    @Autowired
-    private DataService<AcspMembersResponse, AcspMembersRequest> acspMembersService;
     @Autowired
     private DataService<CertificatesResponse, CertificatesRequest> certificatesService;
     @Autowired
@@ -60,11 +49,7 @@ public class TestDataServiceImpl implements TestDataService {
     @Autowired
     private DataService<CertificatesResponse, MissingImageDeliveriesRequest> missingImageDeliveriesService;
     @Autowired
-    private AcspMembersRepository acspMembersRepository;
-    @Autowired
     private DataService<TransactionsResponse, TransactionsRequest> transactionService;
-    @Autowired
-    private AcspProfileService acspProfileService;
     @Autowired
     AppealsService appealsService;
     @Autowired
@@ -75,78 +60,6 @@ public class TestDataServiceImpl implements TestDataService {
     private DataService<AdminPermissionsResponse, AdminPermissionsRequest> adminPermissionsService;
     @Autowired
     private ItemGroupsService itemGroupsService;
-
-    @Override
-    public AcspMembersResponse createAcspMembersData(final AcspMembersRequest spec) throws DataException {
-        if (spec.getUserId() == null) {
-            throw new DataException("User ID is required to create an ACSP member");
-        }
-
-        var acspProfileSpec = new AcspProfileRequest();
-        if (spec.getAcspProfile() != null) {
-            acspProfileSpec = spec.getAcspProfile();
-        }
-
-        try {
-            var acspProfileData = createAcspProfile(acspProfileSpec);
-            spec.setAcspNumber(acspProfileData.getAcspNumber());
-
-            AcspMembersResponse createdMember = createAcspMember(spec);
-
-            return new AcspMembersResponse(
-                    new ObjectId(createdMember.getAcspMemberId()),
-                    createdMember.getAcspNumber(),
-                    createdMember.getUserId(),
-                    createdMember.getStatus(),
-                    createdMember.getUserRole()
-            );
-        } catch (Exception ex) {
-            throw new DataException(ex);
-        }
-    }
-
-    private AcspProfileResponse createAcspProfile(AcspProfileRequest acspProfileRequest)
-            throws DataException {
-        try {
-            return this.acspProfileService.create(acspProfileRequest);
-        } catch (Exception ex) {
-            throw new DataException("Error creating ACSP profile", ex);
-        }
-    }
-
-    private AcspMembersResponse createAcspMember(AcspMembersRequest spec) throws DataException {
-        try {
-            return this.acspMembersService.create(spec);
-        } catch (Exception ex) {
-            throw new DataException("Error creating ACSP member", ex);
-        }
-    }
-
-    @Override
-    public boolean deleteAcspMembersData(String acspMemberId) throws DataException {
-        List<Exception> suppressedExceptions = new ArrayList<>();
-        try {
-            var maybeMember = acspMembersRepository.findById(acspMemberId);
-            if (maybeMember.isPresent()) {
-                var member = maybeMember.get();
-                String acspNumber = member.getAcspNumber();
-
-                deleteAcspMember(acspMemberId, suppressedExceptions);
-                deleteAcspProfile(acspNumber, suppressedExceptions);
-            } else {
-                return false;
-            }
-        } catch (Exception de) {
-            suppressedExceptions.add(de);
-        }
-
-        if (!suppressedExceptions.isEmpty()) {
-            var ex = new DataException("Error deleting acsp member's data");
-            suppressedExceptions.forEach(ex::addSuppressed);
-            throw ex;
-        }
-        return true;
-    }
 
     @Override
     public CertificatesResponse createCertificatesData(
@@ -352,28 +265,6 @@ public class TestDataServiceImpl implements TestDataService {
             postcodesResponseList.add(postcodeData);
         }
         return postcodesResponseList;
-    }
-
-    public Optional<AcspProfile> getAcspProfileData(String acspNumber)
-            throws NoDataFoundException {
-
-        return acspProfileService.getAcspProfile(acspNumber);
-    }
-
-    private void deleteAcspMember(String acspMemberId, List<Exception> suppressedExceptions) {
-        try {
-            acspMembersService.delete(acspMemberId);
-        } catch (Exception ex) {
-            suppressedExceptions.add(new DataException("Error deleting ACSP member", ex));
-        }
-    }
-
-    private void deleteAcspProfile(String acspNumber, List<Exception> suppressedExceptions) {
-        try {
-            this.acspProfileService.delete(acspNumber);
-        } catch (Exception ex) {
-            suppressedExceptions.add(new DataException("Error deleting ACSP profile", ex));
-        }
     }
 
     public TransactionsResponse createTransactionData(TransactionsRequest transactionsRequest)

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/AcspWorkflowServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/AcspWorkflowServiceImpl.java
@@ -2,13 +2,10 @@ package uk.gov.companieshouse.api.testdata.service.impl.workflow;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import org.bson.types.ObjectId;
 
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
-import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AcspProfileRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
@@ -108,12 +105,6 @@ public class AcspWorkflowServiceImpl implements AcspWorkflowService {
             throw ex;
         }
         return true;
-    }
-
-    public Optional<AcspProfile> getAcspProfileData(String acspNumber)
-            throws NoDataFoundException {
-
-        return acspProfileService.getAcspProfile(acspNumber);
     }
 
     private void deleteAcspProfile(String acspNumber, List<Exception> suppressedExceptions) {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/AcspWorkflowServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/AcspWorkflowServiceImpl.java
@@ -1,0 +1,135 @@
+package uk.gov.companieshouse.api.testdata.service.impl.workflow;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.bson.types.ObjectId;
+
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
+import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
+import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.request.AcspProfileRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
+import uk.gov.companieshouse.api.testdata.model.rest.response.AcspProfileResponse;
+import uk.gov.companieshouse.api.testdata.repository.AcspMembersRepository;
+import uk.gov.companieshouse.api.testdata.service.AcspProfileService;
+import uk.gov.companieshouse.api.testdata.service.AcspWorkflowService;
+import uk.gov.companieshouse.api.testdata.service.DataService;
+
+
+@Service
+public class AcspWorkflowServiceImpl implements AcspWorkflowService {
+
+    private final AcspProfileService acspProfileService;
+
+    private final AcspMembersRepository acspMembersRepository;
+
+    private final DataService<AcspMembersResponse, AcspMembersRequest> acspMembersService;
+
+    public AcspWorkflowServiceImpl(
+            AcspProfileService acspProfileService,
+            AcspMembersRepository acspMembersRepository,
+            DataService<AcspMembersResponse, AcspMembersRequest> acspMembersService) {
+        this.acspProfileService = acspProfileService;
+        this.acspMembersRepository = acspMembersRepository;
+        this.acspMembersService = acspMembersService;
+    }
+
+    @Override
+    public AcspMembersResponse createAcspMembersData(final AcspMembersRequest spec)
+            throws DataException {
+        if (spec.getUserId() == null) {
+            throw new DataException("User ID is required to create an ACSP member");
+        }
+
+        var acspProfileSpec = new AcspProfileRequest();
+        if (spec.getAcspProfile() != null) {
+            acspProfileSpec = spec.getAcspProfile();
+        }
+
+        try {
+            var acspProfileData = createAcspProfile(acspProfileSpec);
+            spec.setAcspNumber(acspProfileData.getAcspNumber());
+
+            AcspMembersResponse createdMember = createAcspMember(spec);
+
+            return new AcspMembersResponse(
+                    new ObjectId(createdMember.getAcspMemberId()),
+                    createdMember.getAcspNumber(),
+                    createdMember.getUserId(),
+                    createdMember.getStatus(),
+                    createdMember.getUserRole()
+            );
+        } catch (Exception ex) {
+            throw new DataException(ex);
+        }
+    }
+
+    private AcspProfileResponse createAcspProfile(AcspProfileRequest acspProfileRequest)
+            throws DataException {
+        try {
+            return this.acspProfileService.create(acspProfileRequest);
+        } catch (Exception ex) {
+            throw new DataException("Error creating ACSP profile", ex);
+        }
+    }
+
+    private AcspMembersResponse createAcspMember(AcspMembersRequest spec) throws DataException {
+        try {
+            return this.acspMembersService.create(spec);
+        } catch (Exception ex) {
+            throw new DataException("Error creating ACSP member", ex);
+        }
+    }
+
+    @Override
+    public boolean deleteAcspMembersData(String acspMemberId) throws DataException {
+        List<Exception> suppressedExceptions = new ArrayList<>();
+        try {
+            var maybeMember = acspMembersRepository.findById(acspMemberId);
+            if (maybeMember.isPresent()) {
+                var member = maybeMember.get();
+                String acspNumber = member.getAcspNumber();
+
+                deleteAcspMember(acspMemberId, suppressedExceptions);
+                deleteAcspProfile(acspNumber, suppressedExceptions);
+            } else {
+                return false;
+            }
+        } catch (Exception de) {
+            suppressedExceptions.add(de);
+        }
+
+        if (!suppressedExceptions.isEmpty()) {
+            var ex = new DataException("Error deleting acsp member's data");
+            suppressedExceptions.forEach(ex::addSuppressed);
+            throw ex;
+        }
+        return true;
+    }
+
+    public Optional<AcspProfile> getAcspProfileData(String acspNumber)
+            throws NoDataFoundException {
+
+        return acspProfileService.getAcspProfile(acspNumber);
+    }
+
+    private void deleteAcspProfile(String acspNumber, List<Exception> suppressedExceptions) {
+        try {
+            this.acspProfileService.delete(acspNumber);
+        } catch (Exception ex) {
+            suppressedExceptions.add(new DataException("Error deleting ACSP profile", ex));
+        }
+    }
+
+    private void deleteAcspMember(String acspMemberId, List<Exception> suppressedExceptions) {
+        try {
+            acspMembersService.delete(acspMemberId);
+        } catch (Exception ex) {
+            suppressedExceptions.add(new DataException("Error deleting ACSP member", ex));
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/AcspMemberControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/AcspMemberControllerTest.java
@@ -24,7 +24,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersRespons
 import uk.gov.companieshouse.api.testdata.service.AcspWorkflowService;
 
 @ExtendWith(MockitoExtension.class)
-public class AcspMemberControllerTest {
+class AcspMemberControllerTest {
 
     @Mock
     private AcspWorkflowService acspWorkflowService;

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/AcspMemberControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/AcspMemberControllerTest.java
@@ -30,7 +30,7 @@ class AcspMemberControllerTest {
     private AcspWorkflowService acspWorkflowService;
 
     @InjectMocks
-    private AcspMemberController testDataController;
+    private AcspMemberController acspMemberController;
 
     @Test
     void createAcspMember() throws Exception {
@@ -45,7 +45,7 @@ class AcspMemberControllerTest {
 
         when(this.acspWorkflowService.createAcspMembersData(request)).thenReturn(acspMember);
         ResponseEntity<AcspMembersResponse> response
-                = this.testDataController.createAcspMember(request);
+                = this.acspMemberController.createAcspMember(request);
 
         assertEquals(acspMember, response.getBody());
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
@@ -59,7 +59,7 @@ class AcspMemberControllerTest {
         when(this.acspWorkflowService.createAcspMembersData(request)).thenThrow(exception);
 
         DataException thrown = assertThrows(DataException.class, () ->
-                this.testDataController.createAcspMember(request));
+                this.acspMemberController.createAcspMember(request));
         assertEquals(exception, thrown);
     }
 
@@ -69,7 +69,7 @@ class AcspMemberControllerTest {
 
         when(this.acspWorkflowService.deleteAcspMembersData(acspMemberId)).thenReturn(true);
         ResponseEntity<Map<String, Object>> response
-                = this.testDataController.deleteAcspMember(acspMemberId);
+                = this.acspMemberController.deleteAcspMember(acspMemberId);
 
         assertNull(response.getBody());
         assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
@@ -82,7 +82,7 @@ class AcspMemberControllerTest {
 
         when(this.acspWorkflowService.deleteAcspMembersData(acspMemberId)).thenReturn(false);
         ResponseEntity<Map<String, Object>> response
-                = this.testDataController.deleteAcspMember(acspMemberId);
+                = this.acspMemberController.deleteAcspMember(acspMemberId);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertEquals("memberId", Objects.requireNonNull(response.getBody()).get("acsp-member-id"));
@@ -99,7 +99,7 @@ class AcspMemberControllerTest {
         when(this.acspWorkflowService.deleteAcspMembersData(acspMemberId)).thenThrow(exception);
 
         DataException thrown = assertThrows(
-                DataException.class, () -> this.testDataController.deleteAcspMember(acspMemberId));
+                DataException.class, () -> this.acspMemberController.deleteAcspMember(acspMemberId));
         assertEquals(exception, thrown);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/AcspMemberControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/AcspMemberControllerTest.java
@@ -1,0 +1,105 @@
+package uk.gov.companieshouse.api.testdata.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.request.AcspProfileRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
+import uk.gov.companieshouse.api.testdata.service.AcspWorkflowService;
+
+@ExtendWith(MockitoExtension.class)
+public class AcspMemberControllerTest {
+
+    @Mock
+    private AcspWorkflowService acspWorkflowService;
+
+    @InjectMocks
+    private AcspMemberController testDataController;
+
+    @Test
+    void createAcspMember() throws Exception {
+        AcspMembersRequest request = new AcspMembersRequest();
+        request.setUserId("rsf3pdwywvse5yz55mfodfx8");
+        request.setUserRole("role");
+        request.setStatus("active");
+        request.setAcspProfile(new AcspProfileRequest());
+
+        AcspMembersResponse acspMember = new AcspMembersResponse(
+                new ObjectId(), "acspNumber", "userId", "active", "role");
+
+        when(this.acspWorkflowService.createAcspMembersData(request)).thenReturn(acspMember);
+        ResponseEntity<AcspMembersResponse> response
+                = this.testDataController.createAcspMember(request);
+
+        assertEquals(acspMember, response.getBody());
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    }
+
+    @Test
+    void createAcspMemberException() throws Exception {
+        AcspMembersRequest request = new AcspMembersRequest();
+        Throwable exception = new DataException("Error message");
+
+        when(this.acspWorkflowService.createAcspMembersData(request)).thenThrow(exception);
+
+        DataException thrown = assertThrows(DataException.class, () ->
+                this.testDataController.createAcspMember(request));
+        assertEquals(exception, thrown);
+    }
+
+    @Test
+    void deleteAcspMember() throws Exception {
+        final String acspMemberId = "memberId";
+
+        when(this.acspWorkflowService.deleteAcspMembersData(acspMemberId)).thenReturn(true);
+        ResponseEntity<Map<String, Object>> response
+                = this.testDataController.deleteAcspMember(acspMemberId);
+
+        assertNull(response.getBody());
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(acspWorkflowService).deleteAcspMembersData(acspMemberId);
+    }
+
+    @Test
+    void deleteAcspMemberNotFound() throws Exception {
+        final String acspMemberId = "memberId";
+
+        when(this.acspWorkflowService.deleteAcspMembersData(acspMemberId)).thenReturn(false);
+        ResponseEntity<Map<String, Object>> response
+                = this.testDataController.deleteAcspMember(acspMemberId);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals("memberId", Objects.requireNonNull(response.getBody()).get("acsp-member-id"));
+        assertEquals(HttpStatus.NOT_FOUND, response.getBody().get("status"));
+
+        verify(acspWorkflowService).deleteAcspMembersData(acspMemberId);
+    }
+
+    @Test
+    void deleteAcspMemberException() throws Exception {
+        final String acspMemberId = "memberId";
+        Throwable exception = new DataException("Error message");
+
+        when(this.acspWorkflowService.deleteAcspMembersData(acspMemberId)).thenThrow(exception);
+
+        DataException thrown = assertThrows(
+                DataException.class, () -> this.testDataController.deleteAcspMember(acspMemberId));
+        assertEquals(exception, thrown);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/AcspProfileControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/AcspProfileControllerTest.java
@@ -1,0 +1,89 @@
+package uk.gov.companieshouse.api.testdata.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
+import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
+import uk.gov.companieshouse.api.testdata.service.AcspWorkflowService;
+
+@ExtendWith(MockitoExtension.class)
+public class AcspProfileControllerTest {
+
+    @Mock
+    private AcspWorkflowService acspWorkflowService;
+
+    @InjectMocks
+    private AcspProfileController acspProfileController;
+
+    @Test
+    void getAcspProfileFound() throws Exception {
+        String acspNumber = "AP000036";
+
+        AcspProfile profile = new AcspProfile();
+        profile.setId(acspNumber);
+        profile.setAcspNumber(acspNumber);
+        profile.setName("Test ACSP Company");
+        profile.setStatus("active");
+
+        when(acspWorkflowService.getAcspProfileData(acspNumber)).thenReturn(Optional.of(profile));
+
+        ResponseEntity<Optional<AcspProfile>> response =
+                acspProfileController.getAcspProfile(acspNumber);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().isPresent());
+
+        AcspProfile returnedProfile = response.getBody().get();
+        assertEquals(acspNumber, returnedProfile.getId());
+        assertEquals(acspNumber, returnedProfile.getAcspNumber());
+        assertEquals("Test ACSP Company", returnedProfile.getName());
+        assertEquals("active", returnedProfile.getStatus());
+
+        verify(acspWorkflowService, times(1)).getAcspProfileData(acspNumber);
+    }
+
+    @Test
+    void getAcspProfileNotFound() throws Exception {
+        String acspNumber = "NON_EXISTENT";
+
+        when(acspWorkflowService.getAcspProfileData(acspNumber)).thenReturn(Optional.empty());
+
+        ResponseEntity<Optional<AcspProfile>> response =
+                acspProfileController.getAcspProfile(acspNumber);
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().isEmpty());
+
+        verify(acspWorkflowService, times(1)).getAcspProfileData(acspNumber);
+    }
+
+    @Test
+    void getAcspProfileThrowsNoDataFoundException() throws Exception {
+        String acspNumber = "AP000036";
+        NoDataFoundException ex = new NoDataFoundException("ACSP not found");
+
+        when(acspWorkflowService.getAcspProfileData(acspNumber)).thenThrow(ex);
+
+        NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
+                acspProfileController.getAcspProfile(acspNumber));
+        assertEquals(ex, thrown);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/AcspProfileControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/AcspProfileControllerTest.java
@@ -18,13 +18,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
-import uk.gov.companieshouse.api.testdata.service.AcspWorkflowService;
+import uk.gov.companieshouse.api.testdata.service.AcspProfileService;
 
 @ExtendWith(MockitoExtension.class)
 class AcspProfileControllerTest {
 
     @Mock
-    private AcspWorkflowService acspWorkflowService;
+    private AcspProfileService acspProfileService;
 
     @InjectMocks
     private AcspProfileController acspProfileController;
@@ -39,7 +39,7 @@ class AcspProfileControllerTest {
         profile.setName("Test ACSP Company");
         profile.setStatus("active");
 
-        when(acspWorkflowService.getAcspProfileData(acspNumber)).thenReturn(Optional.of(profile));
+        when(acspProfileService.getAcspProfile(acspNumber)).thenReturn(Optional.of(profile));
 
         ResponseEntity<Optional<AcspProfile>> response =
                 acspProfileController.getAcspProfile(acspNumber);
@@ -55,14 +55,14 @@ class AcspProfileControllerTest {
         assertEquals("Test ACSP Company", returnedProfile.getName());
         assertEquals("active", returnedProfile.getStatus());
 
-        verify(acspWorkflowService, times(1)).getAcspProfileData(acspNumber);
+        verify(acspProfileService, times(1)).getAcspProfile(acspNumber);
     }
 
     @Test
     void getAcspProfileNotFound() throws Exception {
         String acspNumber = "NON_EXISTENT";
 
-        when(acspWorkflowService.getAcspProfileData(acspNumber)).thenReturn(Optional.empty());
+        when(acspProfileService.getAcspProfile(acspNumber)).thenReturn(Optional.empty());
 
         ResponseEntity<Optional<AcspProfile>> response =
                 acspProfileController.getAcspProfile(acspNumber);
@@ -72,7 +72,7 @@ class AcspProfileControllerTest {
         assertNotNull(response.getBody());
         assertTrue(response.getBody().isEmpty());
 
-        verify(acspWorkflowService, times(1)).getAcspProfileData(acspNumber);
+        verify(acspProfileService, times(1)).getAcspProfile(acspNumber);
     }
 
     @Test
@@ -80,7 +80,7 @@ class AcspProfileControllerTest {
         String acspNumber = "AP000036";
         NoDataFoundException ex = new NoDataFoundException("ACSP not found");
 
-        when(acspWorkflowService.getAcspProfileData(acspNumber)).thenThrow(ex);
+        when(acspProfileService.getAcspProfile(acspNumber)).thenThrow(ex);
 
         NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
                 acspProfileController.getAcspProfile(acspNumber));

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/AcspProfileControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/AcspProfileControllerTest.java
@@ -21,7 +21,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
 import uk.gov.companieshouse.api.testdata.service.AcspWorkflowService;
 
 @ExtendWith(MockitoExtension.class)
-public class AcspProfileControllerTest {
+class AcspProfileControllerTest {
 
     @Mock
     private AcspWorkflowService acspWorkflowService;

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/TestDataControllerTest.java
@@ -1,5 +1,22 @@
 package uk.gov.companieshouse.api.testdata.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,10 +27,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
-import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
-import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
-import uk.gov.companieshouse.api.testdata.model.rest.request.AcspProfileRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AdminPermissionsRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CertificatesRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CertifiedCopiesRequest;
@@ -25,7 +39,6 @@ import uk.gov.companieshouse.api.testdata.model.rest.request.PenaltyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.TransactionsRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateAccountPenaltiesRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AccountPenaltiesResponse;
-import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AdminPermissionsResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.CertificatesResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.CombinedSicActivitiesResponse;
@@ -36,24 +49,6 @@ import uk.gov.companieshouse.api.testdata.model.rest.response.TransactionsRespon
 import uk.gov.companieshouse.api.testdata.service.FilingHistoryService;
 import uk.gov.companieshouse.api.testdata.service.TestDataService;
 import uk.gov.companieshouse.api.testdata.service.VerifiedIdentityService;
-
-import java.time.Instant;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class TestDataControllerTest {
@@ -77,77 +72,6 @@ class TestDataControllerTest {
 
     @Mock
     private VerifiedIdentityService<IdentityVerificationResponse> verifiedIdentityService;
-
-    @Test
-    void createAcspMember() throws Exception {
-        AcspMembersRequest request = new AcspMembersRequest();
-        request.setUserId("rsf3pdwywvse5yz55mfodfx8");
-        request.setUserRole("role");
-        request.setStatus("active");
-        request.setAcspProfile(new AcspProfileRequest());
-
-        AcspMembersResponse acspMember = new AcspMembersResponse(
-                new ObjectId(), "acspNumber", "userId", "active", "role");
-
-        when(this.testDataService.createAcspMembersData(request)).thenReturn(acspMember);
-        ResponseEntity<AcspMembersResponse> response
-                = this.testDataController.createAcspMember(request);
-
-        assertEquals(acspMember, response.getBody());
-        assertEquals(HttpStatus.CREATED, response.getStatusCode());
-    }
-
-    @Test
-    void createAcspMemberException() throws Exception {
-        AcspMembersRequest request = new AcspMembersRequest();
-        Throwable exception = new DataException("Error message");
-
-        when(this.testDataService.createAcspMembersData(request)).thenThrow(exception);
-
-        DataException thrown = assertThrows(DataException.class, () ->
-                this.testDataController.createAcspMember(request));
-        assertEquals(exception, thrown);
-    }
-
-    @Test
-    void deleteAcspMember() throws Exception {
-        final String acspMemberId = "memberId";
-
-        when(this.testDataService.deleteAcspMembersData(acspMemberId)).thenReturn(true);
-        ResponseEntity<Map<String, Object>> response
-                = this.testDataController.deleteAcspMember(acspMemberId);
-
-        assertNull(response.getBody());
-        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
-        verify(testDataService).deleteAcspMembersData(acspMemberId);
-    }
-
-    @Test
-    void deleteAcspMemberNotFound() throws Exception {
-        final String acspMemberId = "memberId";
-
-        when(this.testDataService.deleteAcspMembersData(acspMemberId)).thenReturn(false);
-        ResponseEntity<Map<String, Object>> response
-                = this.testDataController.deleteAcspMember(acspMemberId);
-
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        assertEquals("memberId", Objects.requireNonNull(response.getBody()).get("acsp-member-id"));
-        assertEquals(HttpStatus.NOT_FOUND, response.getBody().get("status"));
-
-        verify(testDataService).deleteAcspMembersData(acspMemberId);
-    }
-
-    @Test
-    void deleteAcspMemberException() throws Exception {
-        final String acspMemberId = "memberId";
-        Throwable exception = new DataException("Error message");
-
-        when(this.testDataService.deleteAcspMembersData(acspMemberId)).thenThrow(exception);
-
-        DataException thrown = assertThrows(
-                DataException.class, () -> this.testDataController.deleteAcspMember(acspMemberId));
-        assertEquals(exception, thrown);
-    }
 
     @Test
     void deleteAppealSuccess() throws Exception {
@@ -1045,53 +969,6 @@ class TestDataControllerTest {
         verify(verifiedIdentityService, times(1)).getIdentityVerificationData(email);
     }
 
-
-    @Test
-    void getAcspProfileFound() throws Exception {
-        String acspNumber = "AP000036";
-
-        AcspProfile profile = new AcspProfile();
-        profile.setId(acspNumber);
-        profile.setAcspNumber(acspNumber);
-        profile.setName("Test ACSP Company");
-        profile.setStatus("active");
-
-        when(testDataService.getAcspProfileData(acspNumber)).thenReturn(Optional.of(profile));
-
-        ResponseEntity<Optional<AcspProfile>> response =
-                testDataController.getAcspProfile(acspNumber);
-
-        assertNotNull(response);
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertTrue(response.getBody().isPresent());
-
-        AcspProfile returnedProfile = response.getBody().get();
-        assertEquals(acspNumber, returnedProfile.getId());
-        assertEquals(acspNumber, returnedProfile.getAcspNumber());
-        assertEquals("Test ACSP Company", returnedProfile.getName());
-        assertEquals("active", returnedProfile.getStatus());
-
-        verify(testDataService, times(1)).getAcspProfileData(acspNumber);
-    }
-
-    @Test
-    void getAcspProfileNotFound() throws Exception {
-        String acspNumber = "NON_EXISTENT";
-
-        when(testDataService.getAcspProfileData(acspNumber)).thenReturn(Optional.empty());
-
-        ResponseEntity<Optional<AcspProfile>> response =
-                testDataController.getAcspProfile(acspNumber);
-
-        assertNotNull(response);
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertNotNull(response.getBody());
-        assertTrue(response.getBody().isEmpty());
-
-        verify(testDataService, times(1)).getAcspProfileData(acspNumber);
-    }
-
     @Test
     void deleteItemGroups() throws Exception {
         final String orderNumber = "ORD-1776329853";
@@ -1134,19 +1011,6 @@ class TestDataControllerTest {
                 testDataController.deleteItemGroups(orderNumber));
         assertEquals(exception, thrown);
         verify(testDataService).deleteItemGroupsData(orderNumber);
-    }
-
-
-    @Test
-    void getAcspProfileThrowsNoDataFoundException() throws Exception {
-        String acspNumber = "AP000036";
-        NoDataFoundException ex = new NoDataFoundException("ACSP not found");
-
-        when(testDataService.getAcspProfileData(acspNumber)).thenThrow(ex);
-
-        NoDataFoundException thrown = assertThrows(NoDataFoundException.class, () ->
-                testDataController.getAcspProfile(acspNumber));
-        assertEquals(ex, thrown);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/TestDataServiceImplTest.java
@@ -1,6 +1,20 @@
 package uk.gov.companieshouse.api.testdata.service.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import jakarta.validation.ConstraintViolationException;
+import java.util.List;
+
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,15 +24,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
-import uk.gov.companieshouse.api.testdata.model.entity.AcspMembers;
-import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
 import uk.gov.companieshouse.api.testdata.model.entity.Certificates;
 import uk.gov.companieshouse.api.testdata.model.entity.CertifiedCopies;
 import uk.gov.companieshouse.api.testdata.model.entity.MissingImageDeliveries;
 import uk.gov.companieshouse.api.testdata.model.entity.Postcodes;
-import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
-import uk.gov.companieshouse.api.testdata.model.rest.request.AcspProfileRequest;
-import uk.gov.companieshouse.api.testdata.model.rest.request.AmlRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CertificatesRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CertifiedCopiesRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CombinedSicActivitiesRequest;
@@ -27,44 +36,20 @@ import uk.gov.companieshouse.api.testdata.model.rest.request.PenaltyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.TransactionsRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateAccountPenaltiesRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.response.AccountPenaltiesResponse;
-import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
-import uk.gov.companieshouse.api.testdata.model.rest.response.AcspProfileResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.CertificatesResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.CombinedSicActivitiesResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.PostcodesResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.TransactionsResponse;
-import uk.gov.companieshouse.api.testdata.repository.AcspMembersRepository;
 import uk.gov.companieshouse.api.testdata.service.AccountPenaltiesService;
-import uk.gov.companieshouse.api.testdata.service.AcspProfileService;
 import uk.gov.companieshouse.api.testdata.service.AppealsService;
 import uk.gov.companieshouse.api.testdata.service.DataService;
 import uk.gov.companieshouse.api.testdata.service.ItemGroupsService;
 import uk.gov.companieshouse.api.testdata.service.PostcodeService;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class TestDataServiceImplTest {
 
-    private static final String COMPANY_NUMBER = "12345678";
     private static final String COMPANY_CODE = "LP";
     private static final String CUSTOMER_CODE = "12345678";
     private static final String PENALTY_ID = "685abc4b9b34c84d4d2f5af6";
@@ -76,12 +61,6 @@ class TestDataServiceImplTest {
     private static final String SIC_ACTIVITY_ID = "6242bbbbafaaaa93274b2efd";
     private static final String TRANSACTION_ID = "903085-903085-903085";
 
-    @Mock
-    private DataService<AcspMembersResponse, AcspMembersRequest> acspMembersService;
-    @Mock
-    private AcspMembersRepository acspMembersRepository;
-    @Mock
-    private AcspProfileService acspProfileService;
     @Mock
     private AppealsService appealsService;
     @Mock
@@ -102,261 +81,6 @@ class TestDataServiceImplTest {
 
     @InjectMocks
     private TestDataServiceImpl testDataService;
-
-    /**
-     * Helper to create ACSP members data.
-     *
-     * @param userId      the user id to set on the spec
-     * @param profileData the ACSP profile data to be returned by the profile service
-     * @param membersData the ACSP members data to be returned by the members service
-     * @return the result of testDataService.createAcspMembersData(...)
-     * @throws DataException if creation fails
-     */
-    private AcspMembersResponse createAcspMembersDataHelper(String userId,
-                                                            AcspProfileResponse profileData,
-                                                            AcspMembersResponse membersData, AcspProfileRequest profileSpec) throws DataException {
-        AcspMembersRequest spec = new AcspMembersRequest();
-        spec.setUserId(userId);
-        spec.setAcspProfile(profileSpec);
-        when(acspProfileService.create(any(AcspProfileRequest.class))).thenReturn(profileData);
-        when(acspMembersService.create(any(AcspMembersRequest.class))).thenReturn(membersData);
-        return testDataService.createAcspMembersData(spec);
-    }
-
-    private void verifyAcspMembersData(AcspMembersResponse data,
-                                       String expectedMemberId,
-                                       String expectedAcspNumber,
-                                       String expectedUserId,
-                                       String expectedStatus,
-                                       String expectedUserRole) {
-        assertNotNull(data);
-        assertEquals(expectedMemberId, data.getAcspMemberId());
-        assertEquals(expectedAcspNumber, data.getAcspNumber());
-        assertEquals(expectedUserId, data.getUserId());
-        assertEquals(expectedStatus, data.getStatus());
-        assertEquals(expectedUserRole, data.getUserRole());
-    }
-
-    /**
-     * Helper to perform deletion of ACSP member data.
-     *
-     * @param acspMemberId   the member id to delete
-     * @param memberOptional an Optional containing the AcspMembers if found
-     * @return the result of testDataService.deleteAcspMembersData(...)
-     * @throws DataException if deletion fails
-     */
-    private boolean deleteAcspMembersDataHelper(String acspMemberId,
-                                                Optional<AcspMembers> memberOptional)
-            throws DataException {
-        when(acspMembersRepository.findById(acspMemberId)).thenReturn(memberOptional);
-        return testDataService.deleteAcspMembersData(acspMemberId);
-    }
-
-    @Test
-    void createAcspMembersData() throws DataException {
-        AcspProfileRequest profileSpec = new AcspProfileRequest();
-        profileSpec.setAcspNumber("acspNumber");
-        profileSpec.setStatus("active");
-        profileSpec.setType("limited-company");
-
-        AcspProfile profileEntity = new AcspProfile();
-        profileEntity.setAcspNumber(profileSpec.getAcspNumber());
-        profileEntity.setName(profileSpec.getName());
-        profileEntity.setVersion(1L);
-
-        AcspProfileResponse acspProfileResponse =
-                new AcspProfileResponse(profileEntity);
-        AcspMembersResponse expectedMembersData =
-                new AcspMembersResponse(new ObjectId(),
-                        profileSpec.getAcspNumber(), "userId", "active", "role");
-        AcspMembersResponse result = createAcspMembersDataHelper(
-                "userId", acspProfileResponse, expectedMembersData, profileSpec);
-        verifyAcspMembersData(result,
-                String.valueOf(expectedMembersData.getAcspMemberId()),
-                acspProfileResponse.getAcspNumber(), expectedMembersData.getUserId(),
-                expectedMembersData.getStatus(), expectedMembersData.getUserRole());
-        verify(acspMembersService).create(any(AcspMembersRequest.class));
-        verify(acspProfileService).create(argThat(profile -> profile.getAmlDetails() == null));
-    }
-
-    @Test
-    void createAcspMembersDataNullUserId() {
-        AcspMembersRequest spec = new AcspMembersRequest();
-        DataException exception = assertThrows(DataException.class,
-                () -> testDataService.createAcspMembersData(spec));
-        assertEquals("User ID is required to create an ACSP member", exception.getMessage());
-    }
-
-    @Test
-    void createAcspMembersDataException() throws DataException {
-        AcspMembersRequest spec = new AcspMembersRequest();
-        spec.setUserId("userId");
-
-        when(acspProfileService.create(any(AcspProfileRequest.class)))
-                .thenThrow(new DataException("Error creating ACSP profile"));
-        DataException exception = assertThrows(DataException.class,
-                () -> testDataService.createAcspMembersData(spec));
-        assertEquals(
-                "uk.gov.companieshouse.api.testdata.exception.DataException: Error creating ACSP profile",
-                exception.getMessage());
-    }
-
-    @Test
-    void createAcspMembersDataWhenProfileIsNotNull() throws DataException {
-        AcspMembersRequest spec = new AcspMembersRequest();
-        spec.setUserId("userId");
-        AcspProfile profileEntity = new AcspProfile();
-        profileEntity.setAcspNumber("acspNumber");
-        profileEntity.setName("name");
-        profileEntity.setVersion(1L);
-
-        AcspProfileResponse acspProfileResponse = new AcspProfileResponse(profileEntity);
-        AcspMembersResponse acspMembersResponse =
-                new AcspMembersResponse(new ObjectId(), acspProfileResponse.getAcspNumber(),"userId",
-                        "active", "role");
-        var acspStatus = "active";
-        var acspType = "ltd";
-        var supervisoryBody = "financial-conduct-authority-fca";
-        var membershipDetails = "Membership ID: FCA654321";
-        AcspProfileRequest acspProfile = new AcspProfileRequest();
-        acspProfile.setStatus(acspStatus);
-        acspProfile.setType(acspType);
-        AmlRequest amlRequest = new AmlRequest();
-        amlRequest.setSupervisoryBody(supervisoryBody);
-        amlRequest.setMembershipDetails(membershipDetails);
-
-        acspProfile.setAmlDetails(Collections.singletonList(amlRequest));
-
-        spec.setAcspProfile(acspProfile);
-
-        when(acspProfileService.create(any(AcspProfileRequest.class))).thenReturn(acspProfileResponse);
-        when(acspMembersService.create(any(AcspMembersRequest.class))).thenReturn(acspMembersResponse);
-        AcspMembersResponse result = testDataService.createAcspMembersData(spec);
-
-        verifyAcspMembersData(result,
-                String.valueOf(acspMembersResponse.getAcspMemberId()),
-                acspProfileResponse.getAcspNumber(), acspMembersResponse.getUserId(), acspMembersResponse.getStatus(), acspMembersResponse.getUserRole());
-        acspProfileResponse.getAcspNumber();
-
-        verify(acspProfileService).create(acspProfile);
-
-        verify(acspMembersService).create(argThat(membersSpec ->
-                acspMembersResponse.getUserId().equals(membersSpec.getUserId())
-                        && acspMembersResponse.getAcspNumber().equals(membersSpec.getAcspNumber())
-        ));
-    }
-
-    @Test
-    void createAcspMembersDataWhenProfileIsNull() throws DataException {
-        AcspMembersRequest spec = new AcspMembersRequest();
-        spec.setUserId("userId");
-
-        AcspProfile profileEntity = new AcspProfile();
-        profileEntity.setAcspNumber("acspNumber");
-        profileEntity.setName("name");
-        profileEntity.setVersion(1L);
-
-        AcspProfileResponse acspProfileResponse = new AcspProfileResponse(profileEntity);
-        AcspMembersResponse acspMembersResponse = new AcspMembersResponse(new ObjectId(),
-                "acspNumber", "userId", "active", "role");
-        spec.setAcspProfile(null);
-
-        when(acspProfileService.create(any(AcspProfileRequest.class))).thenReturn(acspProfileResponse);
-        when(acspMembersService.create(any(AcspMembersRequest.class))).thenReturn(acspMembersResponse);
-
-        AcspMembersResponse result = testDataService.createAcspMembersData(spec);
-
-        verifyAcspMembersData(result,
-                String.valueOf(acspMembersResponse.getAcspMemberId()),
-                acspProfileResponse.getAcspNumber(), acspMembersResponse.getUserId(), acspMembersResponse.getStatus(), acspMembersResponse.getUserRole());
-
-        verify(acspProfileService).create(argThat(profile ->
-                profile.getStatus() == null
-                        && profile.getType() == null
-                        && profile.getAmlDetails() == null));
-        verify(acspMembersService).create(argThat(membersSpec ->
-                acspMembersResponse.getUserId().equals(membersSpec.getUserId())
-                        && acspMembersResponse.getAcspNumber().equals(membersSpec.getAcspNumber())
-        ));
-    }
-
-    @Test
-    void createAcspMembersDataProfileCreationException() throws DataException {
-        AcspMembersRequest spec = new AcspMembersRequest();
-        spec.setUserId("userId");
-        AcspProfileRequest profileRequest = new AcspProfileRequest();
-        profileRequest.setStatus("active");
-        profileRequest.setType("limited-company");
-        spec.setAcspProfile(profileRequest);
-
-        when(acspProfileService.create(any(AcspProfileRequest.class)))
-                .thenThrow(new DataException("Error creating ACSP profile"));
-        DataException exception = assertThrows(DataException.class,
-                () -> testDataService.createAcspMembersData(spec));
-        assertEquals(
-                "uk.gov.companieshouse.api.testdata.exception.DataException: Error creating ACSP profile",
-                exception.getMessage());
-        verify(acspProfileService).create(profileRequest);
-        verify(acspMembersService, never()).create(any(AcspMembersRequest.class));
-    }
-
-    @Test
-    void createAcspMembersDataMemberCreationException() throws DataException {
-        AcspMembersRequest spec = new AcspMembersRequest();
-        spec.setUserId("userId");
-
-        AcspProfile profileEntity = new AcspProfile();
-        profileEntity.setAcspNumber("acspNumber");
-        profileEntity.setName("name");
-        profileEntity.setVersion(1L);
-
-        AcspProfileResponse acspProfileResponse = new AcspProfileResponse(profileEntity);
-        when(acspProfileService.create(any(AcspProfileRequest.class))).thenReturn(acspProfileResponse);
-        when(acspMembersService.create(any(AcspMembersRequest.class)))
-                .thenThrow(new DataException("Error creating ACSP member"));
-        DataException exception = assertThrows(DataException.class,
-                () -> testDataService.createAcspMembersData(spec));
-        assertEquals(
-                "uk.gov.companieshouse.api.testdata.exception.DataException: Error creating ACSP member",
-                exception.getMessage());
-    }
-
-    @Test
-    void deleteAcspMembersData() throws DataException {
-        String acspMemberId = "memberId";
-        AcspMembers member = new AcspMembers();
-        member.setAcspNumber("acspNumber");
-
-        boolean result = deleteAcspMembersDataHelper(acspMemberId, Optional.of(member));
-
-        assertTrue(result);
-        verify(acspMembersService).delete(acspMemberId);
-        verify(acspProfileService).delete("acspNumber");
-    }
-
-    @Test
-    void deleteAcspMembersDataNotFound() throws DataException {
-        String acspMemberId = "memberId";
-        boolean result = deleteAcspMembersDataHelper(acspMemberId, Optional.empty());
-
-        assertFalse(result);
-        verify(acspMembersService, never()).delete(anyString());
-        verify(acspProfileService, never()).delete(anyString());
-    }
-
-    @Test
-    void deleteAcspMembersDataException() {
-        String acspMemberId = "memberId";
-        AcspMembers member = new AcspMembers();
-        member.setAcspNumber("acspNumber");
-
-        when(acspMembersRepository.findById(acspMemberId)).thenReturn(Optional.of(member));
-        doThrow(new RuntimeException(new DataException("Error")))
-                .when(acspMembersService).delete(acspMemberId);
-        DataException exception = assertThrows(DataException.class,
-                () -> testDataService.deleteAcspMembersData(acspMemberId));
-        assertEquals("Error deleting acsp member's data", exception.getMessage());
-    }
 
     @Test
     void deleteAppealsDataSuccess() throws DataException {
@@ -1069,46 +793,6 @@ class TestDataServiceImplTest {
         assertEquals("Error deleting appeals data", exception.getMessage());
         assertEquals(ex, exception.getCause());
         verify(combinedSicActivitiesService, times(1)).delete(SIC_ACTIVITY_ID);
-    }
-
-    @Test
-    void getAcspProfileDataReturnsProfile() throws NoDataFoundException {
-        String acspNumber = "AP000036";
-
-        AcspProfile profile = new AcspProfile();
-        profile.setId(acspNumber);
-        profile.setAcspNumber(acspNumber);
-        profile.setName("Test ACSP Company");
-        profile.setStatus("active");
-
-        when(acspProfileService.getAcspProfile(acspNumber)).thenReturn(Optional.of(profile));
-
-        Optional<AcspProfile> result = testDataService.getAcspProfileData(acspNumber);
-
-        assertNotNull(result);
-        assertTrue(result.isPresent());
-
-        AcspProfile returnedProfile = result.get();
-        assertEquals(acspNumber, returnedProfile.getId());
-        assertEquals(acspNumber, returnedProfile.getAcspNumber());
-        assertEquals("Test ACSP Company", returnedProfile.getName());
-        assertEquals("active", returnedProfile.getStatus());
-
-        verify(acspProfileService, times(1)).getAcspProfile(acspNumber);
-    }
-
-    @Test
-    void getAcspProfileDataReturnsEmpty() throws NoDataFoundException {
-        String acspNumber = "NON_EXISTENT";
-
-        when(acspProfileService.getAcspProfile(acspNumber)).thenReturn(Optional.empty());
-
-        Optional<AcspProfile> result = testDataService.getAcspProfileData(acspNumber);
-
-        assertNotNull(result);
-        assertTrue(result.isEmpty());
-
-        verify(acspProfileService, times(1)).getAcspProfile(acspNumber);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/AcspWorkflowServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/AcspWorkflowServiceImplTest.java
@@ -48,11 +48,11 @@ class AcspWorkflowServiceImplTest {
     @Mock
     private AcspProfileService acspProfileService;
 
-    private AcspWorkflowServiceImpl testDataService;
+    private AcspWorkflowServiceImpl acspWorkflowService;
 
     @BeforeEach
     void setUp() {
-        testDataService = new AcspWorkflowServiceImpl(
+        acspWorkflowService = new AcspWorkflowServiceImpl(
                 acspProfileService,
                 acspMembersRepository,
                 acspMembersService);
@@ -75,7 +75,7 @@ class AcspWorkflowServiceImplTest {
         spec.setAcspProfile(profileSpec);
         when(acspProfileService.create(any(AcspProfileRequest.class))).thenReturn(profileData);
         when(acspMembersService.create(any(AcspMembersRequest.class))).thenReturn(membersData);
-        return testDataService.createAcspMembersData(spec);
+        return acspWorkflowService.createAcspMembersData(spec);
     }
 
     private void verifyAcspMembersData(AcspMembersResponse data,
@@ -104,7 +104,7 @@ class AcspWorkflowServiceImplTest {
                                                 Optional<AcspMembers> memberOptional)
             throws DataException {
         when(acspMembersRepository.findById(acspMemberId)).thenReturn(memberOptional);
-        return testDataService.deleteAcspMembersData(acspMemberId);
+        return acspWorkflowService.deleteAcspMembersData(acspMemberId);
     }
 
     @Test
@@ -138,7 +138,7 @@ class AcspWorkflowServiceImplTest {
     void createAcspMembersDataNullUserId() {
         AcspMembersRequest spec = new AcspMembersRequest();
         DataException exception = assertThrows(DataException.class,
-                () -> testDataService.createAcspMembersData(spec));
+                () -> acspWorkflowService.createAcspMembersData(spec));
         assertEquals("User ID is required to create an ACSP member", exception.getMessage());
     }
 
@@ -150,7 +150,7 @@ class AcspWorkflowServiceImplTest {
         when(acspProfileService.create(any(AcspProfileRequest.class)))
                 .thenThrow(new DataException("Error creating ACSP profile"));
         DataException exception = assertThrows(DataException.class,
-                () -> testDataService.createAcspMembersData(spec));
+                () -> acspWorkflowService.createAcspMembersData(spec));
         assertEquals(
                 "uk.gov.companieshouse.api.testdata.exception.DataException: Error creating ACSP profile",
                 exception.getMessage());
@@ -183,7 +183,7 @@ class AcspWorkflowServiceImplTest {
                         "active", "role");
         when(acspProfileService.create(any(AcspProfileRequest.class))).thenReturn(acspProfileResponse);
         when(acspMembersService.create(any(AcspMembersRequest.class))).thenReturn(acspMembersResponse);
-        AcspMembersResponse result = testDataService.createAcspMembersData(spec);
+        AcspMembersResponse result = acspWorkflowService.createAcspMembersData(spec);
 
         verifyAcspMembersData(result,
                 String.valueOf(acspMembersResponse.getAcspMemberId()),
@@ -216,7 +216,7 @@ class AcspWorkflowServiceImplTest {
         when(acspProfileService.create(any(AcspProfileRequest.class))).thenReturn(acspProfileResponse);
         when(acspMembersService.create(any(AcspMembersRequest.class))).thenReturn(acspMembersResponse);
 
-        AcspMembersResponse result = testDataService.createAcspMembersData(spec);
+        AcspMembersResponse result = acspWorkflowService.createAcspMembersData(spec);
 
         verifyAcspMembersData(result,
                 String.valueOf(acspMembersResponse.getAcspMemberId()),
@@ -244,7 +244,7 @@ class AcspWorkflowServiceImplTest {
         when(acspProfileService.create(any(AcspProfileRequest.class)))
                 .thenThrow(new DataException("Error creating ACSP profile"));
         DataException exception = assertThrows(DataException.class,
-                () -> testDataService.createAcspMembersData(spec));
+                () -> acspWorkflowService.createAcspMembersData(spec));
         assertEquals(
                 "uk.gov.companieshouse.api.testdata.exception.DataException: Error creating ACSP profile",
                 exception.getMessage());
@@ -267,7 +267,7 @@ class AcspWorkflowServiceImplTest {
         when(acspMembersService.create(any(AcspMembersRequest.class)))
                 .thenThrow(new DataException("Error creating ACSP member"));
         DataException exception = assertThrows(DataException.class,
-                () -> testDataService.createAcspMembersData(spec));
+                () -> acspWorkflowService.createAcspMembersData(spec));
         assertEquals(
                 "uk.gov.companieshouse.api.testdata.exception.DataException: Error creating ACSP member",
                 exception.getMessage());
@@ -306,7 +306,7 @@ class AcspWorkflowServiceImplTest {
         doThrow(new RuntimeException(new DataException("Error")))
                 .when(acspMembersService).delete(acspMemberId);
         DataException exception = assertThrows(DataException.class,
-                () -> testDataService.deleteAcspMembersData(acspMemberId));
+                () -> acspWorkflowService.deleteAcspMembersData(acspMemberId));
         assertEquals("Error deleting acsp member's data", exception.getMessage());
     }
 
@@ -322,7 +322,7 @@ class AcspWorkflowServiceImplTest {
 
         when(acspProfileService.getAcspProfile(acspNumber)).thenReturn(Optional.of(profile));
 
-        Optional<AcspProfile> result = testDataService.getAcspProfileData(acspNumber);
+        Optional<AcspProfile> result = acspWorkflowService.getAcspProfileData(acspNumber);
 
         assertNotNull(result);
         assertTrue(result.isPresent());
@@ -342,7 +342,7 @@ class AcspWorkflowServiceImplTest {
 
         when(acspProfileService.getAcspProfile(acspNumber)).thenReturn(Optional.empty());
 
-        Optional<AcspProfile> result = testDataService.getAcspProfileData(acspNumber);
+        Optional<AcspProfile> result = acspWorkflowService.getAcspProfileData(acspNumber);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/AcspWorkflowServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/AcspWorkflowServiceImplTest.java
@@ -1,0 +1,353 @@
+package uk.gov.companieshouse.api.testdata.service.impl.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
+import uk.gov.companieshouse.api.testdata.model.entity.AcspMembers;
+import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
+import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.request.AcspProfileRequest;
+
+import uk.gov.companieshouse.api.testdata.model.rest.request.AmlRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.response.AcspMembersResponse;
+import uk.gov.companieshouse.api.testdata.model.rest.response.AcspProfileResponse;
+import uk.gov.companieshouse.api.testdata.repository.AcspMembersRepository;
+
+import uk.gov.companieshouse.api.testdata.service.AcspProfileService;
+import uk.gov.companieshouse.api.testdata.service.DataService;
+
+@ExtendWith(MockitoExtension.class)
+public class AcspWorkflowServiceImplTest {
+
+    @Mock
+    private DataService<AcspMembersResponse, AcspMembersRequest> acspMembersService;
+    @Mock
+    private AcspMembersRepository acspMembersRepository;
+    @Mock
+    private AcspProfileService acspProfileService;
+
+    // Manually constructed in @BeforeEach to guarantee correct injection order.
+    private AcspWorkflowServiceImpl testDataService;
+
+    @BeforeEach
+    void setUp() {
+        testDataService = new AcspWorkflowServiceImpl(
+                acspProfileService,
+                acspMembersRepository,
+                acspMembersService);
+    }
+
+    /**
+     * Helper to create ACSP members data.
+     *
+     * @param userId      the user id to set on the spec
+     * @param profileData the ACSP profile data to be returned by the profile service
+     * @param membersData the ACSP members data to be returned by the members service
+     * @return the result of testDataService.createAcspMembersData(...)
+     * @throws DataException if creation fails
+     */
+    private AcspMembersResponse createAcspMembersDataHelper(String userId,
+                                                            AcspProfileResponse profileData,
+                                                            AcspMembersResponse membersData, AcspProfileRequest profileSpec) throws DataException {
+        AcspMembersRequest spec = new AcspMembersRequest();
+        spec.setUserId(userId);
+        spec.setAcspProfile(profileSpec);
+        when(acspProfileService.create(any(AcspProfileRequest.class))).thenReturn(profileData);
+        when(acspMembersService.create(any(AcspMembersRequest.class))).thenReturn(membersData);
+        return testDataService.createAcspMembersData(spec);
+    }
+
+    private void verifyAcspMembersData(AcspMembersResponse data,
+                                       String expectedMemberId,
+                                       String expectedAcspNumber,
+                                       String expectedUserId,
+                                       String expectedStatus,
+                                       String expectedUserRole) {
+        assertNotNull(data);
+        assertEquals(expectedMemberId, data.getAcspMemberId());
+        assertEquals(expectedAcspNumber, data.getAcspNumber());
+        assertEquals(expectedUserId, data.getUserId());
+        assertEquals(expectedStatus, data.getStatus());
+        assertEquals(expectedUserRole, data.getUserRole());
+    }
+
+    /**
+     * Helper to perform deletion of ACSP member data.
+     *
+     * @param acspMemberId   the member id to delete
+     * @param memberOptional an Optional containing the AcspMembers if found
+     * @return the result of testDataService.deleteAcspMembersData(...)
+     * @throws DataException if deletion fails
+     */
+    private boolean deleteAcspMembersDataHelper(String acspMemberId,
+                                                Optional<AcspMembers> memberOptional)
+            throws DataException {
+        when(acspMembersRepository.findById(acspMemberId)).thenReturn(memberOptional);
+        return testDataService.deleteAcspMembersData(acspMemberId);
+    }
+
+    @Test
+    void createAcspMembersData() throws DataException {
+        AcspProfileRequest profileSpec = new AcspProfileRequest();
+        profileSpec.setAcspNumber("acspNumber");
+        profileSpec.setStatus("active");
+        profileSpec.setType("limited-company");
+
+        AcspProfile profileEntity = new AcspProfile();
+        profileEntity.setAcspNumber(profileSpec.getAcspNumber());
+        profileEntity.setName(profileSpec.getName());
+        profileEntity.setVersion(1L);
+
+        AcspProfileResponse acspProfileResponse =
+                new AcspProfileResponse(profileEntity);
+        AcspMembersResponse expectedMembersData =
+                new AcspMembersResponse(new ObjectId(),
+                        profileSpec.getAcspNumber(), "userId", "active", "role");
+        AcspMembersResponse result = createAcspMembersDataHelper(
+                "userId", acspProfileResponse, expectedMembersData, profileSpec);
+        verifyAcspMembersData(result,
+                String.valueOf(expectedMembersData.getAcspMemberId()),
+                acspProfileResponse.getAcspNumber(), expectedMembersData.getUserId(),
+                expectedMembersData.getStatus(), expectedMembersData.getUserRole());
+        verify(acspMembersService).create(any(AcspMembersRequest.class));
+        verify(acspProfileService).create(argThat(profile -> profile.getAmlDetails() == null));
+    }
+
+    @Test
+    void createAcspMembersDataNullUserId() {
+        AcspMembersRequest spec = new AcspMembersRequest();
+        DataException exception = assertThrows(DataException.class,
+                () -> testDataService.createAcspMembersData(spec));
+        assertEquals("User ID is required to create an ACSP member", exception.getMessage());
+    }
+
+    @Test
+    void createAcspMembersDataException() throws DataException {
+        AcspMembersRequest spec = new AcspMembersRequest();
+        spec.setUserId("userId");
+
+        when(acspProfileService.create(any(AcspProfileRequest.class)))
+                .thenThrow(new DataException("Error creating ACSP profile"));
+        DataException exception = assertThrows(DataException.class,
+                () -> testDataService.createAcspMembersData(spec));
+        assertEquals(
+                "uk.gov.companieshouse.api.testdata.exception.DataException: Error creating ACSP profile",
+                exception.getMessage());
+    }
+
+    @Test
+    void createAcspMembersDataWhenProfileIsNotNull() throws DataException {
+        AcspMembersRequest spec = new AcspMembersRequest();
+        spec.setUserId("userId");
+        AcspProfile profileEntity = new AcspProfile();
+        profileEntity.setAcspNumber("acspNumber");
+        profileEntity.setName("name");
+        profileEntity.setVersion(1L);
+
+        AcspProfileResponse acspProfileResponse = new AcspProfileResponse(profileEntity);
+        var acspStatus = "active";
+        var acspType = "ltd";
+        var supervisoryBody = "financial-conduct-authority-fca";
+        var membershipDetails = "Membership ID: FCA654321";
+        AcspProfileRequest acspProfile = new AcspProfileRequest();
+        acspProfile.setStatus(acspStatus);
+        acspProfile.setType(acspType);
+        AmlRequest amlRequest = new AmlRequest();
+        amlRequest.setSupervisoryBody(supervisoryBody);
+        amlRequest.setMembershipDetails(membershipDetails);
+        acspProfile.setAmlDetails(Collections.singletonList(amlRequest));
+        spec.setAcspProfile(acspProfile);
+        AcspMembersResponse acspMembersResponse =
+                new AcspMembersResponse(new ObjectId(), acspProfileResponse.getAcspNumber(),"userId",
+                        "active", "role");
+        when(acspProfileService.create(any(AcspProfileRequest.class))).thenReturn(acspProfileResponse);
+        when(acspMembersService.create(any(AcspMembersRequest.class))).thenReturn(acspMembersResponse);
+        AcspMembersResponse result = testDataService.createAcspMembersData(spec);
+
+        verifyAcspMembersData(result,
+                String.valueOf(acspMembersResponse.getAcspMemberId()),
+                acspProfileResponse.getAcspNumber(), acspMembersResponse.getUserId(), acspMembersResponse.getStatus(), acspMembersResponse.getUserRole());
+        acspProfileResponse.getAcspNumber();
+
+        verify(acspProfileService).create(acspProfile);
+
+        verify(acspMembersService).create(argThat(membersSpec ->
+                acspMembersResponse.getUserId().equals(membersSpec.getUserId())
+                        && acspMembersResponse.getAcspNumber().equals(membersSpec.getAcspNumber())
+        ));
+    }
+
+    @Test
+    void createAcspMembersDataWhenProfileIsNull() throws DataException {
+        AcspMembersRequest spec = new AcspMembersRequest();
+        spec.setUserId("userId");
+
+        AcspProfile profileEntity = new AcspProfile();
+        profileEntity.setAcspNumber("acspNumber");
+        profileEntity.setName("name");
+        profileEntity.setVersion(1L);
+
+        AcspProfileResponse acspProfileResponse = new AcspProfileResponse(profileEntity);
+        AcspMembersResponse acspMembersResponse = new AcspMembersResponse(new ObjectId(),
+                "acspNumber", "userId", "active", "role");
+        spec.setAcspProfile(null);
+
+        when(acspProfileService.create(any(AcspProfileRequest.class))).thenReturn(acspProfileResponse);
+        when(acspMembersService.create(any(AcspMembersRequest.class))).thenReturn(acspMembersResponse);
+
+        AcspMembersResponse result = testDataService.createAcspMembersData(spec);
+
+        verifyAcspMembersData(result,
+                String.valueOf(acspMembersResponse.getAcspMemberId()),
+                acspProfileResponse.getAcspNumber(), acspMembersResponse.getUserId(), acspMembersResponse.getStatus(), acspMembersResponse.getUserRole());
+
+        verify(acspProfileService).create(argThat(profile ->
+                profile.getStatus() == null
+                        && profile.getType() == null
+                        && profile.getAmlDetails() == null));
+        verify(acspMembersService).create(argThat(membersSpec ->
+                acspMembersResponse.getUserId().equals(membersSpec.getUserId())
+                        && acspMembersResponse.getAcspNumber().equals(membersSpec.getAcspNumber())
+        ));
+    }
+
+    @Test
+    void createAcspMembersDataProfileCreationException() throws DataException {
+        AcspMembersRequest spec = new AcspMembersRequest();
+        spec.setUserId("userId");
+        AcspProfileRequest profileRequest = new AcspProfileRequest();
+        profileRequest.setStatus("active");
+        profileRequest.setType("limited-company");
+        spec.setAcspProfile(profileRequest);
+
+        when(acspProfileService.create(any(AcspProfileRequest.class)))
+                .thenThrow(new DataException("Error creating ACSP profile"));
+        DataException exception = assertThrows(DataException.class,
+                () -> testDataService.createAcspMembersData(spec));
+        assertEquals(
+                "uk.gov.companieshouse.api.testdata.exception.DataException: Error creating ACSP profile",
+                exception.getMessage());
+        verify(acspProfileService).create(profileRequest);
+        verify(acspMembersService, never()).create(any(AcspMembersRequest.class));
+    }
+
+    @Test
+    void createAcspMembersDataMemberCreationException() throws DataException {
+        AcspMembersRequest spec = new AcspMembersRequest();
+        spec.setUserId("userId");
+
+        AcspProfile profileEntity = new AcspProfile();
+        profileEntity.setAcspNumber("acspNumber");
+        profileEntity.setName("name");
+        profileEntity.setVersion(1L);
+
+        AcspProfileResponse acspProfileResponse = new AcspProfileResponse(profileEntity);
+        when(acspProfileService.create(any(AcspProfileRequest.class))).thenReturn(acspProfileResponse);
+        when(acspMembersService.create(any(AcspMembersRequest.class)))
+                .thenThrow(new DataException("Error creating ACSP member"));
+        DataException exception = assertThrows(DataException.class,
+                () -> testDataService.createAcspMembersData(spec));
+        assertEquals(
+                "uk.gov.companieshouse.api.testdata.exception.DataException: Error creating ACSP member",
+                exception.getMessage());
+    }
+
+    @Test
+    void deleteAcspMembersData() throws DataException {
+        String acspMemberId = "memberId";
+        AcspMembers member = new AcspMembers();
+        member.setAcspNumber("acspNumber");
+
+        boolean result = deleteAcspMembersDataHelper(acspMemberId, Optional.of(member));
+
+        assertTrue(result);
+        verify(acspMembersService).delete(acspMemberId);
+        verify(acspProfileService).delete("acspNumber");
+    }
+
+    @Test
+    void deleteAcspMembersDataNotFound() throws DataException {
+        String acspMemberId = "memberId";
+        boolean result = deleteAcspMembersDataHelper(acspMemberId, Optional.empty());
+
+        assertFalse(result);
+        verify(acspMembersService, never()).delete(anyString());
+        verify(acspProfileService, never()).delete(anyString());
+    }
+
+    @Test
+    void deleteAcspMembersDataException() {
+        String acspMemberId = "memberId";
+        AcspMembers member = new AcspMembers();
+        member.setAcspNumber("acspNumber");
+
+        when(acspMembersRepository.findById(acspMemberId)).thenReturn(Optional.of(member));
+        doThrow(new RuntimeException(new DataException("Error")))
+                .when(acspMembersService).delete(acspMemberId);
+        DataException exception = assertThrows(DataException.class,
+                () -> testDataService.deleteAcspMembersData(acspMemberId));
+        assertEquals("Error deleting acsp member's data", exception.getMessage());
+    }
+
+    @Test
+    void getAcspProfileDataReturnsProfile() throws NoDataFoundException {
+        String acspNumber = "AP000036";
+
+        AcspProfile profile = new AcspProfile();
+        profile.setId(acspNumber);
+        profile.setAcspNumber(acspNumber);
+        profile.setName("Test ACSP Company");
+        profile.setStatus("active");
+
+        when(acspProfileService.getAcspProfile(acspNumber)).thenReturn(Optional.of(profile));
+
+        Optional<AcspProfile> result = testDataService.getAcspProfileData(acspNumber);
+
+        assertNotNull(result);
+        assertTrue(result.isPresent());
+
+        AcspProfile returnedProfile = result.get();
+        assertEquals(acspNumber, returnedProfile.getId());
+        assertEquals(acspNumber, returnedProfile.getAcspNumber());
+        assertEquals("Test ACSP Company", returnedProfile.getName());
+        assertEquals("active", returnedProfile.getStatus());
+
+        verify(acspProfileService, times(1)).getAcspProfile(acspNumber);
+    }
+
+    @Test
+    void getAcspProfileDataReturnsEmpty() throws NoDataFoundException {
+        String acspNumber = "NON_EXISTENT";
+
+        when(acspProfileService.getAcspProfile(acspNumber)).thenReturn(Optional.empty());
+
+        Optional<AcspProfile> result = testDataService.getAcspProfileData(acspNumber);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(acspProfileService, times(1)).getAcspProfile(acspNumber);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/AcspWorkflowServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/AcspWorkflowServiceImplTest.java
@@ -10,7 +10,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,7 +23,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
-import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
 import uk.gov.companieshouse.api.testdata.model.entity.AcspMembers;
 import uk.gov.companieshouse.api.testdata.model.entity.AcspProfile;
 import uk.gov.companieshouse.api.testdata.model.rest.request.AcspMembersRequest;
@@ -308,45 +306,5 @@ class AcspWorkflowServiceImplTest {
         DataException exception = assertThrows(DataException.class,
                 () -> acspWorkflowService.deleteAcspMembersData(acspMemberId));
         assertEquals("Error deleting acsp member's data", exception.getMessage());
-    }
-
-    @Test
-    void getAcspProfileDataReturnsProfile() throws NoDataFoundException {
-        String acspNumber = "AP000036";
-
-        AcspProfile profile = new AcspProfile();
-        profile.setId(acspNumber);
-        profile.setAcspNumber(acspNumber);
-        profile.setName("Test ACSP Company");
-        profile.setStatus("active");
-
-        when(acspProfileService.getAcspProfile(acspNumber)).thenReturn(Optional.of(profile));
-
-        Optional<AcspProfile> result = acspWorkflowService.getAcspProfileData(acspNumber);
-
-        assertNotNull(result);
-        assertTrue(result.isPresent());
-
-        AcspProfile returnedProfile = result.get();
-        assertEquals(acspNumber, returnedProfile.getId());
-        assertEquals(acspNumber, returnedProfile.getAcspNumber());
-        assertEquals("Test ACSP Company", returnedProfile.getName());
-        assertEquals("active", returnedProfile.getStatus());
-
-        verify(acspProfileService, times(1)).getAcspProfile(acspNumber);
-    }
-
-    @Test
-    void getAcspProfileDataReturnsEmpty() throws NoDataFoundException {
-        String acspNumber = "NON_EXISTENT";
-
-        when(acspProfileService.getAcspProfile(acspNumber)).thenReturn(Optional.empty());
-
-        Optional<AcspProfile> result = acspWorkflowService.getAcspProfileData(acspNumber);
-
-        assertNotNull(result);
-        assertTrue(result.isEmpty());
-
-        verify(acspProfileService, times(1)).getAcspProfile(acspNumber);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/AcspWorkflowServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/AcspWorkflowServiceImplTest.java
@@ -39,7 +39,7 @@ import uk.gov.companieshouse.api.testdata.service.AcspProfileService;
 import uk.gov.companieshouse.api.testdata.service.DataService;
 
 @ExtendWith(MockitoExtension.class)
-public class AcspWorkflowServiceImplTest {
+class AcspWorkflowServiceImplTest {
 
     @Mock
     private DataService<AcspMembersResponse, AcspMembersRequest> acspMembersService;
@@ -48,7 +48,6 @@ public class AcspWorkflowServiceImplTest {
     @Mock
     private AcspProfileService acspProfileService;
 
-    // Manually constructed in @BeforeEach to guarantee correct injection order.
     private AcspWorkflowServiceImpl testDataService;
 
     @BeforeEach


### PR DESCRIPTION
This pull request refactors the handling of ACSP member and profile endpoints and their related service logic. The main changes are the extraction of ACSP-specific logic from the generic `TestDataController` and `TestDataService` into dedicated controllers and a new `AcspWorkflowService` interface. This improves modularity and separates ACSP workflows from other test data operations.

Key changes include:

**Separation of ACSP Endpoints and Logic:**
- Added new controllers: `AcspMemberController` and `AcspProfileController`, which now handle ACSP member creation/deletion and profile retrieval endpoints, respectively. These endpoints were removed from `TestDataController`. [[1]](diffhunk://#diff-5efcc27719e96efed40dc66596344d56ec1788799eb7be0a0dfd084c745f0014R1-R68) [[2]](diffhunk://#diff-d9ff8cb66d3f3d489f9861cada1b5cb4dc05fe6cd669efd07caa810285f7f3e6R1-R40) [[3]](diffhunk://#diff-b2470cb655a0da3c7274fdb8327991414f0aae5ee42a773a1f15a23f05bbe947L104-L115) [[4]](diffhunk://#diff-b2470cb655a0da3c7274fdb8327991414f0aae5ee42a773a1f15a23f05bbe947L155-L172) [[5]](diffhunk://#diff-b2470cb655a0da3c7274fdb8327991414f0aae5ee42a773a1f15a23f05bbe947L337-L346)
- Introduced the `AcspWorkflowService` interface to encapsulate ACSP member and profile operations, decoupling them from the generic `TestDataService`. [[1]](diffhunk://#diff-826b90d8c748644620fc1ff08866059f5f665ca49a0958e0ce34eb850c2b21d0R1-R47) [[2]](diffhunk://#diff-ddb2bd7fbe94018b87111232e70ab974554b5b5676e46b299ad3da8351da1668L30-L53) [[3]](diffhunk://#diff-ddb2bd7fbe94018b87111232e70ab974554b5b5676e46b299ad3da8351da1668L191-L199)

**Codebase Cleanup and Dependency Removal:**
- Removed ACSP-related service methods and dependencies from `TestDataService`, `TestDataServiceImpl`, and their associated imports and fields, reducing unnecessary coupling. [[1]](diffhunk://#diff-ddb2bd7fbe94018b87111232e70ab974554b5b5676e46b299ad3da8351da1668L30-L53) [[2]](diffhunk://#diff-ddb2bd7fbe94018b87111232e70ab974554b5b5676e46b299ad3da8351da1668L191-L199) F442210dL9R9, [[3]](diffhunk://#diff-4316a3fd5711d392ba86819d2fce6bfc5b8aed01337e004e2a64e5487328e197L23-L32) [[4]](diffhunk://#diff-4316a3fd5711d392ba86819d2fce6bfc5b8aed01337e004e2a64e5487328e197L44-L52) [[5]](diffhunk://#diff-4316a3fd5711d392ba86819d2fce6bfc5b8aed01337e004e2a64e5487328e197L63-L68) [[6]](diffhunk://#diff-4316a3fd5711d392ba86819d2fce6bfc5b8aed01337e004e2a64e5487328e197L79-L150) [[7]](diffhunk://#diff-4316a3fd5711d392ba86819d2fce6bfc5b8aed01337e004e2a64e5487328e197L357-L378)

These changes help make the codebase more maintainable and modular by isolating ACSP workflows from the rest of the test data logic.