### PR TITLE
Feature/fix spring boot dependency issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>4.0.416</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.17</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.18</test-data-generator-library.version>
 
         <!-- Sonar config -->
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>4.0.416</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.18</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.0-SNAPSHOT</test-data-generator-library.version>
 
         <!-- Sonar config -->
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>4.0.416</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.0-SNAPSHOT</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.19</test-data-generator-library.version>
 
         <!-- Sonar config -->
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>

--- a/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
@@ -38,6 +38,7 @@ import uk.gov.companieshouse.api.testdata.repository.IdentityRepository;
 import uk.gov.companieshouse.api.testdata.repository.ItemGroupsRepository;
 import uk.gov.companieshouse.api.testdata.repository.MissingImageDeliveriesRepository;
 import uk.gov.companieshouse.api.testdata.repository.OfficerRepository;
+import uk.gov.companieshouse.api.testdata.repository.OverseasEntityRepository;
 import uk.gov.companieshouse.api.testdata.repository.TransactionsRepository;
 import uk.gov.companieshouse.api.testdata.repository.UserCompanyAssociationRepository;
 import uk.gov.companieshouse.api.testdata.repository.UserRepository;
@@ -65,6 +66,11 @@ public class MongoConfig {
     @Bean
     public CompanyProfileRepository companyProfileRepository() {
         return getMongoRepositoryBean(CompanyProfileRepository.class, "company_profile");
+    }
+
+    @Bean
+    public OverseasEntityRepository overseasEntityRepository() {
+        return getMongoRepositoryBean(OverseasEntityRepository.class, "company_profile");
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/api/testdata/repository/OverseasEntityRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/repository/OverseasEntityRepository.java
@@ -1,0 +1,10 @@
+package uk.gov.companieshouse.api.testdata.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+import uk.gov.companieshouse.api.testdata.model.entity.OverseasEntity;
+
+@NoRepositoryBean
+public interface OverseasEntityRepository extends MongoRepository<OverseasEntity, String> {
+}
+

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -316,6 +316,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
 
         // Accounts
         var accounts = overseasEntity.getAccounts();
+        accounts.setOverdue(false);
         accounts.setNextMadeUpTo(dateInOneYear);
         accounts.setNextDue(dateInOneYearTwoWeeks);
         accounts.setNextAccountsOverdue(false);
@@ -324,6 +325,10 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         accounts.setPeriodEnd(dateInOneYear);
         accounts.setAccountingReferenceDateDay("9");
         accounts.setAccountingReferenceDateMonth("9");
+        accounts.setLastAccountsType("aa");
+        accounts.setLastAccountsPeriodStartOn(dateOneYearAgo);
+        accounts.setLastAccountsPeriodEndOn(dateNow);
+        accounts.setLastAccountsMadeUpTo(dateInOneYear);
 
         if (CompanyType.OVERSEA_COMPANY.equals(companyType)) {
             foreignCompanyDetails.setRegistrationNumber(EXT_REGISTRATION_NUMBER);

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.lang.BooleanUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -27,6 +26,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyNameEnding;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.JurisdictionType;
 import uk.gov.companieshouse.api.testdata.repository.CompanyProfileRepository;
+import uk.gov.companieshouse.api.testdata.repository.OverseasEntityRepository;
 import uk.gov.companieshouse.api.testdata.service.AddressService;
 import uk.gov.companieshouse.api.testdata.service.CompanyProfileService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
@@ -68,14 +68,23 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
             FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY_MUTUALS_PUBLIC_REGISTER =
             "full-data-available-from-financial-conduct-authority-mutuals-public-register";
 
-    @Autowired
-    private RandomService randomService;
+    private final RandomService randomService;
 
-    @Autowired
-    private AddressService addressService;
+    private final AddressService addressService;
 
-    @Autowired
-    private CompanyProfileRepository repository;
+    private final CompanyProfileRepository companyProfileRepository;
+
+    private final OverseasEntityRepository overseasEntityRepository;
+
+    public CompanyProfileServiceImpl(RandomService randomService,
+                                     AddressService addressService,
+                                     CompanyProfileRepository companyProfileRepository,
+                                     OverseasEntityRepository overseasEntityRepository) {
+        this.randomService = randomService;
+        this.addressService = addressService;
+        this.companyProfileRepository = companyProfileRepository;
+        this.overseasEntityRepository = overseasEntityRepository;
+    }
 
     private boolean hasCompanyRegisters = false;
 
@@ -210,7 +219,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         if (Boolean.TRUE.equals(spec.getCompanyWithPopulatedStructureOnly())) {
             return profile;
         }
-        return repository.save(profile);
+        return companyProfileRepository.save(profile);
     }
 
     private OverseasEntity createOverseasEntity(String companyNumber,
@@ -306,34 +315,15 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         overseasEntity.setForeignCompanyDetails(foreignCompanyDetails);
 
         // Accounts
-        OverseasEntity.IAccounts accounts = OverseasEntity.createAccounts();
-        accounts.setOverdue(false);
+        var accounts = overseasEntity.getAccounts();
         accounts.setNextMadeUpTo(dateInOneYear);
         accounts.setNextDue(dateInOneYearTwoWeeks);
-
-        // Accounting Reference Date
-        var overseasAccountingReferenceDate = new OverseasEntity.AccountingReferenceDate();
-        overseasAccountingReferenceDate.setDay("9");
-        overseasAccountingReferenceDate.setMonth("9");
-        accounts.setAccountingReferenceDate(overseasAccountingReferenceDate);
-
-        // Next Accounts
-        var nextAccounts = new OverseasEntity.NextAccounts();
-        nextAccounts.setOverdue(false);
-        nextAccounts.setDueOn(dateInOneYearTwoWeeks);
-        nextAccounts.setPeriodStartOn(dateNow);
-        nextAccounts.setPeriodEndOn(dateInOneYear);
-        accounts.setNextAccounts(nextAccounts);
-
-        // Last Accounts
-        var lastAccounts = new OverseasEntity.LastAccounts();
-        lastAccounts.setType("aa");
-        lastAccounts.setPeriodStartOn(dateOneYearAgo);
-        lastAccounts.setPeriodEndOn(dateNow);
-        lastAccounts.setMadeUpTo(dateInOneYear);
-        accounts.setLastAccounts(lastAccounts);
-
-        overseasEntity.setAccounts(accounts);
+        accounts.setNextAccountsOverdue(false);
+        accounts.setNextAccountsDueOn(dateInOneYearTwoWeeks);
+        accounts.setPeriodStart(dateNow);
+        accounts.setPeriodEnd(dateInOneYear);
+        accounts.setAccountingReferenceDateDay("9");
+        accounts.setAccountingReferenceDateMonth("9");
 
         if (CompanyType.OVERSEA_COMPANY.equals(companyType)) {
             foreignCompanyDetails.setRegistrationNumber(EXT_REGISTRATION_NUMBER);
@@ -352,7 +342,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
             return overseasEntity;
         }
 
-        repository.save(overseasEntity);
+        overseasEntityRepository.save(overseasEntity);
         LOG.info("Returning a CompanyProfile view for " + entityType + ". " + companyNumber);
         return overseasEntity;
     }
@@ -392,7 +382,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         links.setOverseas(LINK_STEM + parentCompanyNumber);
         ukEstablishment.setLinks(links);
 
-        repository.save(ukEstablishment);
+        companyProfileRepository.save(ukEstablishment);
         LOG.info("Created UK establishment " + ukEstablishmentNumber);
 
         return ukEstablishmentNumber;
@@ -420,11 +410,11 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
 
     @Override
     public boolean delete(String companyId) {
-        Optional<CompanyProfile> profile = repository.findByCompanyNumber(companyId)
-                .or(() -> repository.findById(companyId));
+        Optional<CompanyProfile> profile = companyProfileRepository.findByCompanyNumber(companyId)
+                .or(() -> companyProfileRepository.findById(companyId));
 
         if (profile.isPresent()) {
-            repository.delete(profile.get());
+            companyProfileRepository.delete(profile.get());
             return true;
         }
         return false;
@@ -432,7 +422,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
 
     @Override
     public boolean companyExists(String companyNumber) {
-        return repository.findById(companyNumber).isPresent();
+        return companyProfileRepository.findById(companyNumber).isPresent();
     }
 
     private Links createLinks(String companyNumber) {
@@ -575,7 +565,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
 
     @Override
     public List<String> findUkEstablishmentsByParent(String parentCompanyNumber) {
-        return repository.findByBranchCompanyDetailsParentCompanyNumber(parentCompanyNumber)
+        return companyProfileRepository.findByBranchCompanyDetailsParentCompanyNumber(parentCompanyNumber)
                 .stream()
                 .map(CompanyProfile::getCompanyNumber)
                 .toList();
@@ -583,7 +573,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
 
     @Override
     public Optional<CompanyProfile> getCompanyProfile(String companyNumber) {
-        return repository.findByCompanyNumber(companyNumber);
+        return companyProfileRepository.findByCompanyNumber(companyNumber);
     }
 
     @Override
@@ -594,7 +584,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
             throw new DataException("companyNumber is required");
         }
 
-        CompanyProfile company = repository.findByCompanyNumber(request.getCompanyNumber())
+        CompanyProfile company = companyProfileRepository.findByCompanyNumber(request.getCompanyNumber())
                 .orElseThrow(() -> new NoDataFoundException(
                         "Company not found for number: " + request.getCompanyNumber()));
 
@@ -609,7 +599,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         }
 
         try {
-            return repository.save(company);
+            return companyProfileRepository.save(company);
         } catch (Exception ex) {
             throw new DataException("Failed to update company profile", ex);
         }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -429,6 +429,11 @@ class CompanyProfileServiceImplTest {
         assertNotNull(result.getConfirmationStatement().getNextDue());
         assertNotNull(result.getConfirmationStatement().getNextMadeUpTo());
         assertNotNull(result.getRegisteredOfficeAddress());
+        assertFalse(result.getAccounts().getOverdue());
+        assertEquals("aa", result.getAccounts().getLastAccountsType());
+        assertNotNull(result.getAccounts().getLastAccountsPeriodStartOn());
+        assertNotNull(result.getAccounts().getLastAccountsPeriodEndOn());
+        assertNotNull(result.getAccounts().getLastAccountsMadeUpTo());
     }
 
     @Test
@@ -441,6 +446,11 @@ class CompanyProfileServiceImplTest {
         assertNull(profile.getLinks().getFilingHistory());
         assertNull(profile.getLinks().getOfficers());
         assertNull(profile.getLinks().getPersonsWithSignificantControlStatement());
+        assertFalse(profile.getAccounts().getOverdue());
+        assertEquals("aa", profile.getAccounts().getLastAccountsType());
+        assertNotNull(profile.getAccounts().getLastAccountsPeriodStartOn());
+        assertNotNull(profile.getAccounts().getLastAccountsPeriodEndOn());
+        assertNotNull(profile.getAccounts().getLastAccountsMadeUpTo());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -48,6 +48,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.enums.JurisdictionType;
 import uk.gov.companieshouse.api.testdata.model.rest.request.RegistersRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateCompanyRequest;
 import uk.gov.companieshouse.api.testdata.repository.CompanyProfileRepository;
+import uk.gov.companieshouse.api.testdata.repository.OverseasEntityRepository;
 import uk.gov.companieshouse.api.testdata.service.AddressService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 
@@ -82,6 +83,8 @@ class CompanyProfileServiceImplTest {
     private AddressService addressService;
     @Mock
     private CompanyProfileRepository repository;
+    @Mock
+    private OverseasEntityRepository overseasEntityRepository;
 
     @InjectMocks
     private CompanyProfileServiceImpl companyProfileService;
@@ -112,6 +115,8 @@ class CompanyProfileServiceImplTest {
     private void setupCommonMocks(CompanyRequest spec, Address mockAddress) {
         Mockito.lenient().when(randomService.getEtag()).thenReturn(ETAG);
         Mockito.lenient().when(repository.save(any())).thenReturn(savedProfile);
+        Mockito.lenient().when(overseasEntityRepository.save(any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
         Mockito.lenient().when(addressService.getAddress(spec.getJurisdiction())).thenReturn(mockAddress);
     }
 
@@ -119,6 +124,12 @@ class CompanyProfileServiceImplTest {
         Address mockAddress = new Address("", "", "", "", "", "");
         setupCommonMocks(spec, mockAddress);
         CompanyProfile returnedProfile = companyProfileService.create(spec);
+        if (CompanyType.REGISTERED_OVERSEAS_ENTITY.equals(spec.getCompanyType())
+                || CompanyType.OVERSEA_COMPANY.equals(spec.getCompanyType())) {
+            ArgumentCaptor<OverseasEntity> captor = ArgumentCaptor.forClass(OverseasEntity.class);
+            verify(overseasEntityRepository).save(captor.capture());
+            return captor.getValue();
+        }
         ArgumentCaptor<CompanyProfile> captor = ArgumentCaptor.forClass(CompanyProfile.class);
         verify(repository).save(captor.capture());
         return captor.getValue();
@@ -405,11 +416,10 @@ class CompanyProfileServiceImplTest {
         Address overseasAddress = new Address("1", "Gordon Cummins Hwy", "Grantley Adams International Airport", "Barbados", "Christ Church", "123125");
         when(addressService.getOverseasAddress()).thenReturn(overseasAddress);
         when(randomService.getEtag()).thenReturn(ETAG);
-        when(repository.save(any())).thenReturn(savedProfile);
 
         CompanyProfile result = companyProfileService.create(overseasSpec);
-        ArgumentCaptor<CompanyProfile> captor = ArgumentCaptor.forClass(CompanyProfile.class);
-        verify(repository).save(captor.capture());
+        ArgumentCaptor<OverseasEntity> captor = ArgumentCaptor.forClass(OverseasEntity.class);
+        verify(overseasEntityRepository).save(captor.capture());
         CompanyProfile savedEntity = captor.getValue();
         assertTrue(savedEntity instanceof OverseasEntity, "Expected an instance of OverseasEntity");
         assertEquals(REGISTERED_OVERSEAS_ENTITY_NUMBER, result.getId());
@@ -650,11 +660,10 @@ class CompanyProfileServiceImplTest {
         Mockito.lenient().when(addressService.getAddress(overseasSpec.getJurisdiction()))
                 .thenReturn(new Address("", "", "", "", "", ""));
         Mockito.lenient().when(randomService.getEtag()).thenReturn(ETAG);
-        when(repository.save(any())).thenReturn(savedProfile);
 
         CompanyProfile result = companyProfileService.create(overseasSpec);
-        ArgumentCaptor<CompanyProfile> captor = ArgumentCaptor.forClass(CompanyProfile.class);
-        verify(repository).save(captor.capture());
+        ArgumentCaptor<OverseasEntity> captor = ArgumentCaptor.forClass(OverseasEntity.class);
+        verify(overseasEntityRepository).save(captor.capture());
         CompanyProfile savedEntity = captor.getValue();
 
         assertInstanceOf(OverseasEntity.class, savedEntity, "Expected an instance of OverseasEntity");


### PR DESCRIPTION
This pull request introduces a new `OverseasEntityRepository` for handling `OverseasEntity` persistence separately from regular company profiles, and refactors the `CompanyProfileServiceImpl` to use this new repository. It also updates related tests to verify the correct repository is used for overseas entities and simplifies the accounts data structure for these entities.

**Repository and Service Refactoring:**
- Added a new `OverseasEntityRepository` interface extending `MongoRepository` for `OverseasEntity` objects, and registered it as a Spring bean in `MongoConfig`. (`src/main/java/uk/gov/companieshouse/api/testdata/repository/OverseasEntityRepository.java`, `src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java`) [[1]](diffhunk://#diff-67190d713e91834f0e3d1a2e4ca40f4f43a21d0ee484c562b092fe5e84c3fa4fR1-R10) [[2]](diffhunk://#diff-3231932306bf09b3922efe48b53f3fbf4e9b9d179a9dad960f8d06cbcc1aa45dR41) [[3]](diffhunk://#diff-3231932306bf09b3922efe48b53f3fbf4e9b9d179a9dad960f8d06cbcc1aa45dR71-R75)
- Refactored `CompanyProfileServiceImpl` to use constructor injection for dependencies, replaced all direct usage of the old `repository` field with either `companyProfileRepository` or `overseasEntityRepository` as appropriate, and updated the logic to save and retrieve overseas entities using the new repository. (`src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java`) [[1]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086L71-R87) [[2]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086L213-R222) [[3]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086L355-R350) [[4]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086L395-R390) [[5]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086L423-R430) [[6]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086L578-R581) [[7]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086L597-R592) [[8]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086L612-R607)

**Accounts Data Structure Simplification:**
- Simplified the way accounts data is set up for `OverseasEntity`, flattening the structure and removing nested classes for accounts, next accounts, and last accounts. (`src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java`)

**Testing Improvements:**
- Updated tests to mock and verify usage of `OverseasEntityRepository` instead of `CompanyProfileRepository` when creating overseas entities, and added assertions for the new accounts fields. (`src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java`) [[1]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3R51) [[2]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3R86-R87) [[3]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3R118-R132) [[4]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3L408-R422) [[5]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3R432-R436) [[6]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3R449-R453) [[7]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3L653-R676)

**Build Dependency Update:**
- Updated the version of `test-data-generator-library` from `1.0.17` to `1.0.19` in `pom.xml`.