### PR TITLE
Upgrade API SDK to resolve HTTP core dependency issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
         <private-api-sdk-java.version>7.0.9</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
         <test-data-generator-library.version>1.0.23</test-data-generator-library.version>
-        <api-sdk-java.version>7.1.0</api-sdk-java.version>
 
         <!-- Sonar config -->
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>
@@ -201,12 +200,6 @@
             <artifactId>private-api-sdk-java</artifactId>
             <version>${private-api-sdk-java.version}</version>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>uk.gov.companieshouse</groupId>-->
-<!--            <artifactId>api-sdk-java</artifactId>-->
-<!--            <version>7.1.0</version>-->
-<!--            <scope>runtime</scope>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-sdk-manager-java-library</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,10 @@
 
         <!-- internal dependencies -->
         <api-security-java.version>2.0.25</api-security-java.version>
-        <private-api-sdk-java.version>4.0.416</private-api-sdk-java.version>
+        <private-api-sdk-java.version>7.0.9</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
         <test-data-generator-library.version>1.0.23</test-data-generator-library.version>
+        <api-sdk-java.version>7.1.0</api-sdk-java.version>
 
         <!-- Sonar config -->
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>
@@ -200,6 +201,12 @@
             <artifactId>private-api-sdk-java</artifactId>
             <version>${private-api-sdk-java.version}</version>
         </dependency>
+<!--        <dependency>-->
+<!--            <groupId>uk.gov.companieshouse</groupId>-->
+<!--            <artifactId>api-sdk-java</artifactId>-->
+<!--            <version>7.1.0</version>-->
+<!--            <scope>runtime</scope>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-sdk-manager-java-library</artifactId>


### PR DESCRIPTION
This pull request updates the version of an internal dependency in the `pom.xml` file. The `private-api-sdk-java` library is upgraded from version `4.0.416` to `7.0.9`, which may include new features, bug fixes, or other improvements.