### PR TITLE
Added internal company V2 get populated company structure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
         <log4j2.version>2.25.4</log4j2.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
-        <tomcat-embed-core.version>11.0.22</tomcat-embed-core.version>
-        <tomcat-embed-websocket.version>11.0.22</tomcat-embed-websocket.version>
+        <tomcat-embed-core.version>11.0.23</tomcat-embed-core.version>
+        <tomcat-embed-websocket.version>11.0.23</tomcat-embed-websocket.version>
         <tomcat-embed-el.version>11.0.22</tomcat-embed-el.version>
 
         <!-- internal dependencies -->

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/InternalCompanyController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/InternalCompanyController.java
@@ -21,7 +21,6 @@ import uk.gov.companieshouse.api.testdata.model.entity.CompanyProfile;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyWithPopulatedStructureRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.DeleteCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.InternalCompanyRequest;
-import uk.gov.companieshouse.api.testdata.model.rest.request.InternalCompanyRequestV2;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.response.CompanyAuthCodeResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.CompanyProfileResponse;
@@ -39,7 +38,7 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Handles internal company endpoints for company creation, deletion, and
+ * Handles internal v1 company endpoints for company creation, deletion, and
  * pre-populated structure operations.
  * Auth code validation is only applied on internal delete requests when an auth
  * code is provided; create endpoints do not require an auth code.
