### PR TITLE
TDG Mongo: Fix PSC statement generation to align with business rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>7.0.9</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.25</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.26</test-data-generator-library.version>
 
         <!-- Sonar config -->
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>7.0.9</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.27</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.26</test-data-generator-library.version>
 
         <!-- Sonar config -->
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>7.0.9</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.26</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.27</test-data-generator-library.version>
 
         <!-- Sonar config -->
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.java
@@ -14,6 +14,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscStatement;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
 import uk.gov.companieshouse.api.testdata.model.rest.request.InternalCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
+import uk.gov.companieshouse.api.testdata.model.rest.enums.PscStatementType;
 import uk.gov.companieshouse.api.testdata.repository.CompanyPscStatementRepository;
 import uk.gov.companieshouse.api.testdata.service.DataService;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
@@ -55,19 +56,45 @@ public class CompanyPscStatementServiceImpl implements
 
         pscStatement.setNotifiedOn(LocalDate.now().atStartOfDay(ZONE_ID_UTC).toInstant());
 
-        if (spec.getCompanyType() == CompanyType.REGISTERED_OVERSEAS_ENTITY) {
-            pscStatement.setStatement(PscStatement.ALL_BENEFICIAL_OWNERS_IDENTIFIED.getStatement());
-        } else if (BooleanUtils.isTrue(spec.getHasSuperSecurePscs())) {
-            pscStatement.setStatement(PscStatement.PSC_EXISTS_BUT_NOT_IDENTIFIED.getStatement());
-        } else if (Boolean.TRUE.equals(spec.getPscActive())) {
-            pscStatement.setStatement(PscStatement.PSC_EXISTS_BUT_NOT_IDENTIFIED.getStatement());
-        } else if (spec.getWithdrawnStatements() > 0) {
-            pscStatement.setStatement(PscStatement.BENEFICIAL_ACTIVE_OR_CEASED.getStatement());
+        boolean isRoe = spec.getCompanyType() == CompanyType.REGISTERED_OVERSEAS_ENTITY;
+        boolean isPartnership = spec.getCompanyType() == CompanyType.SCOTTISH_PARTNERSHIP
+                || spec.getCompanyType() == CompanyType.LIMITED_PARTNERSHIP;
+        boolean hasSuperSecure = BooleanUtils.isTrue(spec.getHasSuperSecurePscs());
+        boolean hasWithdrawn = spec.getWithdrawnStatements() != null
+                && spec.getWithdrawnStatements() > 0;
+
+        if (isRoe && hasWithdrawn) {
+            pscStatement.setStatement(
+                    PscStatementType.SOMEBODY_HAS_BECOME_OR_CEASED_TO_BE_A_BENEFICIAL_OWNER
+                            .getValue());
+            pscStatement.setCeasedOn(LocalDate.now().minusDays(30)
+                    .atStartOfDay(ZONE_ID_UTC).toInstant());
+        } else if (isRoe) {
+            pscStatement.setStatement(
+                    PscStatementType.ALL_BENEFICIAL_OWNERS_IDENTIFIED.getValue());
+        } else if (isPartnership && hasSuperSecure) {
+            pscStatement.setStatement(
+                    PscStatementType.PSC_HAS_FAILED_TO_CONFIRM_CHANGED_DETAILS_PARTNERSHIP
+                            .getValue());
+        } else if (isPartnership && hasWithdrawn) {
+            pscStatement.setStatement(
+                    PscStatementType.PSC_CONTACTED_BUT_NO_RESPONSE_PARTNERSHIP.getValue());
+            pscStatement.setCeasedOn(LocalDate.now().minusDays(30)
+                    .atStartOfDay(ZONE_ID_UTC).toInstant());
+        } else if (isPartnership) {
+            pscStatement.setStatement(
+                    PscStatementType.PSC_EXISTS_BUT_NOT_IDENTIFIED_PARTNERSHIP.getValue());
+        } else if (hasSuperSecure) {
+            pscStatement.setStatement(
+                    PscStatementType.PSC_HAS_FAILED_TO_CONFIRM_CHANGED_DETAILS.getValue());
+        } else if (hasWithdrawn) {
+            pscStatement.setStatement(
+                    PscStatementType.PSC_DETAILS_NOT_CONFIRMED.getValue());
             pscStatement.setCeasedOn(LocalDate.now().minusDays(30)
                     .atStartOfDay(ZONE_ID_UTC).toInstant());
         } else {
             pscStatement.setStatement(
-                    PscStatement.NO_INDIVIDUAL_OR_ENTITY_WITH_SIGNIFICANT_CONTROL.getStatement());
+                    PscStatementType.NO_INDIVIDUAL_OR_ENTITY_WITH_SIGNIFICANT_CONTROL.getValue());
         }
         if (Boolean.TRUE.equals(spec.getCompanyWithPopulatedStructureOnly())) {
             return pscStatement;
@@ -166,24 +193,5 @@ public class CompanyPscStatementServiceImpl implements
             return true;
         }
         return false;
