### PR TITLE
Remove unwanted internal segment from item groups URL

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/ItemGroupsController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/ItemGroupsController.java
@@ -26,7 +26,7 @@ public class ItemGroupsController {
         this.itemGroupsService = itemGroupsService;
     }
 
-    @DeleteMapping("/internal/item-groups/{orderNumber}")
+    @DeleteMapping("/item-groups/{orderNumber}")
     public ResponseEntity<Map<String, Object>> deleteItemGroups(@PathVariable("orderNumber")
                                                                 String orderNumber) {
         Map<String, Object> response = new HashMap<>();


### PR DESCRIPTION
This PR removes an unintended internal segment from the item groups URL.

Change ### made
Updated the item groups URL to remove the unwanted internal path segment.

### Why
Ensures the generated URL matches the expected endpoint format.
Prevents incorrect routing/URL construction caused by the extra segment.

### Impact
Small, targeted change (1 file changed, 1 insertion, 1 deletion).
No functional changes beyond correcting the URL path.