### PR TITLE
Upgrade Spring Boot and fix database name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <sonar.password/>
         <sonar.projectKey>uk.gov.companieshouse:test-data-generator</sonar.projectKey>
         <sonar.projectName>test-data-generator</sonar.projectName>
-        <sonar.coverage.exclusions>**/Application.java</sonar.coverage.exclusions>
+        <sonar.coverage.exclusions>**/Application.java,**/config/MongoConfig.java</sonar.coverage.exclusions>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <sonar.password/>
         <sonar.projectKey>uk.gov.companieshouse:test-data-generator</sonar.projectKey>
         <sonar.projectName>test-data-generator</sonar.projectName>
+        <sonar.coverage.exclusions>**/Application.java</sonar.coverage.exclusions>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
 
-        <spring-boot-dependencies.version>4.0.7</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>4.0.7</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>4.1.0</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>4.1.0</spring-boot-maven-plugin.version>
         <log4j2.version>2.25.4</log4j2.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
@@ -79,8 +79,12 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-mongodb</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/uk/gov/companieshouse/api/testdata/Application.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/Application.java
@@ -3,10 +3,9 @@ package uk.gov.companieshouse.api.testdata;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.mongodb.autoconfigure.MongoAutoConfiguration;
 
 @SpringBootApplication
-@EnableAutoConfiguration(exclude=MongoAutoConfiguration.class)
+@EnableAutoConfiguration
 public class Application {
 
     public static final String APPLICATION_NAME = "test-data-generator";

--- a/src/main/java/uk/gov/companieshouse/api/testdata/Application.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/Application.java
@@ -1,11 +1,9 @@
 package uk.gov.companieshouse.api.testdata;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-@EnableAutoConfiguration
 public class Application {
 
     public static final String APPLICATION_NAME = "test-data-generator";

--- a/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
@@ -1,8 +1,8 @@
 package uk.gov.companieshouse.api.testdata.config;
 
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
-import org.springframework.boot.mongodb.autoconfigure.MongoProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
@@ -15,11 +15,13 @@ import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.repository.support.MongoRepositoryFactoryBean;
 import org.springframework.data.repository.Repository;
 import uk.gov.companieshouse.api.testdata.repository.AccountPenaltiesRepository;
+import uk.gov.companieshouse.api.testdata.repository.AdminPermissionsRepository;
 import uk.gov.companieshouse.api.testdata.repository.AcspApplicationRepository;
 import uk.gov.companieshouse.api.testdata.repository.AcspMemberRepository;
 import uk.gov.companieshouse.api.testdata.repository.AcspProfileRepository;
 import uk.gov.companieshouse.api.testdata.repository.AppealsRepository;
 import uk.gov.companieshouse.api.testdata.repository.AppointmentsRepository;
+import uk.gov.companieshouse.api.testdata.repository.AppointmentsDataRepository;
 import uk.gov.companieshouse.api.testdata.repository.BacklogRepository;
 import uk.gov.companieshouse.api.testdata.repository.BasketRepository;
 import uk.gov.companieshouse.api.testdata.repository.CertificatesRepository;
@@ -47,21 +49,21 @@ import uk.gov.companieshouse.api.testdata.repository.UvidRepository;
 import java.io.Serializable;
 
 @Configuration
-@EnableConfigurationProperties(MongoProperties.class)
 public class MongoConfig {
+
+    @Value("${spring.mongodb.uri}")
+    private String mongoUri;
+
+    @Bean
+    public MongoClient mongoClient() {
+        return MongoClients.create(mongoUri);
+    }
 
     private static final String ACCOUNT_DATABASE = "account";
     private static final String ITEMS_DATABASE = "items";
     private static final String SIC_CODE_DATABASE = "sic_code";
     private static final String IDENTITY_VERIFICATION = "identity_verification";
     private static final String ORDERS_ITEM_GROUPS_DATABASE = "orders_item_groups";
-
-    private final MongoProperties mongoProperties;
-
-    public MongoConfig(MongoProperties mongoProperties) {
-        super();
-        this.mongoProperties = mongoProperties;
-    }
 
     @Bean
     public CompanyProfileRepository companyProfileRepository() {
@@ -79,6 +81,11 @@ public class MongoConfig {
     }
 
     @Bean
+    public AdminPermissionsRepository adminPermissionsRepository() {
+        return getMongoRepositoryBean(AdminPermissionsRepository.class, "admin_permissions");
+    }
+
+    @Bean
     public FilingHistoryRepository filingHistoryRepository() {
         return getMongoRepositoryBean(FilingHistoryRepository.class, "company_filing_history");
     }
@@ -91,6 +98,11 @@ public class MongoConfig {
     @Bean
     public AppointmentsRepository appointmentsRepository() {
         return getMongoRepositoryBean(AppointmentsRepository.class, "appointments");
+    }
+
+    @Bean
+    public AppointmentsDataRepository appointmentsDataRepository() {
+        return getMongoRepositoryBean(AppointmentsDataRepository.class, "appointments");
     }
 
     @Bean
@@ -219,7 +231,7 @@ public class MongoConfig {
 
     private MongoTemplate createMongoTemplate(final String database) {
         var simpleMongoDbFactory = new SimpleMongoClientDatabaseFactory(
-                MongoClients.create(this.mongoProperties.determineUri()), database);
+                mongoClient(), database);
         var mappingMongoConverter = getMappingMongoConverter(
                 simpleMongoDbFactory);
         return new MongoTemplate(simpleMongoDbFactory, mappingMongoConverter);

--- a/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
@@ -82,7 +82,7 @@ public class MongoConfig {
 
     @Bean
     public AdminPermissionsRepository adminPermissionsRepository() {
-        return getMongoRepositoryBean(AdminPermissionsRepository.class, "admin_permissions");
+        return getMongoRepositoryBean(AdminPermissionsRepository.class, ACCOUNT_DATABASE);
     }
 
     @Bean


### PR DESCRIPTION
This pull request updates the project's MongoDB integration to use the latest Spring Boot and MongoDB libraries, and refactors the MongoDB configuration for improved clarity and maintainability. It also introduces new repository beans for additional data access.

**Dependency and configuration updates:**

* Upgraded Spring Boot dependencies from version `4.0.7` to `4.1.0` in `pom.xml` for both the parent and Maven plugin, ensuring access to the latest features and security updates.
* Replaced the `spring-boot-starter-data-mongodb` dependency with the standalone `mongodb-driver-sync` and `spring-data-mongodb` dependencies in `pom.xml`, decoupling MongoDB driver management from Spring Boot auto-configuration.

**MongoDB configuration refactor:**

* Refactored `MongoConfig.java` to remove reliance on `MongoProperties` and `MongoAutoConfiguration`, instead injecting the MongoDB URI via `@Value` and managing the `MongoClient` bean directly. This gives more explicit control over the MongoDB connection. [[1]](diffhunk://#diff-3231932306bf09b3922efe48b53f3fbf4e9b9d179a9dad960f8d06cbcc1aa45dR3-R5) [[2]](diffhunk://#diff-3231932306bf09b3922efe48b53f3fbf4e9b9d179a9dad960f8d06cbcc1aa45dL50-L65) [[3]](diffhunk://#diff-294c73721a65092fb23bc78201022906c1d92a8665856778ade5e0042077cda1L6-R8)
* Updated the `createMongoTemplate` method to use the new `mongoClient()` bean, aligning with the refactored configuration approach.

**Repository beans:**

* Added beans for `AdminPermissionsRepository` and `AppointmentsDataRepository` to `MongoConfig.java`, enabling dependency injection for these new data access components. [[1]](diffhunk://#diff-3231932306bf09b3922efe48b53f3fbf4e9b9d179a9dad960f8d06cbcc1aa45dR18-R24) [[2]](diffhunk://#diff-3231932306bf09b3922efe48b53f3fbf4e9b9d179a9dad960f8d06cbcc1aa45dR83-R87) [[3]](diffhunk://#diff-3231932306bf09b3922efe48b53f3fbf4e9b9d179a9dad960f8d06cbcc1aa45dR103-R107)