-    }
-
-    public enum PscStatement {
-        NO_INDIVIDUAL_OR_ENTITY_WITH_SIGNIFICANT_CONTROL(
-                "no-individual-or-entity-with-signficant-control"),
-        PSC_EXISTS_BUT_NOT_IDENTIFIED("psc-exists-but-not-identified"),
-        ALL_BENEFICIAL_OWNERS_IDENTIFIED("all-beneficial-owners-identified"),
-        BENEFICIAL_ACTIVE_OR_CEASED("somebody-has-become-or-ceased-to-be-a-beneficial-owner"),
-        NO_ACTIVE_BENEFICIAL_OWNER("nobody-has-become-or-ceased-to-be-a-beneficial-owner"),
-        AT_LEAST_ONE_BENEFICIAL_OWNER("at-least-one-beneficial-owner-unidentified");
-        private final String statement;
-
-        PscStatement(String statement) {
-            this.statement = statement;
-        }
-
-        public String getStatement() {
-            return statement;
-        }
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java
@@ -40,8 +40,6 @@ class CompanyPscStatementServiceImplTest {
     private static final String COMPANY_NUMBER = "12345678";
     private static final String ENCODED_VALUE = "abc123def456";
     private static final String ETAG = "etag";
-    private static final String PSC_STATEMENT_2 = "no-individual-or-entity-with-signficant-control";
-    private static final String PSC_STATEMENT_3 = "all-beneficial-owners-identified";
     private static final String PSC_ID = "PSC1234567";
     private static final ZoneId ZONE_ID_UTC = ZoneId.of("UTC");
 
@@ -90,7 +88,7 @@ class CompanyPscStatementServiceImplTest {
         assertNotNull(links);
         assertEquals("/company/" + COMPANY_NUMBER + "/persons-with-significant-control-statements/" + ENCODED_VALUE, links.getSelf());
 
-        assertEquals(PSC_STATEMENT_2, capturedStatement.getStatement());
+        assertEquals(PscStatementType.NO_INDIVIDUAL_OR_ENTITY_WITH_SIGNIFICANT_CONTROL.getValue(), capturedStatement.getStatement());
     }
 
     @Test
@@ -184,7 +182,7 @@ class CompanyPscStatementServiceImplTest {
         verify(repository, times(1)).save(captor.capture());
         CompanyPscStatement capturedStatement = captor.getValue();
 
-        assertEquals(PSC_STATEMENT_2, pscStatement.getStatement());
+        assertEquals(PscStatementType.NO_INDIVIDUAL_OR_ENTITY_WITH_SIGNIFICANT_CONTROL.getValue(), pscStatement.getStatement());
         assertNull(pscStatement.getCeasedOn());
         assertEquals(pscStatement, capturedStatement);
     }
@@ -208,7 +206,7 @@ class CompanyPscStatementServiceImplTest {
         verify(repository, times(1)).save(captor.capture());
         CompanyPscStatement capturedStatement = captor.getValue();
 
-        assertEquals(PSC_STATEMENT_2, pscStatement.getStatement());
+        assertEquals(PscStatementType.NO_INDIVIDUAL_OR_ENTITY_WITH_SIGNIFICANT_CONTROL.getValue(), pscStatement.getStatement());
         assertNull(pscStatement.getCeasedOn());
         assertEquals(pscStatement, capturedStatement);
     }
@@ -315,7 +313,7 @@ class CompanyPscStatementServiceImplTest {
         verify(repository, times(1)).save(captor.capture());
         CompanyPscStatement capturedStatement = captor.getValue();
 
-        assertEquals(PSC_STATEMENT_2, pscStatement.getStatement());
+        assertEquals(PscStatementType.NO_INDIVIDUAL_OR_ENTITY_WITH_SIGNIFICANT_CONTROL.getValue(), pscStatement.getStatement());
         assertNull(pscStatement.getCeasedOn());
         assertEquals(pscStatement, capturedStatement);
     }
@@ -374,7 +372,7 @@ class CompanyPscStatementServiceImplTest {
         ArgumentCaptor<CompanyPscStatement> statementCaptor = ArgumentCaptor.forClass(CompanyPscStatement.class);
         verify(repository).save(statementCaptor.capture());
         CompanyPscStatement capturedStatement = statementCaptor.getValue();
-        assertEquals(PSC_STATEMENT_3, capturedStatement.getStatement());
+        assertEquals(PscStatementType.ALL_BENEFICIAL_OWNERS_IDENTIFIED.getValue(), capturedStatement.getStatement());
     }
 
     @Test
@@ -393,7 +391,7 @@ class CompanyPscStatementServiceImplTest {
         ArgumentCaptor<CompanyPscStatement> statementCaptor = ArgumentCaptor.forClass(CompanyPscStatement.class);
         verify(repository).save(statementCaptor.capture());
         CompanyPscStatement capturedStatement = statementCaptor.getValue();
-        assertEquals(PSC_STATEMENT_2, capturedStatement.getStatement());
+        assertEquals(PscStatementType.NO_INDIVIDUAL_OR_ENTITY_WITH_SIGNIFICANT_CONTROL.getValue(), capturedStatement.getStatement());
     }
 
     @Test
@@ -413,7 +411,7 @@ class CompanyPscStatementServiceImplTest {
         ArgumentCaptor<CompanyPscStatement> statementCaptor = ArgumentCaptor.forClass(CompanyPscStatement.class);
         verify(repository).save(statementCaptor.capture());
         CompanyPscStatement capturedStatement = statementCaptor.getValue();
-        assertEquals(PSC_STATEMENT_2, capturedStatement.getStatement());
+        assertEquals(PscStatementType.NO_INDIVIDUAL_OR_ENTITY_WITH_SIGNIFICANT_CONTROL.getValue(), capturedStatement.getStatement());
     }
 
     @Test
@@ -433,7 +431,7 @@ class CompanyPscStatementServiceImplTest {
         ArgumentCaptor<CompanyPscStatement> statementCaptor = ArgumentCaptor.forClass(CompanyPscStatement.class);
         verify(repository).save(statementCaptor.capture());
         CompanyPscStatement capturedStatement = statementCaptor.getValue();
-        assertEquals(PSC_STATEMENT_2, capturedStatement.getStatement());
+        assertEquals(PscStatementType.NO_INDIVIDUAL_OR_ENTITY_WITH_SIGNIFICANT_CONTROL.getValue(), capturedStatement.getStatement());
     }
 
     @Test
@@ -560,7 +558,7 @@ class CompanyPscStatementServiceImplTest {
         verify(repository).save(statementCaptor.capture());
         CompanyPscStatement capturedStatement = statementCaptor.getValue();
         assertEquals("persons-with-significant-control-statement", capturedStatement.getKind());
-        assertEquals("all-beneficial-owners-identified", capturedStatement.getStatement());
+        assertEquals(PscStatementType.ALL_BENEFICIAL_OWNERS_IDENTIFIED.getValue(), capturedStatement.getStatement());
     }
 
     @Test
@@ -580,7 +578,7 @@ class CompanyPscStatementServiceImplTest {
         verify(repository).save(statementCaptor.capture());
         CompanyPscStatement capturedStatement = statementCaptor.getValue();
         assertEquals("persons-with-significant-control-statement", capturedStatement.getKind());
-        assertEquals(PSC_STATEMENT_2, capturedStatement.getStatement());
+        assertEquals(PscStatementType.NO_INDIVIDUAL_OR_ENTITY_WITH_SIGNIFICANT_CONTROL.getValue(), capturedStatement.getStatement());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java
@@ -30,6 +30,7 @@ import uk.gov.companieshouse.api.testdata.model.entity.CompanyPscStatement;
 import uk.gov.companieshouse.api.testdata.model.entity.Links;
 import uk.gov.companieshouse.api.testdata.model.rest.request.InternalCompanyRequest;
 import uk.gov.companieshouse.api.testdata.model.rest.enums.CompanyType;
+import uk.gov.companieshouse.api.testdata.model.rest.enums.PscStatementType;
 import uk.gov.companieshouse.api.testdata.repository.CompanyPscStatementRepository;
 import uk.gov.companieshouse.api.testdata.service.RandomService;
 
@@ -41,7 +42,6 @@ class CompanyPscStatementServiceImplTest {
     private static final String ETAG = "etag";
     private static final String PSC_STATEMENT_2 = "no-individual-or-entity-with-signficant-control";
     private static final String PSC_STATEMENT_3 = "all-beneficial-owners-identified";
-    private static final String PSC_STATEMENT_4 = "psc-exists-but-not-identified";
     private static final String PSC_ID = "PSC1234567";
     private static final ZoneId ZONE_ID_UTC = ZoneId.of("UTC");
 
@@ -115,7 +115,7 @@ class CompanyPscStatementServiceImplTest {
         assertEquals(ETAG, pscStatement.getEtag());
         assertEquals("persons-with-significant-control-statement", pscStatement.getKind());
         assertEquals("/company/" + COMPANY_NUMBER + "/persons-with-significant-control-statements/" + PSC_ID, pscStatement.getLinks().getSelf());
-        assertEquals(CompanyPscStatementServiceImpl.PscStatement.ALL_BENEFICIAL_OWNERS_IDENTIFIED.getStatement(), pscStatement.getStatement());
+        assertEquals(PscStatementType.ALL_BENEFICIAL_OWNERS_IDENTIFIED.getValue(), pscStatement.getStatement());
         assertNull(pscStatement.getCeasedOn());
         assertNotNull(pscStatement.getNotifiedOn());
         assertNotNull(pscStatement.getCreatedAt());
@@ -141,9 +141,28 @@ class CompanyPscStatementServiceImplTest {
         verify(repository, times(1)).save(captor.capture());
         CompanyPscStatement capturedStatement = captor.getValue();
 
-        assertEquals(CompanyPscStatementServiceImpl.PscStatement.PSC_EXISTS_BUT_NOT_IDENTIFIED.getStatement(), pscStatement.getStatement());
+        assertEquals(PscStatementType.PSC_HAS_FAILED_TO_CONFIRM_CHANGED_DETAILS.getValue(),
+                pscStatement.getStatement());
         assertNull(pscStatement.getCeasedOn());
         assertEquals(pscStatement, capturedStatement);
+    }
+
+    @Test
+    void createCompanyPscStatement_superSecure_scottishPartnership() {
+        when(randomService.getEncodedIdWithSalt(any(Integer.class), any(Integer.class)))
+                .thenReturn(PSC_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any(CompanyPscStatement.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        spec.setCompanyType(CompanyType.SCOTTISH_PARTNERSHIP);
+        spec.setHasSuperSecurePscs(true);
+
+        CompanyPscStatement pscStatement = companyPscStatementService.create(spec);
+
+        assertEquals(PscStatementType.PSC_HAS_FAILED_TO_CONFIRM_CHANGED_DETAILS_PARTNERSHIP.getValue(),
+                pscStatement.getStatement());
+        assertNull(pscStatement.getCeasedOn());
     }
 
     @Test
@@ -181,6 +200,7 @@ class CompanyPscStatementServiceImplTest {
         spec.setCompanyType(CompanyType.LTD);
         spec.setHasSuperSecurePscs(false);
         spec.setPscActive(true);
+        spec.setWithdrawnStatements(0);
 
         CompanyPscStatement pscStatement = companyPscStatementService.create(spec);
 
@@ -188,7 +208,7 @@ class CompanyPscStatementServiceImplTest {
         verify(repository, times(1)).save(captor.capture());
         CompanyPscStatement capturedStatement = captor.getValue();
 
-        assertEquals(CompanyPscStatementServiceImpl.PscStatement.PSC_EXISTS_BUT_NOT_IDENTIFIED.getStatement(), pscStatement.getStatement());
+        assertEquals(PSC_STATEMENT_2, pscStatement.getStatement());
         assertNull(pscStatement.getCeasedOn());
         assertEquals(pscStatement, capturedStatement);
     }
@@ -212,11 +232,68 @@ class CompanyPscStatementServiceImplTest {
         verify(repository, times(1)).save(captor.capture());
         CompanyPscStatement capturedStatement = captor.getValue();
 
-        assertEquals(CompanyPscStatementServiceImpl.PscStatement.BENEFICIAL_ACTIVE_OR_CEASED.getStatement(), pscStatement.getStatement());
+        assertEquals(PscStatementType.PSC_DETAILS_NOT_CONFIRMED.getValue(), pscStatement.getStatement());
         assertNotNull(pscStatement.getCeasedOn());
         assertEquals(LocalDate.now().minusDays(30).atStartOfDay(ZONE_ID_UTC).toInstant().truncatedTo(ChronoUnit.SECONDS),
                 pscStatement.getCeasedOn().truncatedTo(ChronoUnit.SECONDS));
         assertEquals(pscStatement, capturedStatement);
+    }
+
+    @Test
+    void createCompanyPscStatement_withdrawnStatements_registeredOverseasEntity() {
+        when(randomService.getEncodedIdWithSalt(any(Integer.class), any(Integer.class)))
+                .thenReturn(PSC_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any(CompanyPscStatement.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        spec.setCompanyType(CompanyType.REGISTERED_OVERSEAS_ENTITY);
+        spec.setHasSuperSecurePscs(false);
+        spec.setWithdrawnStatements(1);
+
+        CompanyPscStatement pscStatement = companyPscStatementService.create(spec);
+
+        assertEquals(PscStatementType.SOMEBODY_HAS_BECOME_OR_CEASED_TO_BE_A_BENEFICIAL_OWNER.getValue(),
+                pscStatement.getStatement());
+        assertNotNull(pscStatement.getCeasedOn());
+    }
+
+    @Test
+    void createCompanyPscStatement_withdrawnStatements_scottishPartnership() {
+        when(randomService.getEncodedIdWithSalt(any(Integer.class), any(Integer.class)))
+                .thenReturn(PSC_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any(CompanyPscStatement.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        spec.setCompanyType(CompanyType.SCOTTISH_PARTNERSHIP);
+        spec.setHasSuperSecurePscs(false);
+        spec.setWithdrawnStatements(1);
+
+        CompanyPscStatement pscStatement = companyPscStatementService.create(spec);
+
+        assertEquals(PscStatementType.PSC_CONTACTED_BUT_NO_RESPONSE_PARTNERSHIP.getValue(),
+                pscStatement.getStatement());
+        assertNotNull(pscStatement.getCeasedOn());
+    }
+
+    @Test
+    void createCompanyPscStatement_withdrawnStatements_limitedPartnership() {
+        when(randomService.getEncodedIdWithSalt(any(Integer.class), any(Integer.class)))
+                .thenReturn(PSC_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any(CompanyPscStatement.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        spec.setCompanyType(CompanyType.LIMITED_PARTNERSHIP);
+        spec.setHasSuperSecurePscs(false);
+        spec.setWithdrawnStatements(1);
+
+        CompanyPscStatement pscStatement = companyPscStatementService.create(spec);
+
+        assertEquals(PscStatementType.PSC_CONTACTED_BUT_NO_RESPONSE_PARTNERSHIP.getValue(),
+                pscStatement.getStatement());
+        assertNotNull(pscStatement.getCeasedOn());
     }
 
     @Test
@@ -238,9 +315,47 @@ class CompanyPscStatementServiceImplTest {
         verify(repository, times(1)).save(captor.capture());
         CompanyPscStatement capturedStatement = captor.getValue();
 
-        assertEquals(PSC_STATEMENT_4, pscStatement.getStatement());
+        assertEquals(PSC_STATEMENT_2, pscStatement.getStatement());
         assertNull(pscStatement.getCeasedOn());
         assertEquals(pscStatement, capturedStatement);
+    }
+
+    @Test
+    void createCompanyPscStatement_scottishPartnership() {
+        when(randomService.getEncodedIdWithSalt(any(Integer.class), any(Integer.class)))
+                .thenReturn(PSC_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any(CompanyPscStatement.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        spec.setCompanyType(CompanyType.SCOTTISH_PARTNERSHIP);
+        spec.setHasSuperSecurePscs(false);
+        spec.setWithdrawnStatements(0);
+
+        CompanyPscStatement pscStatement = companyPscStatementService.create(spec);
+
+        assertEquals(PscStatementType.PSC_EXISTS_BUT_NOT_IDENTIFIED_PARTNERSHIP.getValue(),
+                pscStatement.getStatement());
+        assertNull(pscStatement.getCeasedOn());
+    }
+
+    @Test
+    void createCompanyPscStatement_limitedPartnership() {
+        when(randomService.getEncodedIdWithSalt(any(Integer.class), any(Integer.class)))
+                .thenReturn(PSC_ID);
+        when(randomService.getEtag()).thenReturn(ETAG);
+        when(repository.save(any(CompanyPscStatement.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        spec.setCompanyType(CompanyType.LIMITED_PARTNERSHIP);
+        spec.setHasSuperSecurePscs(false);
+        spec.setWithdrawnStatements(0);
+
+        CompanyPscStatement pscStatement = companyPscStatementService.create(spec);
+
+        assertEquals(PscStatementType.PSC_EXISTS_BUT_NOT_IDENTIFIED_PARTNERSHIP.getValue(),
+                pscStatement.getStatement());
+        assertNull(pscStatement.getCeasedOn());
     }
 
     @Test


### PR DESCRIPTION
This pull request refactors how PSC (Persons with Significant Control) statement values are determined and assigned in `CompanyPscStatementServiceImpl`, moving from a local enum to the shared `PscStatementType` enum. The logic for assigning PSC statements is now more nuanced, especially for partnerships and overseas entities, and the test suite has been significantly expanded to cover these cases.

The most important changes are:

### Refactoring and Logic Updates

* The internal `PscStatement` enum in `CompanyPscStatementServiceImpl` was removed, and statement assignment now uses the shared `PscStatementType` enum for consistency across the codebase. (`src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.java`, [src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.javaL170-L188](diffhunk://#diff-7e3efa7693964af8841af3220058baa0ef2bce844fcbcc038110fdb75dc3ed0eL170-L188))
* The logic in the `create` method was reworked to handle additional company types (e.g., Scottish and Limited Partnerships, Registered Overseas Entities) and new scenarios (e.g., handling withdrawn statements and "super secure" PSCs) with more precise statement assignment and ceased dates. (`src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.java`, [src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.javaL58-R97](diffhunk://#diff-7e3efa7693964af8841af3220058baa0ef2bce844fcbcc038110fdb75dc3ed0eL58-R97))

### Dependency and Import Updates

* The `test-data-generator-library` dependency was updated from version `1.0.25` to `1.0.26` in `pom.xml`.
* Imports in both the service and test files were updated to use `PscStatementType` instead of the removed local enum. (`src/main/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImpl.java`, [[1]](diffhunk://#diff-7e3efa7693964af8841af3220058baa0ef2bce844fcbcc038110fdb75dc3ed0eR17); `src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java`, [[2]](diffhunk://#diff-c5d14f8fe0970be4ffac65376d7554fb6fddd1d30b7bcd6e5515c7476c86f1f6R33)

### Test Suite Expansion

* The test class now includes multiple new tests for the new company types and scenarios, ensuring the correct PSC statement and ceased date are set for partnerships, overseas entities, and when withdrawn statements are present. (`src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java`, [[1]](diffhunk://#diff-c5d14f8fe0970be4ffac65376d7554fb6fddd1d30b7bcd6e5515c7476c86f1f6L144-R167) [[2]](diffhunk://#diff-c5d14f8fe0970be4ffac65376d7554fb6fddd1d30b7bcd6e5515c7476c86f1f6L215-R298) [[3]](diffhunk://#diff-c5d14f8fe0970be4ffac65376d7554fb6fddd1d30b7bcd6e5515c7476c86f1f6L241-R360)
* Existing tests were updated to reference `PscStatementType` and to align with the new logic and statement values. (`src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CompanyPscStatementServiceImplTest.java`, [[1]](diffhunk://#diff-c5d14f8fe0970be4ffac65376d7554fb6fddd1d30b7bcd6e5515c7476c86f1f6L118-R118) [[2]](diffhunk://#diff-c5d14f8fe0970be4ffac65376d7554fb6fddd1d30b7bcd6e5515c7476c86f1f6R203-R211)

These changes improve maintainability, consistency, and test coverage of PSC statement handling.