### PR TITLE
Bump log4j and tomcat-embed versions to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,12 +32,12 @@
 
         <spring-boot-dependencies.version>4.1.0</spring-boot-dependencies.version>
         <spring-boot-maven-plugin.version>4.1.0</spring-boot-maven-plugin.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
-        <tomcat-embed-core.version>11.0.23</tomcat-embed-core.version>
-        <tomcat-embed-websocket.version>11.0.23</tomcat-embed-websocket.version>
-        <tomcat-embed-el.version>11.0.22</tomcat-embed-el.version>
+        <tomcat-embed-core.version>11.0.24</tomcat-embed-core.version>
+        <tomcat-embed-websocket.version>11.0.24</tomcat-embed-websocket.version>
+        <tomcat-embed-el.version>11.0.24</tomcat-embed-el.version>
 
         <!-- internal dependencies -->
         <api-security-java.version>2.0.25</api-security-java.version>


### PR DESCRIPTION
This pull request updates dependency versions in the `pom.xml` file to incorporate the latest bug fixes and security enhancements for logging and Tomcat components.

Dependency version upgrades:

* Upgraded `log4j2` from version 2.25.4 to 2.26.1 to include recent fixes and improvements.
* Upgraded `tomcat-embed-core`, `tomcat-embed-websocket`, and `tomcat-embed-el` from versions 11.0.23/11.0.22 to 11.0.24 to ensure compatibility and address potential vulnerabilities.