### PR TITLE
Add PSC discrepancies and reports functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,17 @@ For example, if one corporate officer role and five identification types are sup
 #### Appointments
 - DELETE: Sending a DELETE request on the endpoint `{Base URL}/test-data/internal/company/{companyNumber}/appointments` will delete all appointments for a given company. `companyNumber` is required in the URL path.
   - Response: 204 NO_CONTENT on successful deletion
-  - Response: 404 NOT_FOUND if no appointments exist for the company
+  - Response: 404 NOT_FOUND if no appointments exist for the company 
+
+#### Creating and Deleting PSC Discrepancies
+
+- POST: Sending a POST request to create PSC Discrepancies `{Base URL}/test-data/internal/pscdiscrepancies` will create a PSC Discrepancy Report and an associated PSC Discrepancy entry.
+  - `user_id`: The user ID associated with the PSC discrepancy report. This is mandatory.
+  - `psc_type`: The PSC type associated with the discrepancy(eg., `corporate-entity-person-with-significant-control`, `PSC is missing`, `psc-is-missing`, `legal-person-beneficial-owner`, `individual-beneficial-owner`, `legal-person-with-significant-control`, `corporate-entity-beneficial-owner`, `individual-person-with-significant-control`, `legal-person-person-with-significant-control`). This is mandatory
+  - `status`: The status for the Psc discrepancy reports and psc discrepancies(eg., `INCOMPLETE`, `COMPLETE`, `FAILED_TO_SUBMIT`, `SUBMITTED`). This is mandatory
+
+  A usage example looks like this: `{"user_id": "QdMXdyxwQBmCxxUoPlGFyScmiUK", "psc_type": "PSC is missing","status": "INCOMPLETE"}`
+- DELETE: Sending a DELETE request on the endpoint `{Base URL}/test-data/internal/pscdiscrepancies/{pscdiscrepanciesid}` will delete the `Psc discrepancies and psc discrepancy reports`.
 
 ## Environment Variables
 The supported environmental variables have been categorised by use case and are as follows.

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>7.0.9</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.27</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.28</test-data-generator-library.version>
 
         <!-- Sonar config -->
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <api-security-java.version>2.0.25</api-security-java.version>
         <private-api-sdk-java.version>7.0.9</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
-        <test-data-generator-library.version>1.0.25</test-data-generator-library.version>
+        <test-data-generator-library.version>1.0.26-SNAPSHOT</test-data-generator-library.version>
 
         <!-- Sonar config -->
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>

