### PR TITLE
restrict company sub type private fund limited partnership to limited partnerships

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/CompanySubTypeValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/CompanySubTypeValidator.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.api.testdata.service;
+
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
+
+public final class CompanySubTypeValidator {
+
+    public static final String PRIVATE_FUND_LIMITED_PARTNERSHIP =
+            "private-fund-limited-partnership";
+    public static final String COMMUNITY_INTEREST_COMPANY = "community-interest-company";
+    private static final String INVALID_REQUEST = "invalid request";
+
+    private CompanySubTypeValidator() {
+    }
+
+    public static void validate(String subType, CompanyType companyType) {
+        if (PRIVATE_FUND_LIMITED_PARTNERSHIP.equals(subType)
+                && !CompanyType.LIMITED_PARTNERSHIP.equals(companyType)) {
+            throw new HttpMessageNotReadableException(INVALID_REQUEST, (HttpInputMessage) null);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -28,6 +28,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.enums.JurisdictionType;
 import uk.gov.companieshouse.api.testdata.repository.CompanyProfileRepository;
 import uk.gov.companieshouse.api.testdata.repository.OverseasEntityRepository;
 import uk.gov.companieshouse.api.testdata.service.AddressService;
+import uk.gov.companieshouse.api.testdata.service.CompanySubTypeValidator;
 import uk.gov.companieshouse.api.testdata.service.CompanyProfileService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 import uk.gov.companieshouse.logging.Logger;
@@ -98,6 +99,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         final CompanyType companyType = internalCompanyRequest.getCompanyType();
         final String subType = internalCompanyRequest.getSubType();
         final Boolean hasSuperSecurePscs = internalCompanyRequest.getHasSuperSecurePscs();
+        CompanySubTypeValidator.validate(subType, companyType);
         final String companyStatusDetail = internalCompanyRequest.getCompanyStatusDetail();
         final String companyStatus = internalCompanyRequest.getCompanyStatus();
         final String accountsDueStatus = internalCompanyRequest.getAccountsDueStatus();
@@ -499,7 +501,8 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
 
     private void setSubType(CompanyProfile profile, String subType) {
         if (subType != null) {
-            profile.setIsCommunityInterestCompany(subType.equals("community-interest-company"));
+            profile.setIsCommunityInterestCompany(
+                    subType.equals(CompanySubTypeValidator.COMMUNITY_INTEREST_COMPANY));
             profile.setSubtype(subType);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/CreateCompanyWorkflowServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/CreateCompanyWorkflowServiceImpl.java
@@ -20,6 +20,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.response.CompanyProfileResp
 import uk.gov.companieshouse.api.testdata.model.rest.response.PopulatedCompanyDetailsResponse;
 import uk.gov.companieshouse.api.testdata.service.AppointmentService;
 import uk.gov.companieshouse.api.testdata.service.CompanyAuthCodeService;
+import uk.gov.companieshouse.api.testdata.service.CompanySubTypeValidator;
 import uk.gov.companieshouse.api.testdata.service.CreateCompanyWorkflowService;
 import uk.gov.companieshouse.api.testdata.service.DeleteCompanyWorkflowService;
 import uk.gov.companieshouse.api.testdata.service.CompanyProfileService;
@@ -124,6 +125,7 @@ public class CreateCompanyWorkflowServiceImpl implements CreateCompanyWorkflowSe
     public PopulatedCompanyDetailsResponse buildCompanyDataStructure(
             InternalCompanyRequest spec) throws DataException {
         assignCompanyNumber(spec);
+        CompanySubTypeValidator.validate(spec.getSubType(), spec.getCompanyType());
 
         try {
             var response = new PopulatedCompanyDetailsResponse();
@@ -234,6 +236,7 @@ public class CreateCompanyWorkflowServiceImpl implements CreateCompanyWorkflowSe
      */
     protected CompanyProfileResponse createCompany(InternalCompanyRequest companySpec) throws DataException {
         assignCompanyNumber(companySpec);
+        CompanySubTypeValidator.validate(companySpec.getSubType(), companySpec.getCompanyType());
         companySpec.setCompanyWithPopulatedStructureOnly(false);
 
         try {
@@ -359,5 +362,4 @@ public class CreateCompanyWorkflowServiceImpl implements CreateCompanyWorkflowSe
         return data;
     }
 }
-
 

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -34,6 +34,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.exception.NoDataFoundException;
@@ -50,6 +51,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.request.UpdateCompanyReques
 import uk.gov.companieshouse.api.testdata.repository.CompanyProfileRepository;
 import uk.gov.companieshouse.api.testdata.repository.OverseasEntityRepository;
 import uk.gov.companieshouse.api.testdata.service.AddressService;
+import uk.gov.companieshouse.api.testdata.service.CompanySubTypeValidator;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 
 @ExtendWith(MockitoExtension.class)
@@ -273,12 +275,24 @@ class CompanyProfileServiceImplTest {
     }
 
     @Test
-    void createCompanyWithNonCicSubType() {
-        setCompanyJurisdictionAndType(JurisdictionType.ENGLAND_WALES,CompanyType.LTD);
-        internalCompanyRequest.setSubType("private-fund-limited-partnership");
+    void createLimitedPartnershipWithPrivateFundLimitedPartnershipSubType() {
+        setCompanyJurisdictionAndType(JurisdictionType.ENGLAND_WALES, CompanyType.LIMITED_PARTNERSHIP);
+        internalCompanyRequest.setSubType(CompanySubTypeValidator.PRIVATE_FUND_LIMITED_PARTNERSHIP);
         CompanyProfile profile = createAndCapture(internalCompanyRequest);
-        assertEquals("private-fund-limited-partnership", profile.getSubtype());
+        assertEquals(CompanySubTypeValidator.PRIVATE_FUND_LIMITED_PARTNERSHIP, profile.getSubtype());
         assertFalse(profile.getIsCommunityInterestCompany());
+    }
+
+    @Test
+    void createLtdWithPrivateFundLimitedPartnershipSubTypeThrowsInvalidRequestException() {
+        setCompanyJurisdictionAndType(JurisdictionType.ENGLAND_WALES, CompanyType.LTD);
+        internalCompanyRequest.setSubType(CompanySubTypeValidator.PRIVATE_FUND_LIMITED_PARTNERSHIP);
+
+        HttpMessageNotReadableException thrown = assertThrows(HttpMessageNotReadableException.class,
+                () -> companyProfileService.create(internalCompanyRequest));
+
+        assertEquals("invalid request", thrown.getMessage());
+        verify(repository, never()).save(any());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/CreateCompanyWorkflowServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/workflow/CreateCompanyWorkflowServiceImplTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.model.entity.Appointment;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyAuthCode;
@@ -16,6 +17,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscs;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyRegisters;
 import uk.gov.companieshouse.api.testdata.model.entity.Disqualifications;
 import uk.gov.companieshouse.api.testdata.model.entity.FilingHistory;
+import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.JurisdictionType;
 import uk.gov.companieshouse.api.testdata.model.rest.request.InternalCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.request.CompanyWithPopulatedStructureRequest;
@@ -27,6 +29,7 @@ import uk.gov.companieshouse.api.testdata.model.rest.response.CompanyProfileResp
 import uk.gov.companieshouse.api.testdata.model.rest.response.PopulatedCompanyDetailsResponse;
 import uk.gov.companieshouse.api.testdata.service.AppointmentService;
 import uk.gov.companieshouse.api.testdata.service.CompanyAuthCodeService;
+import uk.gov.companieshouse.api.testdata.service.CompanySubTypeValidator;
 import uk.gov.companieshouse.api.testdata.service.DeleteCompanyWorkflowService;
 import uk.gov.companieshouse.api.testdata.service.CompanyProfileService;
 import uk.gov.companieshouse.api.testdata.service.CompanyPscService;
@@ -165,6 +168,43 @@ class CreateCompanyWorkflowServiceImplTest {
         CompanyProfileResponse result = creationService.createInternalCompany(spec);
         InternalCompanyRequest capturedSpec = captureCompanySpec();
         verifyCommonCompanyCreation(capturedSpec, result, COMPANY_NUMBER,
+                JurisdictionType.ENGLAND_WALES);
+    }
+
+    @Test
+    void createInternalCompanyWithInvalidPrivateFundLimitedPartnershipSubTypeThrowsInvalidRequestException()
+            throws Exception {
+        InternalCompanyRequest spec = new InternalCompanyRequest();
+        spec.setJurisdiction(JurisdictionType.ENGLAND_WALES);
+        spec.setCompanyType(CompanyType.LTD);
+        spec.setSubType(CompanySubTypeValidator.PRIVATE_FUND_LIMITED_PARTNERSHIP);
+        when(randomService.getNumber(8)).thenReturn(Long.valueOf(COMPANY_NUMBER));
+        when(companyProfileService.companyExists(COMPANY_NUMBER)).thenReturn(false);
+
+        HttpMessageNotReadableException thrown = assertThrows(HttpMessageNotReadableException.class,
+                () -> creationService.createInternalCompany(spec));
+
+        assertEquals("invalid request", thrown.getMessage());
+        verify(companyProfileService, never()).create(any());
+        verify(deleteCompanyWorkflowService, never()).deleteCompany(any());
+    }
+
+    @Test
+    void createInternalCompanyWithValidPrivateFundLimitedPartnershipSubTypeSucceeds()
+            throws Exception {
+        InternalCompanyRequest spec = new InternalCompanyRequest();
+        spec.setJurisdiction(JurisdictionType.ENGLAND_WALES);
+        spec.setCompanyType(CompanyType.LIMITED_PARTNERSHIP);
+        spec.setSubType(CompanySubTypeValidator.PRIVATE_FUND_LIMITED_PARTNERSHIP);
+        String expectedFullCompanyNumber = "LP" + COMPANY_NUMBER;
+        setupCompanyCreationMocks(COMPANY_NUMBER, 6, expectedFullCompanyNumber);
+
+        CompanyProfileResponse result = creationService.createInternalCompany(spec);
+        InternalCompanyRequest capturedSpec = captureCompanySpec();
+
+        assertEquals(CompanySubTypeValidator.PRIVATE_FUND_LIMITED_PARTNERSHIP,
+                capturedSpec.getSubType());
+        verifyCommonCompanyCreation(capturedSpec, result, expectedFullCompanyNumber,
                 JurisdictionType.ENGLAND_WALES);
     }
 
@@ -655,6 +695,23 @@ class CreateCompanyWorkflowServiceImplTest {
     }
 
     @Test
+    void buildCompanyDataStructureWithInvalidPrivateFundLimitedPartnershipSubTypeThrowsInvalidRequestException()
+            throws Exception {
+        InternalCompanyRequest spec = new InternalCompanyRequest();
+        spec.setJurisdiction(JurisdictionType.ENGLAND_WALES);
+        spec.setCompanyType(CompanyType.LTD);
+        spec.setSubType(CompanySubTypeValidator.PRIVATE_FUND_LIMITED_PARTNERSHIP);
+        when(randomService.getNumber(8)).thenReturn(Long.valueOf(COMPANY_NUMBER));
+        when(companyProfileService.companyExists(COMPANY_NUMBER)).thenReturn(false);
+
+        HttpMessageNotReadableException thrown = assertThrows(HttpMessageNotReadableException.class,
+                () -> creationService.buildCompanyDataStructure(spec));
+
+        assertEquals("invalid request", thrown.getMessage());
+        verify(companyProfileService, never()).create(any());
+    }
+
+    @Test
     void buildCompanyDataStructure_noDefaultOfficerTrue_doesNotCreateAppointments()
             throws Exception {
         InternalCompanyRequest spec = new InternalCompanyRequest();
@@ -1026,5 +1083,3 @@ class CreateCompanyWorkflowServiceImplTest {
         validateElasticSearch(spec);
     }
 }
-
-


### PR DESCRIPTION
This pull request introduces a new validation utility for company subtypes and integrates it into the company creation workflow. The main goal is to ensure that certain subtypes, such as "private-fund-limited-partnership," are only used with the correct company type ("limited partnership"). If an invalid combination is detected, an exception is thrown to prevent invalid data from being created. The changes also include corresponding unit tests to verify the new validation logic.

**Validation improvements:**

* Added a new `CompanySubTypeValidator` utility class to enforce subtype and company type compatibility, specifically ensuring "private-fund-limited-partnership" can only be used with "limited partnership" companies. An `HttpMessageNotReadableException` is thrown for invalid combinations.
* Integrated the `CompanySubTypeValidator.validate` method into `CompanyProfileServiceImpl` and `CreateCompanyWorkflowServiceImpl` to validate subtypes at various points in the company creation workflow. [[1]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086R102) [[2]](diffhunk://#diff-76e4ebad41cd70421a265bc27b92c1f16dd27cb0f465f741a0acfc97021a3697R128) [[3]](diffhunk://#diff-76e4ebad41cd70421a265bc27b92c1f16dd27cb0f465f741a0acfc97021a3697R239)

**Refactoring and consistency:**

* Updated usages of hardcoded subtype strings to reference constants from the new validator class, improving maintainability and reducing the risk of typos. [[1]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086L502-R505) [[2]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3L276-R297)

**Testing enhancements:**

* Added and updated unit tests in `CompanyProfileServiceImplTest` and `CreateCompanyWorkflowServiceImplTest` to verify correct behavior when valid and invalid subtype/type combinations are provided, including checks that exceptions are thrown and data is not saved in invalid cases. [[1]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3L276-R297) [[2]](diffhunk://#diff-28d8649baed63353b403dee2dd469e916ae63fadf89af8ac3e687e2a21b26001R174-R210) [[3]](diffhunk://#diff-28d8649baed63353b403dee2dd469e916ae63fadf89af8ac3e687e2a21b26001R697-R713)

These changes strengthen data integrity by enforcing business rules around company subtypes and provide comprehensive test coverage for the new validation logic