### PR TITLE
TDG Mongo & Oracle: Remove redundant company types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>7.0.9</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.24</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.25</test-data-generator-library.version>
 
         <!-- Sonar config -->
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscServiceImpl.java
@@ -84,7 +84,7 @@ public class CompanyPscServiceImpl implements CompanyPscService {
      * <ul>
      *   <li>FCA-regulated investment vehicles (ICVC, assurance, protected cell, investment companies)</li>
      *   <li>Charities regulated outside Companies House (CIOs, SCIOs, further education corporations)</li>
-     *   <li>European and UK economic interest groupings (EEIG, EEIG Establishment, UKEIG)</li>
+     *   <li>UK economic interest groupings (UKEIG)</li>
      *   <li>Overseas and establishment companies (oversea-company, UK establishment)</li>
      *   <li>Entities exempt by structure (limited partnerships, registered societies, royal charter)</li>
      *   <li>Historical company types (old public company)</li>
@@ -93,8 +93,6 @@ public class CompanyPscServiceImpl implements CompanyPscService {
     private static final Set<CompanyType> EXCLUDED_COMPANY_TYPES = Set.of(
             CompanyType.ASSURANCE_COMPANY,
             CompanyType.CHARITABLE_INCORPORATED_ORGANISATION,
-            CompanyType.EEIG,
-            CompanyType.EEIG_ESTABLISHMENT,
             CompanyType.FURTHER_EDUCATION_OR_SIXTH_FORM_COLLEGE_CORPORATION,
             CompanyType.ICVC_SECURITIES,
             CompanyType.ICVC_UMBRELLA,

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyProfileServiceImplTest.java
@@ -1122,8 +1122,6 @@ class CompanyProfileServiceImplTest {
 
     static Stream<Arguments> companyTypeAndExpectedNameEnding() {
         return Stream.of(
-                Arguments.of(CompanyType.EEIG, "EEIG"),
-                Arguments.of(CompanyType.EUROPEAN_PUBLIC_LIMITED_LIABILITY_COMPANY_SE, "SE"),
                 Arguments.of(CompanyType.ICVC_SECURITIES, "ICVC"),
                 Arguments.of(CompanyType.LIMITED_PARTNERSHIP, "LIMITED PARTNERSHIP"),
                 Arguments.of(CompanyType.LLP, "LIMITED LIABILITY PARTNERSHIP"),


### PR DESCRIPTION
This pull request updates dependencies and refines the handling of company types, specifically removing references to European Economic Interest Groupings (EEIG) and related types. The main changes are as follows:

**Dependency update:**
* Updated the `test-data-generator-library` version from `1.0.24` to `1.0.25` in `pom.xml`.

**Company type handling and documentation:**
* Updated JavaDoc in `CompanyPscServiceImpl` to remove mention of "European and UK economic interest groupings (EEIG, EEIG Establishment, UKEIG)" and now only reference "UK economic interest groupings (UKEIG)".
* Removed `EEIG` and `EEIG_ESTABLISHMENT` from the `EXCLUDED_COMPANY_TYPES` set in `CompanyPscServiceImpl`, so these types are no longer explicitly excluded.

**Test updates:**
* Removed test cases for `EEIG` and `EUROPEAN_PUBLIC_LIMITED_LIABILITY_COMPANY_SE` from `companyTypeAndExpectedNameEnding` in `CompanyProfileServiceImplTest`.