### PR TITLE
TDG-90 : Add delete appointments endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,11 @@ In order to use the generator, there are different possible endpoints that can b
   A usage example looks like this: `{ "activity_description" : "Braunkohle waschen", "sic_description" : "Abbau von Braunkohle", "is_ch_activity" : false, "activity_description_search_field" : "braunkohle waschen" }`
 - DELETE: Sending a DELETE request on the endpoint `{Base URL}/test-data/combined-sic-activities/{id}` will delete the `Sic Code and Keyword`.
 
+#### Appointments
+- DELETE: Sending a DELETE request on the endpoint `{Base URL}/test-data/internal/company/{companyNumber}/appointments` will delete all appointments for a given company. `companyNumber` is required in the URL path.
+  - Response: 204 NO_CONTENT on successful deletion
+  - Response: 404 NOT_FOUND if no appointments exist for the company
+
 ## Environment Variables
 The supported environmental variables have been categorised by use case and are as follows.
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/AppointmentsController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/AppointmentsController.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.api.testdata.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import uk.gov.companieshouse.api.testdata.Application;
+import uk.gov.companieshouse.api.testdata.service.AppointmentService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping(value = "${api.endpoint}/internal", produces = MediaType.APPLICATION_JSON_VALUE)
+public class AppointmentsController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Application.APPLICATION_NAME);
+    private static final String STATUS = "status";
+
+    private final AppointmentService appointmentService;
+
+    public AppointmentsController(AppointmentService appointmentService) {
+        this.appointmentService = appointmentService;
+    }
+
+    @DeleteMapping("/company/{companyNumber}/appointments")
+    public ResponseEntity<Map<String, Object>> deleteAppointments(@PathVariable String companyNumber) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("company-number", companyNumber);
+        boolean deleteAppointments = appointmentService.deleteAllAppointments(companyNumber);
+        if (deleteAppointments) {
+            LOG.info("Appointments deleted for company", response);
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } else {
+            response.put(STATUS, HttpStatus.NOT_FOUND);
+            LOG.info("No Appointments found for company", response);
+            return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/AppointmentsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/AppointmentsControllerTest.java
@@ -26,7 +26,7 @@ class AppointmentsControllerTest {
     private AppointmentsController appointmentsController;
 
     @Test
-    void deleteAppointments_success() throws Exception {
+    void deleteAppointments_success() {
         final String companyNumber = "12345678";
         when(appointmentService.deleteAllAppointments(companyNumber)).thenReturn(true);
 
@@ -38,7 +38,7 @@ class AppointmentsControllerTest {
     }
 
     @Test
-    void deleteAppointments_notFound() throws Exception {
+    void deleteAppointments_notFound() {
         final String companyNumber = "12345678";
         when(appointmentService.deleteAllAppointments(companyNumber)).thenReturn(false);
 
@@ -51,7 +51,7 @@ class AppointmentsControllerTest {
     }
 
     @Test
-    void deleteAppointments_exception() throws Exception {
+    void deleteAppointments_exception() {
         final String companyNumber = "12345678";
         RuntimeException exception = new RuntimeException("Error message");
         when(appointmentService.deleteAllAppointments(companyNumber)).thenThrow(exception);

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/AppointmentsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/AppointmentsControllerTest.java
@@ -1,0 +1,64 @@
+package uk.gov.companieshouse.api.testdata.controller;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.api.testdata.service.AppointmentService;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AppointmentsControllerTest {
+
+    @Mock
+    private AppointmentService appointmentService;
+
+    @InjectMocks
+    private AppointmentsController appointmentsController;
+
+    @Test
+    void deleteAppointments_success() throws Exception {
+        final String companyNumber = "12345678";
+        when(appointmentService.deleteAllAppointments(companyNumber)).thenReturn(true);
+
+        ResponseEntity<Map<String, Object>> response = appointmentsController.deleteAppointments(companyNumber);
+
+        assertNull(response.getBody());
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        verify(appointmentService).deleteAllAppointments(companyNumber);
+    }
+
+    @Test
+    void deleteAppointments_notFound() throws Exception {
+        final String companyNumber = "12345678";
+        when(appointmentService.deleteAllAppointments(companyNumber)).thenReturn(false);
+
+        ResponseEntity<Map<String, Object>> response = appointmentsController.deleteAppointments(companyNumber);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals(companyNumber, Objects.requireNonNull(response.getBody()).get("company-number"));
+        assertEquals(HttpStatus.NOT_FOUND, response.getBody().get("status"));
+        verify(appointmentService).deleteAllAppointments(companyNumber);
+    }
+
+    @Test
+    void deleteAppointments_exception() throws Exception {
+        final String companyNumber = "12345678";
+        RuntimeException exception = new RuntimeException("Error message");
+        when(appointmentService.deleteAllAppointments(companyNumber)).thenThrow(exception);
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () ->
+                appointmentsController.deleteAppointments(companyNumber));
+        assertEquals(exception, thrown);
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a new endpoint to allow deletion of all appointments for a given company, along with corresponding documentation and tests. The main changes include implementing the `AppointmentsController` with a DELETE endpoint, updating the API documentation, and adding unit tests for the new controller.

**API Endpoint Addition:**

* Added a new REST endpoint in `AppointmentsController` to handle DELETE requests at `/internal/company/{companyNumber}/appointments`, enabling deletion of all appointments for a specified company and returning appropriate HTTP status codes.

**Documentation Update:**

* Updated `README.md` to document the new DELETE endpoint for appointments, including expected responses for success and not found cases.

**Testing:**

* Added `AppointmentsControllerTest` to verify correct behavior of the new endpoint, including successful deletion, handling of not found cases, and exception scenarios.