### PR TITLE
Upgrade TDG library to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>7.0.9</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.26</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.27</test-data-generator-library.version>
 
         <!-- Sonar config -->
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CertifiedCopiesServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/CertifiedCopiesServiceImplTest.java
@@ -86,7 +86,7 @@ class CertifiedCopiesServiceImplTest {
 
         ItemOptionsRequest itemOptionsRequest = new ItemOptionsRequest();
         itemOptionsRequest.setDeliveryMethod("standard");
-        itemOptionsRequest.setFilingHistoryDocumentsSpec(List.of(filingHistoryDocument));
+        itemOptionsRequest.setFilingHistoryDocuments(List.of(filingHistoryDocument));
 
         ItemCostsRequest itemCostsRequest = new ItemCostsRequest();
         itemCostsRequest.setDiscountApplied("0");
@@ -177,7 +177,7 @@ class CertifiedCopiesServiceImplTest {
         itemOptionsRequest.setCollectionLocation("wales");
         itemOptionsRequest.setContactNumber("844740192");
         itemOptionsRequest.setDeliveryTimescale("same-day");
-        itemOptionsRequest.setFilingHistoryDocumentsSpec(List.of(filingHistoryDocumentsSpec));
+        itemOptionsRequest.setFilingHistoryDocuments(List.of(filingHistoryDocumentsSpec));
         itemOptionsRequest.setForeName("John");
         itemOptionsRequest.setSurName("Test");
 
@@ -335,7 +335,7 @@ class CertifiedCopiesServiceImplTest {
         ItemOptionsRequest itemOption1 = new ItemOptionsRequest();
         itemOption1.setDeliveryTimescale("postal");
         itemOption1.setDeliveryMethod("standard");
-        itemOption1.setFilingHistoryDocumentsSpec(List.of(filingHistoryDocument1));
+        itemOption1.setFilingHistoryDocuments(List.of(filingHistoryDocument1));
 
         filingHistoryDocument1.setFilingHistoryDate("2019-11-23");
         filingHistoryDocument1.setFilingHistoryDescription("incorporation-company");
@@ -344,9 +344,9 @@ class CertifiedCopiesServiceImplTest {
         filingHistoryDocument1.setFilingHistoryCost("30");
 
         ItemOptionsRequest itemOption2 = new ItemOptionsRequest();
-        itemOption1.setDeliveryTimescale("postal");
-        itemOption1.setDeliveryMethod("standard");
-        itemOption1.setFilingHistoryDocumentsSpec(List.of(filingHistoryDocument1));
+        itemOption2.setDeliveryTimescale("postal");
+        itemOption2.setDeliveryMethod("standard");
+        itemOption2.setFilingHistoryDocuments(List.of(filingHistoryDocument1));
 
         certifiedCopiesRequest.setItemOptions(List.of(itemOption1, itemOption2));
 
@@ -446,7 +446,7 @@ class CertifiedCopiesServiceImplTest {
         docSpec.setFilingHistoryCost("1");
 
         ItemOptionsRequest itemOptionsRequest = new ItemOptionsRequest();
-        itemOptionsRequest.setFilingHistoryDocumentsSpec(List.of(docSpec));
+        itemOptionsRequest.setFilingHistoryDocuments(List.of(docSpec));
 
         CertifiedCopiesRequest spec = new CertifiedCopiesRequest();
         spec.setItemOptions(List.of(itemOptionsRequest));


### PR DESCRIPTION
This pull request updates the test code to use the correct setter method for filing history documents in `ItemOptionsRequest`, replacing `setFilingHistoryDocumentsSpec` with `setFilingHistoryDocuments`. It also updates the version of the `test-data-generator-library` dependency in `pom.xml`.

Dependency update:

* Updated the `test-data-generator-library` version from `1.0.26` to `1.0.27` in `pom.xml`.

Test code refactoring:

* Replaced all usages of `setFilingHistoryDocumentsSpec` with `setFilingHistoryDocuments` in the `CertifiedCopiesServiceImplTest` test cases to align with the updated API. [[1]](diffhunk://#diff-7a68977c37fec5abfd52c09ccbe81ca8173b4413b3a1891374556ee41bbdf46eL89-R89) [[2]](diffhunk://#diff-7a68977c37fec5abfd52c09ccbe81ca8173b4413b3a1891374556ee41bbdf46eL180-R180) [[3]](diffhunk://#diff-7a68977c37fec5abfd52c09ccbe81ca8173b4413b3a1891374556ee41bbdf46eL338-R338) [[4]](diffhunk://#diff-7a68977c37fec5abfd52c09ccbe81ca8173b4413b3a1891374556ee41bbdf46eL347-R349) [[5]](diffhunk://#diff-7a68977c37fec5abfd52c09ccbe81ca8173b4413b3a1891374556ee41bbdf46eL449-R449)