### PR TITLE
Refactor PSC creation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImpl.java
@@ -46,29 +46,68 @@ public class CompanyPscServiceImpl implements CompanyPscService {
     static final String[] NATURES_OF_CONTROL_RIGHT_TO_APPOINT = {"right-to-appoint-and-remove-directors",
             "right-to-appoint-and-remove-directors-as-trust",
             "right-to-appoint-and-remove-directors-as-firm",};
+    static final String[] NATURES_OF_CONTROL_SHARES_ROE = {
+            "ownership-of-shares-more-than-25-percent-registered-overseas-entity",
+            "ownership-of-shares-more-than-25-percent-as-trust-registered-overseas-entity",
+            "ownership-of-shares-more-than-25-percent-as-firm-registered-overseas-entity"};
+    static final String[] NATURES_OF_CONTROL_VOTING_RIGHTS_ROE = {
+            "voting-rights-more-than-25-percent-registered-overseas-entity",
+            "voting-rights-more-than-25-percent-as-trust-registered-overseas-entity",
+            "voting-rights-more-than-25-percent-as-firm-registered-overseas-entity"};
+    static final String[] NATURES_OF_CONTROL_RIGHT_TO_APPOINT_ROE = {
+            "right-to-appoint-and-remove-directors-registered-overseas-entity",
+            "right-to-appoint-and-remove-directors-as-trust-registered-overseas-entity",
+            "right-to-appoint-and-remove-directors-as-firm-registered-overseas-entity"};
     private static final int ID_LENGTH = 10;
     private static final int SALT_LENGTH = 8;
     public static final String NATIONALITY = "British";
     public static final String REGISTRATION_NUMBER = "12345678";
-    public static final String LEGAL_FORM = "Legal Form";
-    public static final String LEGAL_AUTHORITY = "Legal Authority";
+    public static final String RLE_LEGAL_FORM = "Private Limited Company";
+    public static final String ORP_LEGAL_FORM = "Local Authority";
+    public static final String ROE_LEGAL_FORM = "S.R.L Overseas Company";
+    public static final String ROE_LEGAL_AUTHORITY = "Cayman Islands";
+    public static final String LEGAL_AUTHORITY = "England & Wales";
     public static final String SUPER_SECURE_BO = "super-secure-beneficial-owner";
     public static final String URL_PREFIX = "/company/";
     public static final String PSC_SUFFIX = "/persons-with-significant-control/";
     public static final String TITLE = "Dr.";
-    public static final String FIRST_NAME = "First";
-    public static final String LAST_NAME = "Last";
-    private static final int DEFAULT_NUMBER_OF_PSC = 1;
+    public static final String FIRST_NAME = "Individual";
+    public static final String LAST_NAME = "Beneficial Owner";
+    private static final int DEFAULT_NUMBER_OF_PSCS = 1;
     private static final String PSC_ERROR_MESSAGE = "psc_type must be accompanied by number_of_psc";
     private static final String BENEFICIAL_OWNER_ERROR =
             "Beneficial owner type is not allowed for this company type";
 
+    /**
+     * Company types that do not maintain a PSC register and therefore require no PSC data.
+     * This includes:
+     * <ul>
+     *   <li>FCA-regulated investment vehicles (ICVC, assurance, protected cell, investment companies)</li>
+     *   <li>Charities regulated outside Companies House (CIOs, SCIOs, further education corporations)</li>
+     *   <li>European and UK economic interest groupings (EEIG, EEIG Establishment, UKEIG)</li>
+     *   <li>Overseas and establishment companies (oversea-company, UK establishment)</li>
+     *   <li>Entities exempt by structure (limited partnerships, registered societies, royal charter)</li>
+     *   <li>Historical company types (old public company)</li>
+     * </ul>
+     */
     private static final Set<CompanyType> EXCLUDED_COMPANY_TYPES = Set.of(
+            CompanyType.ASSURANCE_COMPANY,
             CompanyType.CHARITABLE_INCORPORATED_ORGANISATION,
             CompanyType.EEIG,
             CompanyType.EEIG_ESTABLISHMENT,
             CompanyType.FURTHER_EDUCATION_OR_SIXTH_FORM_COLLEGE_CORPORATION,
+            CompanyType.ICVC_SECURITIES,
+            CompanyType.ICVC_UMBRELLA,
+            CompanyType.ICVC_WARRANT,
+            CompanyType.INVESTMENT_COMPANY_WITH_VARIABLE_CAPITAL,
+            CompanyType.LIMITED_PARTNERSHIP,
+            CompanyType.OLD_PUBLIC_COMPANY,
             CompanyType.OVERSEA_COMPANY,
+            CompanyType.PROTECTED_CELL_COMPANY,
+            CompanyType.REGISTERED_SOCIETY_NON_JURISDICTIONAL,
+            CompanyType.ROYAL_CHARTER,
+            CompanyType.UK_ESTABLISHMENT,
+            CompanyType.UKEIG,
             CompanyType.SCOTTISH_CHARITABLE_INCORPORATED_ORGANISATION
     );
 
@@ -95,7 +134,7 @@ public class CompanyPscServiceImpl implements CompanyPscService {
              internalCompanyRequest.setPscType(List.of(PscType.INDIVIDUAL_BENEFICIAL_OWNER));
         }
 
-        if (shouldReturnNullForCompaniesThatDoNotNeedPscs(internalCompanyRequest)) {
+        if (shouldSkipPscCreation(internalCompanyRequest)) {
             LOG.info("Company type does not require a PSC. No PSCs will be created.");
             internalCompanyRequest.setNumberOfPscs(0);
             return Collections.emptyList();
@@ -120,12 +159,12 @@ public class CompanyPscServiceImpl implements CompanyPscService {
         return createPscsBasedOnCompanyType(internalCompanyRequest, numberOfPsc);
     }
 
-    private boolean shouldReturnNullForCompaniesThatDoNotNeedPscs(InternalCompanyRequest internalCompanyRequest) {
+    private boolean shouldSkipPscCreation(InternalCompanyRequest internalCompanyRequest) {
         if (internalCompanyRequest == null || internalCompanyRequest.getCompanyType() == null) {
             return false;
         }
         boolean result = EXCLUDED_COMPANY_TYPES.contains(internalCompanyRequest.getCompanyType());
-        LOG.debug("shouldReturnNullForExcludedCompanies: " + result);
+        LOG.debug("shouldSkipPscCreation: " + result);
         return result;
     }
 
@@ -170,7 +209,7 @@ public class CompanyPscServiceImpl implements CompanyPscService {
     }
 
     private int getNumberOfPsc(InternalCompanyRequest spec) {
-        int numberOfPsc = Optional.ofNullable(spec.getNumberOfPscs()).orElse(DEFAULT_NUMBER_OF_PSC);
+        int numberOfPsc = Optional.ofNullable(spec.getNumberOfPscs()).orElse(DEFAULT_NUMBER_OF_PSCS);
         LOG.debug("Number of PSCs determined: " + numberOfPsc);
         return numberOfPsc;
     }
@@ -184,7 +223,6 @@ public class CompanyPscServiceImpl implements CompanyPscService {
             return Collections.emptyList();
         }
 
-        CompanyPscs firstPsc = null;
         boolean isOverseasEntity = CompanyType.REGISTERED_OVERSEAS_ENTITY.equals(internalCompanyRequest.getCompanyType());
 
         boolean ceaseFirstPsc = internalCompanyRequest.getPscActive() != null && !internalCompanyRequest.getPscActive();
@@ -198,9 +236,6 @@ public class CompanyPscServiceImpl implements CompanyPscService {
                     ? createBeneficialOwner(internalCompanyRequest, getBeneficialOwnerType(internalCompanyRequest.getPscType(), i), isActive)
                     : createPsc(internalCompanyRequest, getRegularPscType(internalCompanyRequest.getPscType(), i), isActive);
 
-            if (firstPsc == null) {
-                firstPsc = psc;
-            }
             listOfCommonPscs.add(psc);
         }
 
@@ -235,7 +270,7 @@ public class CompanyPscServiceImpl implements CompanyPscService {
     }
 
     private CompanyPscs createSuperSecureBeneficialOwner(InternalCompanyRequest spec) {
-        CompanyPscs superSecureBo = createBasePsc(spec, true);
+        CompanyPscs superSecureBo = createBasePsc(spec, true, true);
         buildSuperSecureBeneficialOwner(superSecureBo);
         if (Boolean.TRUE.equals(spec.getCompanyWithPopulatedStructureOnly())) {
             return superSecureBo;
@@ -244,7 +279,7 @@ public class CompanyPscServiceImpl implements CompanyPscService {
     }
 
     private CompanyPscs createSuperSecurePsc(InternalCompanyRequest spec) {
-        CompanyPscs superSecurePsc = createBasePsc(spec, true);
+        CompanyPscs superSecurePsc = createBasePsc(spec, true, false);
         buildSuperSecurePsc(superSecurePsc);
         if (Boolean.TRUE.equals(spec.getCompanyWithPopulatedStructureOnly())) {
             return superSecurePsc;
@@ -252,7 +287,7 @@ public class CompanyPscServiceImpl implements CompanyPscService {
         return repository.save(superSecurePsc);
     }
 
-    CompanyPscs createBasePsc(InternalCompanyRequest spec, boolean isActive) {
+    CompanyPscs createBasePsc(InternalCompanyRequest spec, boolean isActive, boolean isBeneficialOwner) {
         var companyPsc = new CompanyPscs();
         companyPsc.setCompanyNumber(spec.getCompanyNumber());
 
@@ -271,9 +306,13 @@ public class CompanyPscServiceImpl implements CompanyPscService {
         companyPsc.setId(this.randomService.getEncodedIdWithSalt(ID_LENGTH, SALT_LENGTH));
         companyPsc.setEtag(this.randomService.getEtag());
         companyPsc.setStatementType("statement type");
-        companyPsc.setAddress(addressService.getAddress(JurisdictionType.ENGLAND_WALES));
 
-        setNaturesOfControl(companyPsc);
+        JurisdictionType serviceAddressJurisdiction = isBeneficialOwner
+                ? JurisdictionType.EUROPEAN_UNION
+                : JurisdictionType.ENGLAND_WALES;
+        companyPsc.setAddress(addressService.getAddress(serviceAddressJurisdiction));
+
+        setNaturesOfControl(companyPsc, isBeneficialOwner);
 
         return companyPsc;
     }
@@ -290,15 +329,19 @@ public class CompanyPscServiceImpl implements CompanyPscService {
     /**
      * Sets the natures of control for a given CompanyPscs object.
      * This method selects one random nature of control from each of the predefined categories:
-     * ownership of shares, voting rights, and the right to appoint and remove directors
-     * The selected values are then assigned to the CompanyPscs object.
+     * ownership of shares, voting rights, and the right to appoint and remove directors.
+     * Registered overseas entity beneficial owners use ROE-specific nature of control values.
      *
-     * @param companyPsc the CompanyPscs object to which the natures of control will be assigned
+     * @param companyPsc         the CompanyPscs object to which the natures of control will be assigned
+     * @param isBeneficialOwner  true if this PSC is a beneficial owner (ROE context)
      */
-    private void setNaturesOfControl(CompanyPscs companyPsc) {
-        List<String> sharesList = new ArrayList<>(Arrays.asList(NATURES_OF_CONTROL_SHARES));
-        List<String> votingRightsList = new ArrayList<>(Arrays.asList(NATURES_OF_CONTROL_VOTING_RIGHTS));
-        List<String> rightToAppointList = new ArrayList<>(Arrays.asList(NATURES_OF_CONTROL_RIGHT_TO_APPOINT));
+    private void setNaturesOfControl(CompanyPscs companyPsc, boolean isBeneficialOwner) {
+        List<String> sharesList = new ArrayList<>(Arrays.asList(
+                isBeneficialOwner ? NATURES_OF_CONTROL_SHARES_ROE : NATURES_OF_CONTROL_SHARES));
+        List<String> votingRightsList = new ArrayList<>(Arrays.asList(
+                isBeneficialOwner ? NATURES_OF_CONTROL_VOTING_RIGHTS_ROE : NATURES_OF_CONTROL_VOTING_RIGHTS));
+        List<String> rightToAppointList = new ArrayList<>(Arrays.asList(
+                isBeneficialOwner ? NATURES_OF_CONTROL_RIGHT_TO_APPOINT_ROE : NATURES_OF_CONTROL_RIGHT_TO_APPOINT));
         Collections.shuffle(sharesList);
         Collections.shuffle(votingRightsList);
         Collections.shuffle(rightToAppointList);
@@ -333,13 +376,16 @@ public class CompanyPscServiceImpl implements CompanyPscService {
     }
 
     private CompanyPscs createPsc(InternalCompanyRequest spec, PscType pscType, boolean isActive) {
-        var companyPscs = createBasePsc(spec, isActive);
+        var companyPscs = createBasePsc(spec, isActive, false);
         switch (pscType) {
             case INDIVIDUAL:
                 buildIndividualPsc(companyPscs, pscType.getKind(), pscType.getLinkType());
                 break;
-            case LEGAL_PERSON, CORPORATE_ENTITY:
-                buildWithIdentificationPsc(companyPscs, pscType.getKind(), pscType.getLinkType());
+            case LEGAL_PERSON:
+                buildLegalPersonPsc(companyPscs, pscType.getKind(), pscType.getLinkType());
+                break;
+            case CORPORATE_ENTITY:
+                buildCorporateEntityPsc(companyPscs, pscType.getKind(), pscType.getLinkType());
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported PSC type: " + pscType);
@@ -351,7 +397,7 @@ public class CompanyPscServiceImpl implements CompanyPscService {
     }
 
     private CompanyPscs createBeneficialOwner(InternalCompanyRequest spec, PscType pscType, boolean isActive) {
-        var beneficialOwner = createBasePsc(spec, isActive);
+        var beneficialOwner = createBasePsc(spec, isActive, true);
         switch (pscType) {
             case INDIVIDUAL_BENEFICIAL_OWNER:
                 buildIndividualBeneficialOwner(beneficialOwner);
@@ -371,7 +417,7 @@ public class CompanyPscServiceImpl implements CompanyPscService {
     private void buildIndividualBeneficialOwner(CompanyPscs beneficialOwner) {
         beneficialOwner.setKind(PscType.INDIVIDUAL_BENEFICIAL_OWNER.getKind());
         beneficialOwner.setCountryOfResidence(addressService
-                .getCountryOfResidence(JurisdictionType.WALES));
+                .getCountryOfResidence(JurisdictionType.NON_EU));
         beneficialOwner.setNationality(NATIONALITY);
         beneficialOwner.setDateOfBirth(new DateOfBirth(20, 9, 1975));
 
@@ -394,7 +440,7 @@ public class CompanyPscServiceImpl implements CompanyPscService {
 
     private void buildCorporateBeneficialOwner(CompanyPscs beneficialOwner) {
         beneficialOwner.setKind(PscType.CORPORATE_BENEFICIAL_OWNER.getKind());
-        beneficialOwner.setName(FIRST_NAME + " " + LAST_NAME);
+        beneficialOwner.setName("Overseas Corporate Company");
 
         var links = new Links();
         links.setSelf(URL_PREFIX + beneficialOwner.getCompanyNumber()
@@ -407,15 +453,18 @@ public class CompanyPscServiceImpl implements CompanyPscService {
         beneficialOwner.setPrincipalOfficeAddress(addressService.getAddress(JurisdictionType.NON_EU));
 
         var identification = new Identification();
-        identification.setLegalAuthority(LEGAL_AUTHORITY);
-        identification.setLegalForm(LEGAL_FORM);
+        identification.setLegalAuthority(ROE_LEGAL_AUTHORITY);
+        identification.setLegalForm(ROE_LEGAL_FORM);
         beneficialOwner.setIdentification(identification);
     }
 
+    /**
+     * Builds an individual PSC (filing name - PSC01).
+     */
     private void buildIndividualPsc(CompanyPscs companyPsc, String pscType, String linkType) {
         companyPsc.setKind(pscType);
         companyPsc.setCountryOfResidence(addressService.getCountryOfResidence(JurisdictionType.WALES));
-        companyPsc.setAddress(addressService.getAddress(JurisdictionType.SCOTLAND));
+        companyPsc.setAddress(addressService.getAddress(JurisdictionType.WALES));
         companyPsc.setUsualResidentialAddress(addressService.getAddress(JurisdictionType.WALES));
         companyPsc.setResidentialAddressSameAsServiceAddress(false);
         companyPsc.setNationality(NATIONALITY);
@@ -423,9 +472,9 @@ public class CompanyPscServiceImpl implements CompanyPscService {
 
         NameElements nameElements = new NameElements();
         nameElements.setTitle("Mr");
-        nameElements.setForename("Test");
-        nameElements.setOtherForenames("Tester");
-        nameElements.setSurname("Testington");
+        nameElements.setForename("Person");
+        nameElements.setOtherForenames(FIRST_NAME);
+        nameElements.setSurname("PSC");
         companyPsc.setNameElements(nameElements);
         companyPsc.setName(nameElements.getTitle() + " " + nameElements.getForename()
                 + " " + nameElements.getOtherForenames() + " " + nameElements.getSurname());
@@ -436,20 +485,46 @@ public class CompanyPscServiceImpl implements CompanyPscService {
         companyPsc.setLinks(links);
     }
 
-    private void buildWithIdentificationPsc(
+    /**
+     * Builds a Relevant Legal Entity PSC (filing name - PSC02).
+     */
+    private void buildCorporateEntityPsc(
+           CompanyPscs companyPsc, String pscType, String linkType) {
+       companyPsc.setKind(pscType);
+
+       Identification identification = new Identification();
+       identification.setCountryRegistered(
+               addressService.getCountryOfResidence(JurisdictionType.ENGLAND_WALES));
+       identification.setLegalAuthority(LEGAL_AUTHORITY);
+       identification.setLegalForm(RLE_LEGAL_FORM);
+       identification.setPlaceRegistered(addressService.getCountryOfResidence(JurisdictionType.ENGLAND));
+       identification.setRegistrationNumber(REGISTRATION_NUMBER);
+       companyPsc.setIdentification(identification);
+
+       companyPsc.setName("Relevant Legal Entity (RLE) PSC");
+
+       Links links = new Links();
+       links.setSelf(URL_PREFIX + companyPsc.getCompanyNumber()
+               + PSC_SUFFIX
+               + linkType + "/" + companyPsc.getId());
+       companyPsc.setLinks(links);
+    }
+
+    /**
+     * Builds a Legal Person also known as Other Registrable Person (filing name - PSC03).
+     */
+    private void buildLegalPersonPsc(
             CompanyPscs companyPsc, String pscType, String linkType) {
         companyPsc.setKind(pscType);
 
         Identification identification = new Identification();
         identification.setCountryRegistered(
-                addressService.getCountryOfResidence(JurisdictionType.UNITED_KINGDOM));
+                addressService.getCountryOfResidence(JurisdictionType.SCOTLAND));
         identification.setLegalAuthority(LEGAL_AUTHORITY);
-        identification.setLegalForm(LEGAL_FORM);
-        identification.setPlaceRegistered(addressService.getCountryOfResidence(JurisdictionType.WALES));
-        identification.setRegistrationNumber(REGISTRATION_NUMBER);
+        identification.setLegalForm(ORP_LEGAL_FORM);
         companyPsc.setIdentification(identification);
 
-        companyPsc.setName("Mr A Jones");
+        companyPsc.setName("Other Registrable Person (ORP) PSC");
 
         Links links = new Links();
         links.setSelf(URL_PREFIX + companyPsc.getCompanyNumber()

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImplTest.java
@@ -30,6 +30,7 @@ import uk.gov.companieshouse.api.testdata.exception.DataException;
 import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscs;
 import uk.gov.companieshouse.api.testdata.model.rest.request.InternalCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
+import uk.gov.companieshouse.api.testdata.model.rest.enums.JurisdictionType;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.PscType;
 import uk.gov.companieshouse.api.testdata.repository.CompanyPscsRepository;
 import uk.gov.companieshouse.api.testdata.service.AddressService;
@@ -330,6 +331,46 @@ class CompanyPscServiceImplTest {
     }
 
     @Test
+    void create_LegalPersonPsc_DoesNotSetPlaceRegisteredOrRegistrationNumber() throws DataException {
+        InternalCompanyRequest internalCompanyRequest = new InternalCompanyRequest();
+        internalCompanyRequest.setCompanyNumber(COMPANY_NUMBER);
+        internalCompanyRequest.setCompanyType(CompanyType.LTD);
+        internalCompanyRequest.setNumberOfPscs(1);
+        internalCompanyRequest.setPscType(List.of(PscType.LEGAL_PERSON));
+        internalCompanyRequest.setCompanyWithPopulatedStructureOnly(false);
+
+        when(randomService.getEncodedIdWithSalt(anyInt(), anyInt())).thenReturn(ENCODED_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(new CompanyPscs());
+
+        companyPscsService.create(internalCompanyRequest);
+
+        // placeRegistered is only set via getCountryOfResidence(ENGLAND) in buildCorporateEntityPsc
+        verify(addressService, never()).getCountryOfResidence(JurisdictionType.ENGLAND);
+        verify(repository).save(any(CompanyPscs.class));
+    }
+
+    @Test
+    void create_CorporateEntityPsc_SetPlaceRegisteredAndRegistrationNumber() throws DataException {
+        InternalCompanyRequest internalCompanyRequest = new InternalCompanyRequest();
+        internalCompanyRequest.setCompanyNumber(COMPANY_NUMBER);
+        internalCompanyRequest.setCompanyType(CompanyType.LTD);
+        internalCompanyRequest.setNumberOfPscs(1);
+        internalCompanyRequest.setPscType(List.of(PscType.CORPORATE_ENTITY));
+        internalCompanyRequest.setCompanyWithPopulatedStructureOnly(false);
+
+        when(randomService.getEncodedIdWithSalt(anyInt(), anyInt())).thenReturn(ENCODED_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(new CompanyPscs());
+
+        companyPscsService.create(internalCompanyRequest);
+
+        // placeRegistered is set via getCountryOfResidence(ENGLAND) only in buildCorporateEntityPsc
+        verify(addressService).getCountryOfResidence(JurisdictionType.ENGLAND);
+        verify(repository).save(any(CompanyPscs.class));
+    }
+
+    @Test
     void create_WithZeroNumberOfPsc_AndNullPscType_ReturnsEmptyList() throws DataException {
         InternalCompanyRequest internalCompanyRequest = new InternalCompanyRequest();
         internalCompanyRequest.setCompanyNumber(COMPANY_NUMBER);
@@ -380,6 +421,44 @@ class CompanyPscServiceImplTest {
         assertEquals(COMPANY_NUMBER, result.get(0).getCompanyNumber());
         assertEquals(ENCODED_ID, result.get(0).getId());
         verify(repository, never()).save(any());
+    }
+
+    @Test
+    void create_BeneficialOwner_UsesEuropeanUnionServiceAddress() throws DataException {
+        InternalCompanyRequest internalCompanyRequest = new InternalCompanyRequest();
+        internalCompanyRequest.setCompanyNumber(COMPANY_NUMBER);
+        internalCompanyRequest.setCompanyType(CompanyType.REGISTERED_OVERSEAS_ENTITY);
+        internalCompanyRequest.setNumberOfPscs(1);
+        internalCompanyRequest.setPscType(List.of(PscType.INDIVIDUAL_BENEFICIAL_OWNER));
+        internalCompanyRequest.setCompanyWithPopulatedStructureOnly(false);
+
+        when(randomService.getEncodedIdWithSalt(anyInt(), anyInt())).thenReturn(ENCODED_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(new CompanyPscs());
+
+        companyPscsService.create(internalCompanyRequest);
+
+        verify(addressService).getAddress(JurisdictionType.EUROPEAN_UNION);
+        verify(addressService, never()).getAddress(JurisdictionType.ENGLAND_WALES);
+    }
+
+    @Test
+    void create_NonBeneficialOwner_UsesEnglandWalesServiceAddress() throws DataException {
+        InternalCompanyRequest internalCompanyRequest = new InternalCompanyRequest();
+        internalCompanyRequest.setCompanyNumber(COMPANY_NUMBER);
+        internalCompanyRequest.setCompanyType(CompanyType.LTD);
+        internalCompanyRequest.setNumberOfPscs(1);
+        internalCompanyRequest.setPscType(List.of(PscType.INDIVIDUAL));
+        internalCompanyRequest.setCompanyWithPopulatedStructureOnly(false);
+
+        when(randomService.getEncodedIdWithSalt(anyInt(), anyInt())).thenReturn(ENCODED_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(new CompanyPscs());
+
+        companyPscsService.create(internalCompanyRequest);
+
+        verify(addressService).getAddress(JurisdictionType.ENGLAND_WALES);
+        verify(addressService, never()).getAddress(JurisdictionType.EUROPEAN_UNION);
     }
 
 }


### PR DESCRIPTION
This pull request refactors and extends the `CompanyPscServiceImpl` class to improve support for different PSC (Person with Significant Control) types, especially for overseas entities, and clarifies how PSCs are generated for various company types. Key changes include the introduction of new constants for legal forms and natures of control, improved handling of excluded company types, and more specialized builder methods for different PSC categories.

### Support for Overseas Entities and Legal Forms

* Added ROE (Registered Overseas Entity)-specific constants for natures of control and legal forms, and updated methods to use these when creating beneficial owners and corporate beneficial owners. [[1]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dR49-R110) [[2]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dL293-R344) [[3]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dL410-R477)
* Updated the `buildCorporateBeneficialOwner` and `buildIndividualBeneficialOwner` methods to use overseas-specific values for name, legal authority, legal form, and country of residence. ([src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImpl.javaL397-R443](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dL397-R443), Fb3cf123L417)

### Improved PSC Creation Logic

* Renamed and refactored the method for skipping PSC creation for certain company types (`shouldReturnNullForCompaniesThatDoNotNeedPscs` → `shouldSkipPscCreation`) and expanded the set of excluded company types. [[1]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dR49-R110) [[2]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dL98-R137) [[3]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dL123-R167)
* Changed the default number of PSCs constant to `DEFAULT_NUMBER_OF_PSCS` and ensured consistent usage. [[1]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dR49-R110) [[2]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dL173-R212)

### Enhanced PSC Builders

* Split the generic identification PSC builder into more specific methods: `buildCorporateEntityPsc` for RLE PSCs and `buildLegalPersonPsc` for ORP PSCs, each with appropriate legal form and authority values. [[1]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dL336-R388) [[2]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dL439-R527)
* Improved the `createBasePsc` and `setNaturesOfControl` methods to select the correct jurisdiction and natures of control based on whether the PSC is a beneficial owner. [[1]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dL274-R315) [[2]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dL293-R344)

### Test and Naming Consistency

* Updated test imports to include `JurisdictionType` and changed various constants and variable names for clarity and consistency. [[1]](diffhunk://#diff-e20ed2cbaaf795a0b107342ac70574d088fd45dbc614695dd172e0c335186853R33) [[2]](diffhunk://#diff-3b52a4927b307d96521df83cc4b4c5084f59ea69c3a2710b317a1b017a5e087dR49-R110)

These changes make the PSC generation logic more robust and better aligned with the requirements for different company and PSC types.