### PR TITLE
TDG Mongo: Restrict Company sub type CIC to eligible companies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>7.0.9</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.23</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.24</test-data-generator-library.version>
 
         <!-- Sonar config -->
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/CompanySubTypeValidator.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/CompanySubTypeValidator.java
@@ -19,5 +19,13 @@ public final class CompanySubTypeValidator {
                 && !CompanyType.LIMITED_PARTNERSHIP.equals(companyType)) {
             throw new HttpMessageNotReadableException(INVALID_REQUEST, (HttpInputMessage) null);
         }
+        if (COMMUNITY_INTEREST_COMPANY.equals(subType)
+                && !allowsCommunityInterestCompanySubType(companyType)) {
+            throw new HttpMessageNotReadableException(INVALID_REQUEST, (HttpInputMessage) null);
+        }
+    }
+
+    private static boolean allowsCommunityInterestCompanySubType(CompanyType companyType) {
+        return companyType == null || companyType.allowsCommunityInterestCompanySubType();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImpl.java
@@ -184,7 +184,7 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
         if (internalCompanyRequest.getCompanyName() != null) {
             profile.setCompanyName(internalCompanyRequest.getCompanyName() + " " + companyNumber);
         } else {
-            setCompanyName(profile, companyNumber, companyTypeValue);
+            setCompanyName(profile, companyNumber, companyTypeValue, subType);
         }
         profile.setSicCodes(Collections.singletonList("71200"));
 
@@ -621,10 +621,15 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
     }
 
     private void setCompanyName(CompanyProfile profile, String companyNumber, String companyType) {
+        setCompanyName(profile, companyNumber, companyType, null);
+    }
+
+    private void setCompanyName(CompanyProfile profile, String companyNumber, String companyType, String subType) {
         if (companyType.equals(CompanyType.UNITED_KINGDOM_SOCIETAS.getValue())) {
             profile.setCompanyName(COMPANY_NAME_PREFIX + companyNumber + " UK SOCIETAS");
         } else {
-            profile.setCompanyName(COMPANY_NAME_PREFIX + companyNumber + getCompanyNameEnding(CompanyType.fromValue(companyType)));
+            profile.setCompanyName(COMPANY_NAME_PREFIX + companyNumber
+                    + getCompanyNameEnding(CompanyType.fromValue(companyType), subType));
         }
     }
 