--- a/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
@@ -234,11 +234,13 @@ public class MongoConfig {
 
     @Bean
     public PscDiscrepanciesRepository pscDiscrepanciesRepository() {
-        return getMongoRepositoryBean(
-                PscDiscrepanciesRepository.class,
-                PSC_DISCREPANCIES_DATABASE);
+        return getMongoRepositoryBean( PscDiscrepanciesRepository.class, PSC_DISCREPANCIES_DATABASE);
     }
 
+    @Bean
+    public PscDiscrepancyReportsRepository pscDiscrepancyReportsRepository() {
+        return getMongoRepositoryBean( PscDiscrepancyReportsRepository.class, PSC_DISCREPANCIES_DATABASE);
+    }
     private MongoTemplate createMongoTemplate(final String database) {
         var simpleMongoDbFactory = new SimpleMongoClientDatabaseFactory(
                 mongoClient(), database);

--- a/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/config/MongoConfig.java
@@ -41,6 +41,8 @@ import uk.gov.companieshouse.api.testdata.repository.ItemGroupsRepository;
 import uk.gov.companieshouse.api.testdata.repository.MissingImageDeliveriesRepository;
 import uk.gov.companieshouse.api.testdata.repository.OfficerRepository;
 import uk.gov.companieshouse.api.testdata.repository.OverseasEntityRepository;
+import uk.gov.companieshouse.api.testdata.repository.PscDiscrepanciesRepository;
+import uk.gov.companieshouse.api.testdata.repository.PscDiscrepancyReportsRepository;
 import uk.gov.companieshouse.api.testdata.repository.TransactionsRepository;
 import uk.gov.companieshouse.api.testdata.repository.UserCompanyAssociationRepository;
 import uk.gov.companieshouse.api.testdata.repository.UserRepository;
@@ -64,6 +66,7 @@ public class MongoConfig {
     private static final String SIC_CODE_DATABASE = "sic_code";
     private static final String IDENTITY_VERIFICATION = "identity_verification";
     private static final String ORDERS_ITEM_GROUPS_DATABASE = "orders_item_groups";
+    private static final String PSC_DISCREPANCIES_DATABASE = "psc_discrepancies";
 
     @Bean
     public CompanyProfileRepository companyProfileRepository() {
@@ -227,6 +230,13 @@ public class MongoConfig {
     @Bean
     public CombinedSicActivitiesRepository combinedSicActivitiesRepository() {
         return getMongoRepositoryBean(CombinedSicActivitiesRepository.class, SIC_CODE_DATABASE);
+    }
+
+    @Bean
+    public PscDiscrepanciesRepository pscDiscrepanciesRepository() {
+        return getMongoRepositoryBean(
+                PscDiscrepanciesRepository.class,
+                PSC_DISCREPANCIES_DATABASE);
     }
 
     private MongoTemplate createMongoTemplate(final String database) {

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/PscDiscrepanciesController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/PscDiscrepanciesController.java
@@ -1,0 +1,108 @@
+package uk.gov.companieshouse.api.testdata.controller;
+
+import jakarta.validation.Valid;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import uk.gov.companieshouse.api.testdata.Application;
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.model.rest.request.PscDiscrepanciesRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.response.PscDiscrepanciesResponse;
+import uk.gov.companieshouse.api.testdata.service.PscDiscrepanciesService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@RestController
+@RequestMapping(value = "${api.endpoint}/internal", produces = MediaType.APPLICATION_JSON_VALUE)
+public class PscDiscrepanciesController {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(Application.APPLICATION_NAME);
+
+    private static final String STATUS = "status";
+
+    private final PscDiscrepanciesService pscDiscrepanciesService;
+
+    public PscDiscrepanciesController(
+            PscDiscrepanciesService pscDiscrepanciesService) {
+        this.pscDiscrepanciesService = pscDiscrepanciesService;
+    }
+
+    @PostMapping("/pscdiscrepancies")
+    public ResponseEntity<String> test() {
+        return ResponseEntity.ok("PSC endpoint works");
+    }
+
+//    @PostMapping("/pscdiscrepancies")
+//    public ResponseEntity<PscDiscrepanciesResponse> createPscDiscrepancy(
+//            @Valid @RequestBody PscDiscrepanciesRequest request)
+//            throws DataException {
+//
+//        try {
+//            var createdPscDiscrepancy =
+//                    pscDiscrepanciesService.create(request);
+//
+//            Map<String, Object> data = new HashMap<>();
+//            data.put(
+//                    "psc-discrepancies-id",
+//                    createdPscDiscrepancy.getPscDiscrepanciesId());
+//
+//            data.put(
+//                    "psc-discrepancy-report-id",
+//                    createdPscDiscrepancy.getPscDiscrepancyReportId());
+//
+//            LOG.info("New PSC discrepancy created", data);
+//
+//            return new ResponseEntity<>(
+//                    createdPscDiscrepancy,
+//                    HttpStatus.CREATED);
+//
+//        } catch (Exception ex) {
+//            throw new DataException(
+//                    "Error creating PSC discrepancy",
+//                    ex);
+//        }
+//    }
+
+    @DeleteMapping("/pscdiscrepancies/{pscDiscrepanciesId}")
+    public ResponseEntity<Map<String, Object>> deletePscDiscrepancy(
+            @PathVariable("pscDiscrepanciesId") String pscDiscrepanciesId)
+            throws DataException {
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("id", pscDiscrepanciesId);
+
+        try {
+
+            boolean deleted =
+                    pscDiscrepanciesService.delete(pscDiscrepanciesId);
+
+            if (deleted) {
+                LOG.info("PSC discrepancy deleted", response);
+                return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+            }
+
+            response.put(STATUS, HttpStatus.NOT_FOUND);
+            LOG.info("PSC discrepancy not found", response);
+
+            return new ResponseEntity<>(
+                    response,
+                    HttpStatus.NOT_FOUND);
+
+        } catch (Exception ex) {
+            throw new DataException(
+                    "Error deleting PSC discrepancy",
+                    ex);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/controller/PscDiscrepanciesController.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/controller/PscDiscrepanciesController.java
@@ -39,40 +39,35 @@ public class PscDiscrepanciesController {
     }
 
     @PostMapping("/pscdiscrepancies")
-    public ResponseEntity<String> test() {
-        return ResponseEntity.ok("PSC endpoint works");
-    }
+    public ResponseEntity<PscDiscrepanciesResponse> createPscDiscrepancy(
+            @Valid @RequestBody PscDiscrepanciesRequest request)
+            throws DataException {
 
-//    @PostMapping("/pscdiscrepancies")
-//    public ResponseEntity<PscDiscrepanciesResponse> createPscDiscrepancy(
-//            @Valid @RequestBody PscDiscrepanciesRequest request)
-//            throws DataException {
-//
-//        try {
-//            var createdPscDiscrepancy =
-//                    pscDiscrepanciesService.create(request);
-//
-//            Map<String, Object> data = new HashMap<>();
-//            data.put(
-//                    "psc-discrepancies-id",
-//                    createdPscDiscrepancy.getPscDiscrepanciesId());
-//
-//            data.put(
-//                    "psc-discrepancy-report-id",
-//                    createdPscDiscrepancy.getPscDiscrepancyReportId());
-//
-//            LOG.info("New PSC discrepancy created", data);
-//
-//            return new ResponseEntity<>(
-//                    createdPscDiscrepancy,
-//                    HttpStatus.CREATED);
-//
-//        } catch (Exception ex) {
-//            throw new DataException(
-//                    "Error creating PSC discrepancy",
-//                    ex);
-//        }
-//    }
+        try {
+            var createdPscDiscrepancy =
+                    pscDiscrepanciesService.create(request);
+
+            Map<String, Object> data = new HashMap<>();
+            data.put(
+                    "psc-discrepancies-id",
+                    createdPscDiscrepancy.getPscDiscrepanciesId());
+
+            data.put(
+                    "psc-discrepancy-report-id",
+                    createdPscDiscrepancy.getPscDiscrepancyReportId());
+
+            LOG.info("New PSC discrepancy created", data);
+
+            return new ResponseEntity<>(
+                    createdPscDiscrepancy,
+                    HttpStatus.CREATED);
+
+        } catch (Exception ex) {
+            throw new DataException(
+                    "Error creating PSC discrepancy",
+                    ex);
+        }
+    }
 
     @DeleteMapping("/pscdiscrepancies/{pscDiscrepanciesId}")
     public ResponseEntity<Map<String, Object>> deletePscDiscrepancy(

--- a/src/main/java/uk/gov/companieshouse/api/testdata/repository/PscDiscrepanciesRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/repository/PscDiscrepanciesRepository.java
@@ -1,0 +1,9 @@
+package uk.gov.companieshouse.api.testdata.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+import uk.gov.companieshouse.api.testdata.model.entity.PscDiscrepancies;
+
+@NoRepositoryBean
+public interface PscDiscrepanciesRepository extends MongoRepository<PscDiscrepancies, String> {
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/repository/PscDiscrepancyReportsRepository.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/repository/PscDiscrepancyReportsRepository.java
@@ -1,0 +1,9 @@
+package uk.gov.companieshouse.api.testdata.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+import uk.gov.companieshouse.api.testdata.model.entity.PscDiscrepancyReports;
+
+@NoRepositoryBean
+public interface PscDiscrepancyReportsRepository extends MongoRepository<PscDiscrepancyReports, String> {
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/PscDiscrepanciesService.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/PscDiscrepanciesService.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.api.testdata.service;
+
+import uk.gov.companieshouse.api.testdata.model.rest.request.PscDiscrepanciesRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.response.PscDiscrepanciesResponse;
+
+public interface PscDiscrepanciesService
+        extends DataService<PscDiscrepanciesResponse, PscDiscrepanciesRequest> {
+}

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/PscDiscrepanciesServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/PscDiscrepanciesServiceImpl.java
@@ -127,7 +127,7 @@ public class PscDiscrepanciesServiceImpl implements PscDiscrepanciesService {
         report.setStatus("INCOMPLETE");
         report.setLinks(links);
         report.setEncryptedDiscrepancyData(encryptedReportData);
-
+        report.setPscType(request.getPscType());
         return report;
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/PscDiscrepanciesServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/testdata/service/impl/PscDiscrepanciesServiceImpl.java
@@ -1,0 +1,163 @@
+package uk.gov.companieshouse.api.testdata.service.impl;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.model.entity.EncryptedDiscrepancyData;
+import uk.gov.companieshouse.api.testdata.model.entity.Links;
+import uk.gov.companieshouse.api.testdata.model.entity.PscDiscrepancies;
+import uk.gov.companieshouse.api.testdata.model.entity.PscDiscrepancyReports;
+import uk.gov.companieshouse.api.testdata.model.rest.request.PscDiscrepanciesRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.response.PscDiscrepanciesResponse;
+import uk.gov.companieshouse.api.testdata.repository.PscDiscrepanciesRepository;
+import uk.gov.companieshouse.api.testdata.repository.PscDiscrepancyReportsRepository;
+import uk.gov.companieshouse.api.testdata.service.PscDiscrepanciesService;
+import uk.gov.companieshouse.api.testdata.service.RandomService;
+
+@Service
+public class PscDiscrepanciesServiceImpl implements PscDiscrepanciesService {
+
+    private final PscDiscrepanciesRepository pscDiscrepanciesRepository;
+    private final PscDiscrepancyReportsRepository pscDiscrepancyReportsRepository;
+    private final RandomService randomService;
+
+    public PscDiscrepanciesServiceImpl(
+            PscDiscrepanciesRepository pscDiscrepanciesRepository,
+            PscDiscrepancyReportsRepository pscDiscrepancyReportsRepository,
+            RandomService randomService) {
+
+        this.pscDiscrepanciesRepository = pscDiscrepanciesRepository;
+        this.pscDiscrepancyReportsRepository = pscDiscrepancyReportsRepository;
+        this.randomService = randomService;
+    }
+
+    @Override
+    public PscDiscrepanciesResponse create(PscDiscrepanciesRequest request)
+            throws DataException {
+
+        Instant now = getCurrentDateTime();
+
+        String reportId = UUID.randomUUID().toString();
+        String discrepancyId = UUID.randomUUID().toString();
+
+        var report = buildPscDiscrepancyReport(
+                reportId,
+                request,
+                now);
+
+        pscDiscrepancyReportsRepository.save(report);
+
+        var discrepancy = buildPscDiscrepancy(
+                discrepancyId,
+                reportId,
+                request,
+                now);
+
+        pscDiscrepanciesRepository.save(discrepancy);
+
+        var response = new PscDiscrepanciesResponse();
+        response.setPscDiscrepanciesId(discrepancyId);
+        response.setPscDiscrepancyReportId(reportId);
+
+        return response;
+    }
+
+    private PscDiscrepancies buildPscDiscrepancy(
+            String discrepancyId,
+            String reportId,
+            PscDiscrepanciesRequest request,
+            Instant now) {
+
+        var links = new Links();
+        links.setPscDiscrepancyReport(
+                "/psc-discrepancy-reports/" + reportId);
+        links.setSelf(
+                "/psc-discrepancy-reports/"
+                        + reportId
+                        + "/discrepancies/"
+                        + discrepancyId);
+
+        var discrepancy = new PscDiscrepancies();
+
+        discrepancy.setId(discrepancyId);
+        discrepancy.setCreatedAt(now);
+        discrepancy.setKind("psc_discrepancy#psc_discrepancy_report");
+        discrepancy.setEtag(randomService.getEtag());
+        discrepancy.setLinks(links);
+        discrepancy.setPscType(request.getPscType());
+
+        var encryptedDiscrepancyData = new EncryptedDiscrepancyData();
+        encryptedDiscrepancyData.setCipherText("test-data");
+        encryptedDiscrepancyData.setContextKind(
+                "psc_discrepancy#psc_discrepancy_report");
+        encryptedDiscrepancyData.setContextId(reportId);
+
+        discrepancy.setEncryptedDiscrepancyData(
+                encryptedDiscrepancyData);
+
+        return discrepancy;
+    }
+
+    private PscDiscrepancyReports buildPscDiscrepancyReport(
+            String reportId,
+            PscDiscrepanciesRequest request,
+            Instant now) {
+
+        var links = new Links();
+        links.setSelf("/psc-discrepancy-reports/" + reportId);
+
+        var encryptedReportData = new EncryptedDiscrepancyData();
+        encryptedReportData.setCipherText("test-data");
+        encryptedReportData.setContextKind(
+                "psc_discrepancy_report#psc_discrepancy_report");
+        encryptedReportData.setContextId(reportId);
+
+        var report = new PscDiscrepancyReports();
+
+        report.setId(reportId);
+        report.setUserId(request.getUserId());
+        report.setCreatedAt(now);
+        report.setKind("psc_discrepancy_report#psc_discrepancy_report");
+        report.setEtag(randomService.getEtag());
+        report.setStatus("INCOMPLETE");
+        report.setLinks(links);
+        report.setEncryptedDiscrepancyData(encryptedReportData);
+
+        return report;
+    }
+
+    @Override
+    public boolean delete(String pscDiscrepanciesId) {
+
+        var discrepancyOptional =
+                pscDiscrepanciesRepository.findById(pscDiscrepanciesId);
+
+        if (discrepancyOptional.isEmpty()) {
+            return false;
+        }
+
+        var discrepancy = discrepancyOptional.get();
+
+        String reportLink =
+                discrepancy.getLinks().getPscDiscrepancyReport();
+
+        String reportId =
+                reportLink.substring(reportLink.lastIndexOf('/') + 1);
+
+        pscDiscrepanciesRepository.delete(discrepancy);
+
+        pscDiscrepancyReportsRepository.findById(reportId)
+                .ifPresent(pscDiscrepancyReportsRepository::delete);
+
+        return true;
+    }
+
+    protected Instant getCurrentDateTime() {
+        return Instant.now().atZone(ZoneOffset.UTC).toInstant();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/testdata/controller/PscDiscrepanciesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/controller/PscDiscrepanciesControllerTest.java
@@ -1,0 +1,163 @@
+package uk.gov.companieshouse.api.testdata.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import uk.gov.companieshouse.api.testdata.exception.DataException;
+import uk.gov.companieshouse.api.testdata.model.rest.request.PscDiscrepanciesRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.response.PscDiscrepanciesResponse;
+import uk.gov.companieshouse.api.testdata.service.PscDiscrepanciesService;
+
+@ExtendWith(MockitoExtension.class)
+class PscDiscrepanciesControllerTest {
+
+    private static final String PSC_DISCREPANCY_ID =
+            "5d03f438-972b-4d60-b0ae-f32ae8e22833";
+
+    private static final String PSC_DISCREPANCY_REPORT_ID =
+            "c119c044-2c78-4083-b633-c397e4f64eda";
+
+    @Mock
+    private PscDiscrepanciesService pscDiscrepanciesService;
+
+    @InjectMocks
+    private PscDiscrepanciesController pscDiscrepanciesController;
+
+    @Test
+    void createPscDiscrepancySuccess() throws Exception {
+
+        PscDiscrepanciesRequest request = new PscDiscrepanciesRequest();
+        request.setUserId("test-user");
+        request.setPscType("individual-person-with-significant-control");
+
+        PscDiscrepanciesResponse response =
+                new PscDiscrepanciesResponse();
+        response.setPscDiscrepanciesId(PSC_DISCREPANCY_ID);
+        response.setPscDiscrepancyReportId(
+                PSC_DISCREPANCY_REPORT_ID);
+
+        when(pscDiscrepanciesService.create(request))
+                .thenReturn(response);
+
+        ResponseEntity<PscDiscrepanciesResponse> result =
+                pscDiscrepanciesController.createPscDiscrepancy(
+                        request);
+
+        assertEquals(HttpStatus.CREATED,
+                result.getStatusCode());
+        assertEquals(response,
+                result.getBody());
+
+        verify(pscDiscrepanciesService, times(1))
+                .create(request);
+    }
+
+    @Test
+    void createPscDiscrepancyThrowsDataException() throws Exception {
+
+        PscDiscrepanciesRequest request =
+                new PscDiscrepanciesRequest();
+
+        RuntimeException exception =
+                new RuntimeException("Create failure");
+
+        when(pscDiscrepanciesService.create(request))
+                .thenThrow(exception);
+
+        DataException thrown =
+                assertThrows(DataException.class,
+                        () -> pscDiscrepanciesController
+                                .createPscDiscrepancy(request));
+
+        assertEquals(
+                "Error creating PSC discrepancy",
+                thrown.getMessage());
+
+        verify(pscDiscrepanciesService, times(1))
+                .create(request);
+    }
+
+    @Test
+    void deletePscDiscrepancySuccess() throws Exception {
+
+        when(pscDiscrepanciesService.delete(
+                PSC_DISCREPANCY_ID))
+                .thenReturn(true);
+
+        ResponseEntity<Map<String, Object>> response =
+                pscDiscrepanciesController
+                        .deletePscDiscrepancy(
+                                PSC_DISCREPANCY_ID);
+
+        assertEquals(HttpStatus.NO_CONTENT,
+                response.getStatusCode());
+
+        verify(pscDiscrepanciesService, times(1))
+                .delete(PSC_DISCREPANCY_ID);
+    }
+
+    @Test
+    void deletePscDiscrepancyNotFound() throws Exception {
+
+        when(pscDiscrepanciesService.delete(
+                PSC_DISCREPANCY_ID))
+                .thenReturn(false);
+
+        ResponseEntity<Map<String, Object>> response =
+                pscDiscrepanciesController
+                        .deletePscDiscrepancy(
+                                PSC_DISCREPANCY_ID);
+
+        assertEquals(HttpStatus.NOT_FOUND,
+                response.getStatusCode());
+
+        assertEquals(
+                HttpStatus.NOT_FOUND,
+                response.getBody().get("status"));
+
+        assertEquals(
+                PSC_DISCREPANCY_ID,
+                response.getBody().get("id"));
+
+        verify(pscDiscrepanciesService, times(1))
+                .delete(PSC_DISCREPANCY_ID);
+    }
+
+    @Test
+    void deletePscDiscrepancyThrowsDataException()
+            throws Exception {
+
+        RuntimeException exception =
+                new RuntimeException("Delete failure");
+
+        when(pscDiscrepanciesService.delete(
+                PSC_DISCREPANCY_ID))
+                .thenThrow(exception);
+
+        DataException thrown =
+                assertThrows(DataException.class,
+                        () -> pscDiscrepanciesController
+                                .deletePscDiscrepancy(
+                                        PSC_DISCREPANCY_ID));
+
+        assertEquals(
+                "Error deleting PSC discrepancy",
+                thrown.getMessage());
+
+        verify(pscDiscrepanciesService, times(1))
+                .delete(PSC_DISCREPANCY_ID);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/PscDiscrepanciesServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/testdata/service/impl/PscDiscrepanciesServiceImplTest.java
@@ -1,0 +1,254 @@
+package uk.gov.companieshouse.api.testdata.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.api.testdata.model.entity.Links;
+import uk.gov.companieshouse.api.testdata.model.entity.PscDiscrepancies;
+import uk.gov.companieshouse.api.testdata.model.entity.PscDiscrepancyReports;
+import uk.gov.companieshouse.api.testdata.model.rest.request.PscDiscrepanciesRequest;
+import uk.gov.companieshouse.api.testdata.model.rest.response.PscDiscrepanciesResponse;
+import uk.gov.companieshouse.api.testdata.repository.PscDiscrepanciesRepository;
+import uk.gov.companieshouse.api.testdata.repository.PscDiscrepancyReportsRepository;
+import uk.gov.companieshouse.api.testdata.service.RandomService;
+
+@ExtendWith(MockitoExtension.class)
+class PscDiscrepanciesServiceImplTest {
+
+    private static final String PSC_DISCREPANCY_ID =
+            "5d03f438-972b-4d60-b0ae-f32ae8e22833";
+
+    private static final String PSC_DISCREPANCY_REPORT_ID =
+            "c119c044-2c78-4083-b633-c397e4f64eda";
+
+    @Mock
+    private PscDiscrepanciesRepository pscDiscrepanciesRepository;
+
+    @Mock
+    private PscDiscrepancyReportsRepository pscDiscrepancyReportsRepository;
+
+    @Mock
+    private RandomService randomService;
+
+    @InjectMocks
+    private PscDiscrepanciesServiceImpl service;
+
+    @Test
+    void createPscDiscrepancySuccess() throws Exception {
+
+        PscDiscrepanciesRequest request =
+                new PscDiscrepanciesRequest();
+        request.setUserId("user-id");
+        request.setPscType("individual-person-with-significant-control");
+
+        when(randomService.getEtag())
+                .thenReturn("test-etag");
+
+        PscDiscrepanciesResponse response =
+                service.create(request);
+
+        assertNotNull(response);
+        assertNotNull(response.getPscDiscrepanciesId());
+        assertNotNull(response.getPscDiscrepancyReportId());
+
+        verify(pscDiscrepancyReportsRepository, times(1))
+                .save(any(PscDiscrepancyReports.class));
+
+        verify(pscDiscrepanciesRepository, times(1))
+                .save(any(PscDiscrepancies.class));
+    }
+
+    @Test
+    void createPscDiscrepancyCreatesExpectedReport() throws Exception {
+
+        PscDiscrepanciesRequest request =
+                new PscDiscrepanciesRequest();
+        request.setUserId("user-id");
+        request.setPscType("corporate-entity");
+
+        when(randomService.getEtag())
+                .thenReturn("test-etag");
+
+        service.create(request);
+
+        ArgumentCaptor<PscDiscrepancyReports> reportCaptor =
+                ArgumentCaptor.forClass(PscDiscrepancyReports.class);
+
+        verify(pscDiscrepancyReportsRepository)
+                .save(reportCaptor.capture());
+
+        PscDiscrepancyReports report = reportCaptor.getValue();
+
+        assertNotNull(report.getId());
+        assertTrue(report.getLinks().getSelf()
+                .contains("/psc-discrepancy-reports/"));
+        assertTrue(report.getStatus().equals("INCOMPLETE"));
+        assertTrue(report.getPscType().equals("corporate-entity"));
+    }
+
+    @Test
+    void createPscDiscrepancyCreatesExpectedDiscrepancy() throws Exception {
+
+        PscDiscrepanciesRequest request =
+                new PscDiscrepanciesRequest();
+        request.setUserId("user-id");
+        request.setPscType("legal-person");
+
+        when(randomService.getEtag())
+                .thenReturn("test-etag");
+
+        service.create(request);
+
+        ArgumentCaptor<PscDiscrepancies> discrepancyCaptor =
+                ArgumentCaptor.forClass(PscDiscrepancies.class);
+
+        verify(pscDiscrepanciesRepository)
+                .save(discrepancyCaptor.capture());
+
+        PscDiscrepancies discrepancy =
+                discrepancyCaptor.getValue();
+
+        assertNotNull(discrepancy.getId());
+        assertNotNull(discrepancy.getLinks());
+        assertNotNull(discrepancy.getLinks().getSelf());
+        assertNotNull(
+                discrepancy.getLinks().getPscDiscrepancyReport());
+
+        assertTrue(
+                "legal-person".equals(discrepancy.getPscType()));
+    }
+
+    @Test
+    void deletePscDiscrepancySuccess() {
+
+        Links links = new Links();
+        links.setPscDiscrepancyReport(
+                "/psc-discrepancy-reports/"
+                        + PSC_DISCREPANCY_REPORT_ID);
+
+        PscDiscrepancies discrepancy =
+                new PscDiscrepancies();
+        discrepancy.setLinks(links);
+
+        PscDiscrepancyReports report =
+                new PscDiscrepancyReports();
+
+        when(pscDiscrepanciesRepository.findById(
+                PSC_DISCREPANCY_ID))
+                .thenReturn(Optional.of(discrepancy));
+
+        when(pscDiscrepancyReportsRepository.findById(
+                PSC_DISCREPANCY_REPORT_ID))
+                .thenReturn(Optional.of(report));
+
+        boolean result =
+                service.delete(PSC_DISCREPANCY_ID);
+
+        assertTrue(result);
+
+        verify(pscDiscrepanciesRepository, times(1))
+                .delete(discrepancy);
+
+        verify(pscDiscrepancyReportsRepository, times(1))
+                .delete(report);
+    }
+
+    @Test
+    void deletePscDiscrepancyNotFound() {
+
+        when(pscDiscrepanciesRepository.findById(
+                PSC_DISCREPANCY_ID))
+                .thenReturn(Optional.empty());
+
+        boolean result =
+                service.delete(PSC_DISCREPANCY_ID);
+
+        assertFalse(result);
+
+        verify(pscDiscrepanciesRepository, times(0))
+                .delete(any());
+
+        verify(pscDiscrepancyReportsRepository, times(0))
+                .delete(any());
+    }
+
+    @Test
+    void deletePscDiscrepancyWhenReportNotFound() {
+
+        Links links = new Links();
+
+        links.setPscDiscrepancyReport(
+                "/psc-discrepancy-reports/"
+                        + PSC_DISCREPANCY_REPORT_ID);
+
+        PscDiscrepancies discrepancy =
+                new PscDiscrepancies();
+        discrepancy.setLinks(links);
+
+        when(pscDiscrepanciesRepository.findById(
+                PSC_DISCREPANCY_ID))
+                .thenReturn(Optional.of(discrepancy));
+
+        when(pscDiscrepancyReportsRepository.findById(
+                PSC_DISCREPANCY_REPORT_ID))
+                .thenReturn(Optional.empty());
+
+        boolean result =
+                service.delete(PSC_DISCREPANCY_ID);
+
+        assertTrue(result);
+
+        verify(pscDiscrepanciesRepository, times(1))
+                .delete(discrepancy);
+
+        verify(pscDiscrepancyReportsRepository, times(0))
+                .delete(any());
+    }
+
+    @Test
+    void deletePscDiscrepancyThrowsNullPointerWhenReportLinkMissing() {
+
+        Links links = new Links();
+        links.setPscDiscrepancyReport(null);
+
+        PscDiscrepancies discrepancy =
+                new PscDiscrepancies();
+        discrepancy.setLinks(links);
+
+        when(pscDiscrepanciesRepository.findById(
+                PSC_DISCREPANCY_ID))
+                .thenReturn(Optional.of(discrepancy));
+
+        assertThrows(
+                NullPointerException.class,
+                () -> service.delete(PSC_DISCREPANCY_ID));
+    }
+
+    @Test
+    void getCurrentDateTimeReturnsValue() {
+
+        Instant result = service.getCurrentDateTime();
+
+        assertNotNull(result);
+
+        assertDoesNotThrow(
+                service::getCurrentDateTime);
+    }
+}


### PR DESCRIPTION
## Overview
Adds support for creating and managing PSC (Person of Significant Control) discrepancies and associated reports.

## Changes
- Added `PscDiscrepanciesController` with endpoints for creating and deleting PSC discrepancies
- Implemented `PscDiscrepanciesService` and `PscDiscrepanciesServiceImpl` to handle business logic
- Created MongoDB repositories for `PscDiscrepancies` and `PscDiscrepancyReports` entities
- Updated `MongoConfig` to register new repositories and database configuration
- Updated test-data-generator library version from 1.0.27 to 1.0.28

## Key Features
- Create PSC discrepancies with encrypted data storage
- Generate associated PSC discrepancy reports
- Delete PSC discrepancies and their related reports
- Proper linking between discrepancies and reports