@@ -58,7 +57,6 @@ public class InternalCompanyController {
     private static final String COMPANY_NUMBER_DATA = "company number";
     private static final String JURISDICTION_DATA = "jurisdiction";
     private static final String NEW_COMPANY_CREATED = "New company created";
-    private static final String API_VERSION_HEADER = "X-API-Version";
     private static final String STATUS = "status";
     private static final String ERROR = "error";
 
@@ -77,18 +75,6 @@ public class InternalCompanyController {
     public ResponseEntity<CompanyProfileResponse> createInternalCompanyV1(
             @Valid @RequestBody(required = false) InternalCompanyRequest internalCompanyRequest) throws DataException {
         LOG.info("Received request to create a new company (v1) in internal company API");
-        return createCompanyResponse(internalCompanyRequest);
-    }
-
-    @PostMapping(value = "/company", headers = API_VERSION_HEADER + "=2")
-    public ResponseEntity<CompanyProfileResponse> createInternalCompanyV2(
-            @Valid @RequestBody(required = false) InternalCompanyRequestV2 internalCompanyRequestV2) throws DataException {
-
-        LOG.info("Received request to create a new company (v2) in internal company API");
-
-        InternalCompanyRequest internalCompanyRequest = internalCompanyRequestV2 == null
-                ? new InternalCompanyRequest()
-                : internalCompanyRequestV2.toInternalCompanyRequest();
         return createCompanyResponse(internalCompanyRequest);
     }
 
@@ -128,6 +114,8 @@ public class InternalCompanyController {
     @PostMapping("/get-populated-company-structure")
     public ResponseEntity<PopulatedCompanyDetailsResponse> buildCompanyDataStructure(
             @Valid @RequestBody(required = false) InternalCompanyRequest request) throws DataException {
+
+        LOG.info("Received request to build company data structure in internal company API V1");
 
         Optional<InternalCompanyRequest> optionalRequest = Optional.ofNullable(request);
         InternalCompanyRequest internalCompanyRequest = optionalRequest.orElse(new InternalCompanyRequest());

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/InternalCompanyControllerV2.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/InternalCompanyControllerV2.java
@@ -1,0 +1,77 @@
+package uk.gov.companieshouse.api.testdata.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.testdata.Application;
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.model.rest.request.InternalCompanyRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.request.InternalCompanyRequestV2;
+import uk.gov.companieshouse.api.testdata.model.rest.response.CompanyProfileResponse;
+import uk.gov.companieshouse.api.testdata.model.rest.response.PopulatedCompanyDetailsResponse;
+import uk.gov.companieshouse.api.testdata.service.CreateCompanyWorkflowService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Handles internal v2 company endpoints.
+ */
+@RestController
+@RequestMapping(value = "${api.endpoint}/internal", produces = MediaType.APPLICATION_JSON_VALUE)
+public class InternalCompanyControllerV2 {
+
+    private static final String API_VERSION_HEADER = "X-API-Version";
+    private static final Logger LOG = LoggerFactory.getLogger(Application.APPLICATION_NAME);
+    private static final String COMPANY_NUMBER_DATA = "company number";
+    private static final String JURISDICTION_DATA = "jurisdiction";
+    private static final String NEW_COMPANY_CREATED = "New company created";
+
+    private final CreateCompanyWorkflowService createCompanyWorkflowService;
+
+    public InternalCompanyControllerV2(CreateCompanyWorkflowService createCompanyWorkflowService) {
+        this.createCompanyWorkflowService = createCompanyWorkflowService;
+    }
+
+    @PostMapping(value = "/company", headers = API_VERSION_HEADER + "=2")
+    public ResponseEntity<CompanyProfileResponse> createInternalCompanyV2(
+            @Valid @RequestBody(required = false) InternalCompanyRequestV2 request) throws DataException {
+        LOG.info("Received request to create a new company (v2) in internal company API");
+        InternalCompanyRequest internalCompanyRequest = request == null
+                ? new InternalCompanyRequest()
+                : request.toInternalCompanyRequest();
+        return createCompanyResponse(internalCompanyRequest);
+    }
+
+    @PostMapping(value = "/get-populated-company-structure", headers = API_VERSION_HEADER + "=2")
+    public ResponseEntity<PopulatedCompanyDetailsResponse> buildCompanyDataStructureV2(
+            @Valid @RequestBody(required = false) InternalCompanyRequestV2 request) throws DataException {
+
+        LOG.info("Received request to build a populated company data structure (v2) in internal company API");
+
+        InternalCompanyRequest internalCompanyRequest = request == null
+                ? new InternalCompanyRequest()
+                : request.toInternalCompanyRequest();
+
+        var companyData = createCompanyWorkflowService.buildCompanyDataStructure(internalCompanyRequest);
+        return new ResponseEntity<>(companyData, HttpStatus.OK);
+    }
+
+    private ResponseEntity<CompanyProfileResponse> createCompanyResponse(InternalCompanyRequest request)
+            throws DataException {
+        CompanyProfileResponse createdCompany = createCompanyWorkflowService.createInternalCompany(request);
+
+        Map<String, Object> data = new HashMap<>();
+        data.put(COMPANY_NUMBER_DATA, createdCompany.getCompanyNumber());
+        data.put(JURISDICTION_DATA, request.getJurisdiction());
+        LOG.info(NEW_COMPANY_CREATED, data);
+        return new ResponseEntity<>(createdCompany, HttpStatus.CREATED);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/InternalCompanyControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/InternalCompanyControllerTest.java
@@ -19,7 +19,6 @@ import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyWithPopulate
 import uk.gov.companieshouse.api.testdata.model.rest.request.DeleteCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.DisqualificationsRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.InternalCompanyRequest;
-import uk.gov.companieshouse.api.testdata.model.rest.request.InternalCompanyRequestV2;
 import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.response.CompanyAuthCodeResponse;
 import uk.gov.companieshouse.api.testdata.model.rest.response.CompanyProfileResponse;
@@ -78,25 +77,6 @@ class InternalCompanyControllerTest {
 
         assertEquals(company, response.getBody());
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
-    }
-
-    @Test
-    void createInternalCompanyV2() throws Exception {
-        InternalCompanyRequestV2 request = new InternalCompanyRequestV2();
-        request.setJurisdiction(JurisdictionType.SCOTLAND);
-        InternalCompanyRequestV2.CompanyTypeV2 companyTypeV2 = new InternalCompanyRequestV2.CompanyTypeV2();
-        companyTypeV2.setSubType("community-interest-company");
-        request.setCompanyTypeDetails(companyTypeV2);
-        CompanyProfileResponse company =
-                new CompanyProfileResponse("12345678", "123456", COMPANY_URI);
-
-        when(createCompanyWorkflowService.createInternalCompany(any())).thenReturn(company);
-        ResponseEntity<CompanyProfileResponse> response = internalCompanyController.createInternalCompanyV2(request);
-
-        assertEquals(company, response.getBody());
-        assertEquals(HttpStatus.CREATED, response.getStatusCode());
-        verify(createCompanyWorkflowService).createInternalCompany(internalCompanyRequestCaptor.capture());
-        assertEquals("community-interest-company", internalCompanyRequestCaptor.getValue().getSubType());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/InternalCompanyControllerV2Test.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/InternalCompanyControllerV2Test.java
@@ -1,0 +1,119 @@
+package uk.gov.companieshouse.api.testdata.controller;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.model.rest.enums.JurisdictionType;
+import uk.gov.companieshouse.api.testdata.model.rest.request.InternalCompanyRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.request.InternalCompanyRequestV2;
+import uk.gov.companieshouse.api.testdata.model.rest.response.CompanyProfileResponse;
+import uk.gov.companieshouse.api.testdata.model.rest.response.PopulatedCompanyDetailsResponse;
+import uk.gov.companieshouse.api.testdata.service.CreateCompanyWorkflowService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InternalCompanyControllerV2Test {
+
+    private static final String COMPANY_URI = "http://localhost:1234/company/12345678";
+
+    @Mock
+    private CreateCompanyWorkflowService createCompanyWorkflowService;
+
+    @InjectMocks
+    private InternalCompanyControllerV2 internalCompanyControllerV2;
+
+    @Captor
+    private ArgumentCaptor<InternalCompanyRequest> internalCompanyRequestCaptor;
+
+    @Test
+    void createInternalCompanyV2() throws Exception {
+        InternalCompanyRequestV2 request = new InternalCompanyRequestV2();
+        request.setJurisdiction(JurisdictionType.SCOTLAND);
+        InternalCompanyRequestV2.CompanyTypeV2 companyTypeV2 = new InternalCompanyRequestV2.CompanyTypeV2();
+        companyTypeV2.setSubType("community-interest-company");
+        request.setCompanyTypeDetails(companyTypeV2);
+        CompanyProfileResponse company = new CompanyProfileResponse("12345678", "123456", COMPANY_URI);
+
+        when(createCompanyWorkflowService.createInternalCompany(any())).thenReturn(company);
+
+        ResponseEntity<CompanyProfileResponse> response = internalCompanyControllerV2.createInternalCompanyV2(request);
+
+        assertEquals(company, response.getBody());
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        verify(createCompanyWorkflowService).createInternalCompany(internalCompanyRequestCaptor.capture());
+        assertEquals("community-interest-company", internalCompanyRequestCaptor.getValue().getSubType());
+    }
+
+    @Test
+    void createInternalCompanyV2NullRequestUsesDefault() throws Exception {
+        CompanyProfileResponse company = new CompanyProfileResponse("12345678", "123456", COMPANY_URI);
+        when(createCompanyWorkflowService.createInternalCompany(any())).thenReturn(company);
+
+        ResponseEntity<CompanyProfileResponse> response = internalCompanyControllerV2.createInternalCompanyV2(null);
+
+        assertEquals(company, response.getBody());
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        verify(createCompanyWorkflowService).createInternalCompany(internalCompanyRequestCaptor.capture());
+        assertEquals(JurisdictionType.ENGLAND_WALES, internalCompanyRequestCaptor.getValue().getJurisdiction());
+    }
+
+    @Test
+    void buildCompanyDataStructureV2Success() throws Exception {
+        InternalCompanyRequestV2 request = new InternalCompanyRequestV2();
+        request.setJurisdiction(JurisdictionType.SCOTLAND);
+        InternalCompanyRequestV2.CompanyTypeV2 companyTypeV2 = new InternalCompanyRequestV2.CompanyTypeV2();
+        companyTypeV2.setSubType("community-interest-company");
+        request.setCompanyTypeDetails(companyTypeV2);
+
+        PopulatedCompanyDetailsResponse responseObj = new PopulatedCompanyDetailsResponse();
+        when(createCompanyWorkflowService.buildCompanyDataStructure(any(InternalCompanyRequest.class)))
+                .thenReturn(responseObj);
+
+        ResponseEntity<PopulatedCompanyDetailsResponse> response =
+                internalCompanyControllerV2.buildCompanyDataStructureV2(request);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(responseObj, response.getBody());
+        verify(createCompanyWorkflowService).buildCompanyDataStructure(internalCompanyRequestCaptor.capture());
+        assertEquals("community-interest-company", internalCompanyRequestCaptor.getValue().getSubType());
+    }
+
+    @Test
+    void buildCompanyDataStructureV2NullRequestUsesDefault() throws Exception {
+        PopulatedCompanyDetailsResponse responseObj = new PopulatedCompanyDetailsResponse();
+        when(createCompanyWorkflowService.buildCompanyDataStructure(any(InternalCompanyRequest.class)))
+                .thenReturn(responseObj);
+
+        ResponseEntity<PopulatedCompanyDetailsResponse> response =
+                internalCompanyControllerV2.buildCompanyDataStructureV2(null);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(responseObj, response.getBody());
+        verify(createCompanyWorkflowService).buildCompanyDataStructure(internalCompanyRequestCaptor.capture());
+        assertEquals(JurisdictionType.ENGLAND_WALES, internalCompanyRequestCaptor.getValue().getJurisdiction());
+    }
+
+    @Test
+    void buildCompanyDataStructureV2ThrowsDataException() throws Exception {
+        InternalCompanyRequestV2 request = new InternalCompanyRequestV2();
+        DataException exception = new DataException("error");
+        when(createCompanyWorkflowService.buildCompanyDataStructure(any(InternalCompanyRequest.class)))
+                .thenThrow(exception);
+
+        DataException thrown = assertThrows(DataException.class, () ->
+                internalCompanyControllerV2.buildCompanyDataStructureV2(request));
+        assertEquals(exception, thrown);
+    }
+}


### PR DESCRIPTION
This pull request refactors the handling of internal company API versioning by moving v2-specific endpoints and logic from `InternalCompanyController` into a new dedicated `InternalCompanyControllerV2` class. This separation clarifies the responsibilities of each controller, improves maintainability, and ensures that v1 and v2 endpoints are managed independently. Corresponding test code has also been reorganized, with v2 tests moved to a new test class.

**Controller refactoring and endpoint separation:**

* All v2-specific endpoints and logic (including handling of `InternalCompanyRequestV2` and API version header routing) have been removed from `InternalCompanyController` and placed into a new `InternalCompanyControllerV2` class. This includes both the company creation and populated structure endpoints. [[1]](diffhunk://#diff-d7e0a7f1cc9985f410b9fa1c98d00c9c014d42e38eea5a4e883eb5c2629edb29L24) [[2]](diffhunk://#diff-d7e0a7f1cc9985f410b9fa1c98d00c9c014d42e38eea5a4e883eb5c2629edb29L42-R41) [[3]](diffhunk://#diff-d7e0a7f1cc9985f410b9fa1c98d00c9c014d42e38eea5a4e883eb5c2629edb29L61) [[4]](diffhunk://#diff-d7e0a7f1cc9985f410b9fa1c98d00c9c014d42e38eea5a4e883eb5c2629edb29L83-L94) [[5]](diffhunk://#diff-d7e0a7f1cc9985f410b9fa1c98d00c9c014d42e38eea5a4e883eb5c2629edb29R118-R119) [[6]](diffhunk://#diff-aebe32aed350815907fdd5a11041e18eff69c33700521c8e6d445a0c788798bfR1-R77)

**Test updates and reorganization:**

* All v2-related tests have been removed from `InternalCompanyControllerTest` and new, comprehensive tests for v2 endpoints have been added in a dedicated `InternalCompanyControllerV2Test` class. These tests cover both normal and edge cases for the v2 controller. [[1]](diffhunk://#diff-b3d545789c558975a3796fa3fbf455a00ba8b472d62fa5d92ca3d4eafd56d0a2L22) [[2]](diffhunk://#diff-b3d545789c558975a3796fa3fbf455a00ba8b472d62fa5d92ca3d4eafd56d0a2L83-L101) [[3]](diffhunk://#diff-c6a08bf2ef7c264a5a7fa1e84c9303f1aaac2e148e9b3b8290f574f588c6272cR1-R119)