### PR TITLE
Feature/tdg 81 restrict company sub type private fund limited partnership to limited partnerships

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import org.apache.commons.lang.BooleanUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.util.StringUtils;
 
 import uk.gov.companieshouse.api.testdata.exception.DataException;
@@ -500,16 +501,19 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
     }
 
     private void setSubType(CompanyProfile profile, String subType, CompanyType companyType) {
-        if (subType != null && isAllowedSubType(subType, companyType)) {
+        validateSubType(subType, companyType);
+        if (subType != null) {
             profile.setIsCommunityInterestCompany(
                     subType.equals(COMMUNITY_INTEREST_COMPANY_SUB_TYPE));
             profile.setSubtype(subType);
         }
     }
 
-    private boolean isAllowedSubType(String subType, CompanyType companyType) {
-        return !PRIVATE_FUND_LIMITED_PARTNERSHIP_SUB_TYPE.equals(subType)
-                || CompanyType.LIMITED_PARTNERSHIP.equals(companyType);
+    private void validateSubType(String subType, CompanyType companyType) {
+        if (PRIVATE_FUND_LIMITED_PARTNERSHIP_SUB_TYPE.equals(subType)
+                && !CompanyType.LIMITED_PARTNERSHIP.equals(companyType)) {
+            throw new HttpMessageNotReadableException("invalid request", null);
+        }
     }
 
     private void setCompanyStatusDetail(

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -31,6 +31,7 @@ import uk.gov.companieshouse.api.testdata.repository.OverseasEntityRepository;
 import uk.gov.companieshouse.api.testdata.service.AddressService;
 import uk.gov.companieshouse.api.testdata.service.CompanyProfileService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
+import uk.gov.companieshouse.api.testdata.service.validation.CompanySubTypeRule;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
@@ -58,8 +59,6 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
     private static final String TERMS_OF_PUBLICATION = "Terms of Account Publication";
     private static final String GOVERNED_BY = "Federal Government";
     private static final String COMMUNITY_INTEREST_COMPANY_SUB_TYPE = "community-interest-company";
-    private static final String PRIVATE_FUND_LIMITED_PARTNERSHIP_SUB_TYPE =
-            "private-fund-limited-partnership";
     public static final String
             FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY =
             "full-data-available-from-financial-conduct-authority";
@@ -510,8 +509,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
     }
 
     private void validateSubType(String subType, CompanyType companyType) {
-        if (PRIVATE_FUND_LIMITED_PARTNERSHIP_SUB_TYPE.equals(subType)
-                && !CompanyType.LIMITED_PARTNERSHIP.equals(companyType)) {
+        if (!CompanySubTypeRule.isValidForCompanyType(subType, companyType)) {
             throw new HttpMessageNotReadableException("invalid request", null);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -56,6 +56,9 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
     private static final String FOREIGN_ACCOUNT_TYPE = "ForeignAccountType";
     private static final String TERMS_OF_PUBLICATION = "Terms of Account Publication";
     private static final String GOVERNED_BY = "Federal Government";
+    private static final String COMMUNITY_INTEREST_COMPANY_SUB_TYPE = "community-interest-company";
+    private static final String PRIVATE_FUND_LIMITED_PARTNERSHIP_SUB_TYPE =
+            "private-fund-limited-partnership";
     public static final String
             FULL_DATA_AVAILABLE_FROM_FINANCIAL_CONDUCT_AUTHORITY =
             "full-data-available-from-financial-conduct-authority";
@@ -213,7 +216,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         profile.setHasCharges(false);
         profile.setCanFile(true);
         setPartialDataOptions(profile, jurisdiction, companyType);
-        setSubType(profile, subType);
+        setSubType(profile, subType, companyType);
         setCompanyStatusDetail(profile, companyStatusDetail, companyTypeValue);
 
         if (Boolean.TRUE.equals(spec.getCompanyWithPopulatedStructureOnly())) {
@@ -496,11 +499,17 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         }
     }
 
-    private void setSubType(CompanyProfile profile, String subType) {
-        if (subType != null) {
-            profile.setIsCommunityInterestCompany(subType.equals("community-interest-company"));
+    private void setSubType(CompanyProfile profile, String subType, CompanyType companyType) {
+        if (subType != null && isAllowedSubType(subType, companyType)) {
+            profile.setIsCommunityInterestCompany(
+                    subType.equals(COMMUNITY_INTEREST_COMPANY_SUB_TYPE));
             profile.setSubtype(subType);
         }
+    }
+
+    private boolean isAllowedSubType(String subType, CompanyType companyType) {
+        return !PRIVATE_FUND_LIMITED_PARTNERSHIP_SUB_TYPE.equals(subType)
+                || CompanyType.LIMITED_PARTNERSHIP.equals(companyType);
     }
 
     private void setCompanyStatusDetail(

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/CreateCompanyWorkflowServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/CreateCompanyWorkflowServiceImpl.java
@@ -31,6 +31,7 @@ import uk.gov.companieshouse.api.testdata.service.CompanyStructurePersistenceSer
 import uk.gov.companieshouse.api.testdata.service.DataService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 import uk.gov.companieshouse.api.testdata.service.impl.CompanyPscStatementServiceImpl;
+import uk.gov.companieshouse.api.testdata.service.validation.CompanySubTypeRule;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
@@ -44,8 +45,6 @@ public class CreateCompanyWorkflowServiceImpl implements CreateCompanyWorkflowSe
     public static final String COMPANY_NUMBER = "company_number";
     private static final Logger LOG = LoggerFactory.getLogger(Application.APPLICATION_NAME);
     private static final int COMPANY_NUMBER_LENGTH = 8;
-    private static final String PRIVATE_FUND_LIMITED_PARTNERSHIP_SUB_TYPE =
-            "private-fund-limited-partnership";
 
     private final CompanyProfileService companyProfileService;
     private final DataService<FilingHistory, CompanyRequest> filingHistoryService;
@@ -307,8 +306,8 @@ public class CreateCompanyWorkflowServiceImpl implements CreateCompanyWorkflowSe
 
     private void validateSubType(CompanyRequest spec) {
         if (spec != null
-                && PRIVATE_FUND_LIMITED_PARTNERSHIP_SUB_TYPE.equals(spec.getSubType())
-                && !CompanyType.LIMITED_PARTNERSHIP.equals(spec.getCompanyType())) {
+                && !CompanySubTypeRule.isValidForCompanyType(
+                        spec.getSubType(), spec.getCompanyType())) {
             throw new HttpMessageNotReadableException("invalid request", null);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/CreateCompanyWorkflowServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/CreateCompanyWorkflowServiceImpl.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.api.testdata.service.impl.workflow;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
@@ -13,6 +14,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscStatement;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyRegisters;
 import uk.gov.companieshouse.api.testdata.model.entity.Disqualifications;
 import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
+import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyWithPopulatedStructureRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.PublicCompanyRequest;
@@ -42,6 +44,8 @@ public class CreateCompanyWorkflowServiceImpl implements CreateCompanyWorkflowSe
     public static final String COMPANY_NUMBER = "company_number";
     private static final Logger LOG = LoggerFactory.getLogger(Application.APPLICATION_NAME);
     private static final int COMPANY_NUMBER_LENGTH = 8;
+    private static final String PRIVATE_FUND_LIMITED_PARTNERSHIP_SUB_TYPE =
+            "private-fund-limited-partnership";
 
     private final CompanyProfileService companyProfileService;
     private final DataService<FilingHistory, CompanyRequest> filingHistoryService;
@@ -123,6 +127,7 @@ public class CreateCompanyWorkflowServiceImpl implements CreateCompanyWorkflowSe
     @Override
     public PopulatedCompanyDetailsResponse buildCompanyDataStructure(
             CompanyRequest spec) throws DataException {
+        validateSubType(spec);
         assignCompanyNumber(spec);
 
         try {
@@ -233,6 +238,7 @@ public class CreateCompanyWorkflowServiceImpl implements CreateCompanyWorkflowSe
      * If any creation step fails, partial company data is rolled back via {@link #handleCreateFailure}.
      */
     protected CompanyProfileResponse createCompany(CompanyRequest companySpec) throws DataException {
+        validateSubType(companySpec);
         assignCompanyNumber(companySpec);
         companySpec.setCompanyWithPopulatedStructureOnly(false);
 
@@ -299,6 +305,14 @@ public class CreateCompanyWorkflowServiceImpl implements CreateCompanyWorkflowSe
         } while (companyProfileService.companyExists(spec.getCompanyNumber()));
     }
 
+    private void validateSubType(CompanyRequest spec) {
+        if (spec != null
+                && PRIVATE_FUND_LIMITED_PARTNERSHIP_SUB_TYPE.equals(spec.getSubType())
+                && !CompanyType.LIMITED_PARTNERSHIP.equals(spec.getCompanyType())) {
+            throw new HttpMessageNotReadableException("invalid request", null);
+        }
+    }
+
     private CompanyProfileResponse buildCompanyResponse(CompanyRequest spec, String authCode) {
         String companyUri = this.apiUrl + "/company/" + spec.getCompanyNumber();
         return new CompanyProfileResponse(spec.getCompanyNumber(), authCode, companyUri);
@@ -359,5 +373,3 @@ public class CreateCompanyWorkflowServiceImpl implements CreateCompanyWorkflowSe
         return data;
     }
 }
-
-

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/CreateCompanyWorkflowServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/CreateCompanyWorkflowServiceImpl.java
@@ -14,7 +14,6 @@ import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscStatement;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyRegisters;
 import uk.gov.companieshouse.api.testdata.model.entity.Disqualifications;
 import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
-import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyWithPopulatedStructureRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.PublicCompanyRequest;

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/validation/CompanySubTypeRule.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/validation/CompanySubTypeRule.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.api.testdata.service.validation;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
+
+public enum CompanySubTypeRule {
+
+    PRIVATE_FUND_LIMITED_PARTNERSHIP(
+            "private-fund-limited-partnership",
+            CompanyType.LIMITED_PARTNERSHIP
+    );
+
+    private final String value;
+    private final Set<CompanyType> validCompanyTypes;
+
+    CompanySubTypeRule(String value, CompanyType... validCompanyTypes) {
+        this.value = value;
+        this.validCompanyTypes = Set.of(validCompanyTypes);
+    }
+
+    public static boolean isValidForCompanyType(String value, CompanyType companyType) {
+        return Arrays.stream(values())
+                .filter(companySubType -> companySubType.value.equals(value))
+                .findFirst()
+                .map(companySubType -> companySubType.validCompanyTypes.contains(companyType))
+                .orElse(true);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -273,12 +273,21 @@ class CompanyProfileServiceImplTest {
     }
 
     @Test
-    void createCompanyWithNonCicSubType() {
-        setCompanyJurisdictionAndType(JurisdictionType.ENGLAND_WALES,CompanyType.LTD);
+    void createLimitedPartnershipWithPrivateFundLimitedPartnershipSubType() {
+        setCompanyJurisdictionAndType(JurisdictionType.ENGLAND_WALES, CompanyType.LIMITED_PARTNERSHIP);
         spec.setSubType("private-fund-limited-partnership");
         CompanyProfile profile = createAndCapture(spec);
         assertEquals("private-fund-limited-partnership", profile.getSubtype());
         assertFalse(profile.getIsCommunityInterestCompany());
+    }
+
+    @Test
+    void createLtdWithPrivateFundLimitedPartnershipSubTypeDoesNotApplySubType() {
+        setCompanyJurisdictionAndType(JurisdictionType.ENGLAND_WALES, CompanyType.LTD);
+        spec.setSubType("private-fund-limited-partnership");
+        CompanyProfile profile = createAndCapture(spec);
+        assertNull(profile.getSubtype());
+        assertNull(profile.getIsCommunityInterestCompany());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -34,6 +34,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
@@ -282,12 +283,13 @@ class CompanyProfileServiceImplTest {
     }
 
     @Test
-    void createLtdWithPrivateFundLimitedPartnershipSubTypeDoesNotApplySubType() {
+    void createLtdWithPrivateFundLimitedPartnershipSubTypeThrowsInvalidRequestException() {
         setCompanyJurisdictionAndType(JurisdictionType.ENGLAND_WALES, CompanyType.LTD);
         spec.setSubType("private-fund-limited-partnership");
-        CompanyProfile profile = createAndCapture(spec);
-        assertNull(profile.getSubtype());
-        assertNull(profile.getIsCommunityInterestCompany());
+        HttpMessageNotReadableException thrown = assertThrows(HttpMessageNotReadableException.class,
+                () -> companyProfileService.create(spec));
+        assertEquals("invalid request", thrown.getMessage());
+        verify(repository, never()).save(any());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/CreateCompanyWorkflowServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/CreateCompanyWorkflowServiceImplTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.model.entity.Appointment;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyAuthCode;
@@ -16,6 +17,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscs;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyRegisters;
 import uk.gov.companieshouse.api.testdata.model.entity.Disqualifications;
 import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
+import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.JurisdictionType;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyWithPopulatedStructureRequest;
@@ -314,6 +316,39 @@ class CreateCompanyWorkflowServiceImplTest {
                 () -> creationService.createInternalCompany(null));
         verify(companyProfileService, never()).create(any());
         verify(deleteCompanyWorkflowService, never()).deleteCompany(any());
+    }
+
+    @Test
+    void createInternalCompanyWithInvalidPrivateFundLimitedPartnershipSubTypeThrowsInvalidRequest()
+            throws Exception {
+        CompanyRequest spec = new CompanyRequest();
+        spec.setJurisdiction(JurisdictionType.ENGLAND_WALES);
+        spec.setCompanyType(CompanyType.LTD);
+        spec.setSubType("private-fund-limited-partnership");
+
+        HttpMessageNotReadableException thrown = assertThrows(HttpMessageNotReadableException.class,
+                () -> creationService.createInternalCompany(spec));
+
+        assertEquals("invalid request", thrown.getMessage());
+        verify(randomService, never()).getNumber(anyInt());
+        verify(companyProfileService, never()).create(any());
+        verify(deleteCompanyWorkflowService, never()).deleteCompany(any());
+    }
+
+    @Test
+    void buildCompanyDataStructureWithInvalidPrivateFundLimitedPartnershipSubTypeThrowsInvalidRequest()
+            throws Exception {
+        CompanyRequest spec = new CompanyRequest();
+        spec.setJurisdiction(JurisdictionType.ENGLAND_WALES);
+        spec.setCompanyType(CompanyType.LTD);
+        spec.setSubType("private-fund-limited-partnership");
+
+        HttpMessageNotReadableException thrown = assertThrows(HttpMessageNotReadableException.class,
+                () -> creationService.buildCompanyDataStructure(spec));
+
+        assertEquals("invalid request", thrown.getMessage());
+        verify(randomService, never()).getNumber(anyInt());
+        verify(companyProfileService, never()).create(any());
     }
 
     @Test
@@ -1006,5 +1041,3 @@ class CreateCompanyWorkflowServiceImplTest {
         validateElasticSearch(spec);
     }
 }
-
-


### PR DESCRIPTION
This pull request introduces stricter validation for the `subType` field when creating company profiles, specifically ensuring that the `"private-fund-limited-partnership"` sub-type can only be used with companies of type `LIMITED_PARTNERSHIP`. Attempts to use this sub-type with incompatible company types (like `LTD`) will now result in a `HttpMessageNotReadableException`. The changes also include updated and new tests to verify this validation logic.

**Validation improvements:**

* Added a check in both `CompanyProfileServiceImpl` and `CreateCompanyWorkflowServiceImpl` to throw a `HttpMessageNotReadableException` if the `subType` is `"private-fund-limited-partnership"` but the `companyType` is not `LIMITED_PARTNERSHIP`. This prevents invalid company profile creation requests. [[1]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086L499-R518) [[2]](diffhunk://#diff-76e4ebad41cd70421a265bc27b92c1f16dd27cb0f465f741a0acfc97021a3697R308-R315)
* Updated the internal workflow to call this validation method before proceeding with company creation or data structure building. [[1]](diffhunk://#diff-76e4ebad41cd70421a265bc27b92c1f16dd27cb0f465f741a0acfc97021a3697R130) [[2]](diffhunk://#diff-76e4ebad41cd70421a265bc27b92c1f16dd27cb0f465f741a0acfc97021a3697R241)

**Test updates and additions:**

* Added new unit tests in `CompanyProfileServiceImplTest` and `CreateCompanyWorkflowServiceImplTest` to ensure that an exception is thrown when attempting to create a company with an invalid sub-type/type combination. [[1]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3L276-R294) [[2]](diffhunk://#diff-28d8649baed63353b403dee2dd469e916ae63fadf89af8ac3e687e2a21b26001R321-R353)
* Updated existing tests to reflect the new validation logic and to confirm that valid combinations still succeed.

**Code maintenance:**

* Refactored magic strings for sub-types into constants for better maintainability and readability. [[1]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086R60-R62) [[2]](diffhunk://#diff-76e4ebad41cd70421a265bc27b92c1f16dd27cb0f465f741a0acfc97021a3697R47-R48)
* Added necessary imports for `HttpMessageNotReadableException` and `CompanyType` in affected files. [[1]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086R16) [[2]](diffhunk://#diff-76e4ebad41cd70421a265bc27b92c1f16dd27cb0f465f741a0acfc97021a3697R5) [[3]](diffhunk://#diff-76e4ebad41cd70421a265bc27b92c1f16dd27cb0f465f741a0acfc97021a3697R17) [[4]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3R37) [[5]](diffhunk://#diff-28d8649baed63353b403dee2dd469e916ae63fadf89af8ac3e687e2a21b26001R9) [[6]](diffhunk://#diff-28d8649baed63353b403dee2dd469e916ae63fadf89af8ac3e687e2a21b26001R20)