@@ -751,12 +756,16 @@ public class CompanyProfileServiceImpl implements CompanyProfileService {
     }
 
     private String getCompanyNameEnding(CompanyType companyType) {
+        return getCompanyNameEnding(companyType, null);
+    }
+
+    private String getCompanyNameEnding(CompanyType companyType, String subType) {
         if (companyType == null) {
             LOG.info("getCompanyNameEnding called with null companyType");
             return "";
         }
         try {
-            String ending = CompanyNameEnding.fromTypeEnum(companyType).getEnding();
+            String ending = CompanyNameEnding.fromTypeEnum(companyType, subType).getEnding();
             return ending.isEmpty() ? "" : " " + ending;
         } catch (IllegalArgumentException ex) {
             LOG.error("No CompanyNameEnding mapping for CompanyType:}" + companyType, ex);

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -296,6 +296,18 @@ class CompanyProfileServiceImplTest {
     }
 
     @Test
+    void createLimitedPartnershipWithCommunityInterestCompanySubTypeThrowsInvalidRequestException() {
+        setCompanyJurisdictionAndType(JurisdictionType.ENGLAND_WALES, CompanyType.LIMITED_PARTNERSHIP);
+        internalCompanyRequest.setSubType(CompanySubTypeValidator.COMMUNITY_INTEREST_COMPANY);
+
+        HttpMessageNotReadableException thrown = assertThrows(HttpMessageNotReadableException.class,
+                () -> companyProfileService.create(internalCompanyRequest));
+
+        assertEquals("invalid request", thrown.getMessage());
+        verify(repository, never()).save(any());
+    }
+
+    @Test
     void createCompanyWithSuperSecurePscsTrue() {
         internalCompanyRequest.setHasSuperSecurePscs(true);
         CompanyProfile profile = createAndCapture(internalCompanyRequest);
@@ -1033,6 +1045,26 @@ class CompanyProfileServiceImplTest {
         assertEquals("COMPANY " + COMPANY_NUMBER + " PLC", profile.getCompanyName());
     }
 
+    @ParameterizedTest
+    @MethodSource("communityInterestCompanyTypeAndExpectedNameEnding")
+    void createCommunityInterestCompanySetsExpectedCompanyNameEnding(CompanyType companyType,
+                                                                     String expectedEnding) {
+        internalCompanyRequest.setCompanyType(companyType);
+        internalCompanyRequest.setSubType(CompanySubTypeValidator.COMMUNITY_INTEREST_COMPANY);
+        internalCompanyRequest.setCompanyNumber(COMPANY_NUMBER);
+
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any())).thenReturn(savedProfile);
+
+        companyProfileService.create(internalCompanyRequest);
+
+        ArgumentCaptor<CompanyProfile> captor = ArgumentCaptor.forClass(CompanyProfile.class);
+        verify(repository).save(captor.capture());
+        CompanyProfile profile = captor.getValue();
+
+        assertEquals("COMPANY " + COMPANY_NUMBER + " " + expectedEnding, profile.getCompanyName());
+    }
+
     @Test
     void createCompanyTypeWithoutNameEnding() {
         internalCompanyRequest.setCompanyType(CONVERTED_OR_CLOSED_TYPE);
@@ -1068,7 +1100,7 @@ class CompanyProfileServiceImplTest {
         method.setAccessible(true);
 
         try (MockedStatic<CompanyNameEnding> mocked = Mockito.mockStatic(CompanyNameEnding.class)) {
-            mocked.when(() -> CompanyNameEnding.fromTypeEnum(CompanyType.PLC))
+            mocked.when(() -> CompanyNameEnding.fromTypeEnum(CompanyType.PLC, null))
                     .thenThrow(new IllegalArgumentException("No mapping"));
 
             String result = (String) method.invoke(companyProfileService, CompanyType.PLC);
@@ -1099,6 +1131,14 @@ class CompanyProfileServiceImplTest {
                 Arguments.of(CompanyType.PROTECTED_CELL_COMPANY, "PCC LIMITED"),
                 Arguments.of(CompanyType.UKEIG, "UKEIG"),
                 Arguments.of(CompanyType.UNITED_KINGDOM_SOCIETAS, "UK SOCIETAS")
+        );
+    }
+
+    static Stream<Arguments> communityInterestCompanyTypeAndExpectedNameEnding() {
+        return Stream.of(
+                Arguments.of(CompanyType.LTD, "COMMUNITY INTEREST COMPANY"),
+                Arguments.of(CompanyType.PRIVATE_LIMITED_GUARANT_NSC, "COMMUNITY INTEREST COMPANY"),
+                Arguments.of(CompanyType.PLC, "COMMUNITY INTEREST PLC")
         );
     }
 


### PR DESCRIPTION
This pull request introduces improved validation and handling for the "Community Interest Company" (CIC) sub-type, ensuring only allowed company types can use this sub-type and that company name endings reflect the sub-type where appropriate. It also updates dependencies and expands test coverage to verify the new logic.

**Validation and Business Logic Improvements:**

* Added validation in `CompanySubTypeValidator` to ensure the "Community Interest Company" sub-type is only allowed for specific company types, throwing an exception for invalid combinations.
* Updated company name generation logic in `CompanyProfileServiceImpl` to include the sub-type when determining the company name ending, ensuring correct naming for CICs. [[1]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086L187-R187) [[2]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086R624-R632) [[3]](diffhunk://#diff-657c65b93105aa6ca05e40d63ddbb1230700d7414d9afec5cba0e2dcc5c35086R759-R768)

**Testing Enhancements:**

* Added parameterized tests to verify that companies created with the CIC sub-type have the correct name endings, and tests to ensure invalid combinations are rejected. [[1]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3R298-R309) [[2]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3R1048-R1067) [[3]](diffhunk://#diff-6589e7a7353aabc40d0c0d238ca0d49a231fbeae5009e1f003b7483ffdf68cb3R1137-R1144)
* Updated mocks in tests to reflect the new method signatures for company name ending logic.

**Dependency Updates:**

* Bumped the `test-data-generator-library` dependency version from `1.0.23` to `1.0.24` in `pom.xml`.